### PR TITLE
feat: add --verbose error logging to embed/index

### DIFF
--- a/spec/cli.md
+++ b/spec/cli.md
@@ -390,7 +390,14 @@ gno index --collection notes --no-embed
 
 # CI/scripted usage
 gno index --models-pull --yes
+
+# Debug embedding errors
+gno index --verbose
 ```
+
+**Verbose Mode:**
+
+With `--verbose`, embedding errors during the embed phase are logged to stderr (see `gno embed`).
 
 ---
 
@@ -431,6 +438,16 @@ gno embed [--force] [--model <uri>] [--batch-size <n>] [--dry-run] [--yes] [--js
   "model": "hf:BAAI/bge-m3-gguf/bge-m3-q8_0.gguf",
   "searchAvailable": true
 }
+```
+
+**Verbose Mode:**
+
+With `--verbose`, embedding errors are logged to stderr:
+
+```
+[embed] Batch failed: <error message>
+[embed] Count mismatch: got X, expected Y
+[embed] Store failed: <error message>
 ```
 
 ---

--- a/src/cli/commands/index-cmd.ts
+++ b/src/cli/commands/index-cmd.ts
@@ -71,6 +71,7 @@ export async function index(options: IndexOptions = {}): Promise<IndexResult> {
       const { embed } = await import("./embed");
       const result = await embed({
         configPath: options.configPath,
+        verbose: options.verbose,
       });
       if (result.success) {
         embedResult = {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1278,6 +1278,7 @@ function wireManagementCommands(program: Command): void {
         dryRun: Boolean(cmdOpts.dryRun),
         yes: globals.yes,
         json: format === "json",
+        verbose: globals.verbose,
       };
       const result = await embed(opts);
 


### PR DESCRIPTION
## Summary
- Log embedding errors to stderr when `--verbose` flag used
- Wire verbose through CLI → embed() → processBatches()
- Document in spec/cli.md

## Test plan
- [x] `bun run lint:check` passes
- [x] `bun test` passes