### PR TITLE
fix: escape \ in md table

### DIFF
--- a/src/cli/commands/links.ts
+++ b/src/cli/commands/links.ts
@@ -708,7 +708,7 @@ export async function similar(
 
 /** Escape markdown table cell content */
 function escapeTableCell(text: string): string {
-  return text.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  return text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ");
 }
 
 /**


### PR DESCRIPTION
Fix CodeQL alert 83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown table formatting to correctly escape backslashes in table cells, preventing parsing issues when special characters appear in content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->