### PR TITLE
fix: harden embedding cleanup and recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ gno collection clear-embeddings my-collection --all
 gno embed my-collection
 ```
 
+If a re-embed run still reports failures, rerun with:
+
+```bash
+gno --verbose embed --force
+```
+
+Recent releases now print sample embedding errors and a concrete retry hint when
+batch recovery cannot fully recover on its own.
+
 Model guides:
 
 - [Code Embeddings](./docs/guides/code-embeddings.md)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -423,6 +423,19 @@ gno collection clear-embeddings notes --all
 gno embed --collection notes
 ```
 
+If a run still hits model/runtime problems, use verbose mode to see concrete
+sample failures and GNO's retry hint:
+
+```bash
+gno --verbose embed --force
+gno --verbose embed --collection notes
+```
+
+If the error mentions `Object is disposed`, rerun the command once. GNO now
+resets the embedding port automatically after that class of node-llama-cpp
+failure, but a fresh rerun is still the safest last resort when a run was
+interrupted mid-way.
+
 ## Indexing Commands
 
 ### gno update

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -396,6 +396,31 @@ Then, if you used `--all`:
 gno embed --collection my-collection
 ```
 
+### Embedding run says `Object is disposed` or a batch failed partway through
+
+GNO now retries smaller batches, resets the embedding port when node-llama-cpp
+disposes a context unexpectedly, and prints sample failures in verbose mode.
+
+The safest retry commands are:
+
+```bash
+gno --verbose embed --force
+```
+
+or for one collection:
+
+```bash
+gno --verbose embed --collection my-collection
+```
+
+If you changed embedding formatting/profile behavior for the same model URI,
+prefer a full reset first:
+
+```bash
+gno collection clear-embeddings my-collection --all
+gno embed --collection my-collection
+```
+
 ### Force CPU-only for testing
 
 To disable Metal/CUDA/Vulkan and force `node-llama-cpp` onto the CPU backend

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -71,6 +71,9 @@ export type EmbedResult =
       duration: number;
       model: string;
       searchAvailable: boolean;
+      errorSamples?: string[];
+      suggestion?: string;
+      syncError?: string;
     }
   | { success: false; error: string };
 
@@ -85,6 +88,30 @@ function formatDuration(seconds: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = seconds % 60;
   return `${mins}m ${secs.toFixed(0)}s`;
+}
+
+function formatLlmFailure(
+  error: { message: string; cause?: unknown } | undefined
+): string {
+  if (!error) {
+    return "Unknown embedding failure";
+  }
+  const cause =
+    error.cause &&
+    typeof error.cause === "object" &&
+    "message" in error.cause &&
+    typeof error.cause.message === "string"
+      ? error.cause.message
+      : typeof error.cause === "string"
+        ? error.cause
+        : "";
+  return cause && cause !== error.message
+    ? `${error.message} - ${cause}`
+    : error.message;
+}
+
+function isDisposedBatchError(message: string): boolean {
+  return message.toLowerCase().includes("object is disposed");
 }
 
 async function checkVecAvailable(
@@ -111,10 +138,20 @@ interface BatchContext {
   showProgress: boolean;
   totalToEmbed: number;
   verbose: boolean;
+  recreateEmbedPort?: () => Promise<
+    { ok: true; value: EmbeddingPort } | { ok: false; error: string }
+  >;
 }
 
 type BatchResult =
-  | { ok: true; embedded: number; errors: number; duration: number }
+  | {
+      ok: true;
+      embedded: number;
+      errors: number;
+      duration: number;
+      errorSamples: string[];
+      suggestion?: string;
+    }
   | { ok: false; error: string };
 
 interface Cursor {
@@ -126,7 +163,20 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
   const startTime = Date.now();
   let embedded = 0;
   let errors = 0;
+  const errorSamples: string[] = [];
+  let suggestion: string | undefined;
   let cursor: Cursor | undefined;
+
+  const pushErrorSamples = (samples: string[]): void => {
+    for (const sample of samples) {
+      if (errorSamples.length >= 5) {
+        break;
+      }
+      if (!errorSamples.includes(sample)) {
+        errorSamples.push(sample);
+      }
+    }
+  };
 
   while (embedded + errors < ctx.totalToEmbed) {
     // Get next batch using seek pagination (cursor-based)
@@ -161,6 +211,89 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
       )
     );
     if (!batchEmbedResult.ok) {
+      const formattedError = formatLlmFailure(batchEmbedResult.error);
+      if (ctx.recreateEmbedPort && isDisposedBatchError(formattedError)) {
+        if (ctx.verbose) {
+          process.stderr.write(
+            "\n[embed] Embedding port disposed; recreating model/contexts and retrying batch once\n"
+          );
+        }
+        const recreated = await ctx.recreateEmbedPort();
+        if (recreated.ok) {
+          ctx.embedPort = recreated.value;
+          const retryResult = await embedTextsWithRecovery(
+            ctx.embedPort,
+            batch.map((b) =>
+              formatDocForEmbedding(b.text, b.title ?? undefined, ctx.modelUri)
+            )
+          );
+          if (retryResult.ok) {
+            if (ctx.verbose) {
+              process.stderr.write(
+                "\n[embed] Retry after port reset succeeded\n"
+              );
+            }
+            pushErrorSamples(retryResult.value.failureSamples);
+            suggestion ||= retryResult.value.retrySuggestion;
+
+            const retryVectors: VectorRow[] = [];
+            for (const [idx, item] of batch.entries()) {
+              const embedding = retryResult.value.vectors[idx];
+              if (!embedding) {
+                errors += 1;
+                continue;
+              }
+              retryVectors.push({
+                mirrorHash: item.mirrorHash,
+                seq: item.seq,
+                model: ctx.modelUri,
+                embedding: new Float32Array(embedding),
+              });
+            }
+
+            if (retryVectors.length === 0) {
+              if (ctx.verbose) {
+                process.stderr.write(
+                  "\n[embed] No recoverable embeddings in retry batch\n"
+                );
+              }
+              continue;
+            }
+
+            const retryStoreResult =
+              await ctx.vectorIndex.upsertVectors(retryVectors);
+            if (!retryStoreResult.ok) {
+              if (ctx.verbose) {
+                process.stderr.write(
+                  `\n[embed] Store failed: ${retryStoreResult.error.message}\n`
+                );
+              }
+              pushErrorSamples([retryStoreResult.error.message]);
+              suggestion ??=
+                "Store write failed. Rerun `gno embed` once more; if it repeats, run `gno doctor` and `gno vec sync`.";
+              errors += retryVectors.length;
+              continue;
+            }
+
+            embedded += retryVectors.length;
+            if (ctx.showProgress) {
+              const embeddedDisplay = Math.min(embedded, ctx.totalToEmbed);
+              const completed = Math.min(embedded + errors, ctx.totalToEmbed);
+              const pct = (completed / ctx.totalToEmbed) * 100;
+              const elapsed = (Date.now() - startTime) / 1000;
+              const rate = embedded / Math.max(elapsed, 0.001);
+              const eta =
+                Math.max(0, ctx.totalToEmbed - completed) /
+                Math.max(rate, 0.001);
+              process.stdout.write(
+                `\rEmbedding: ${embeddedDisplay.toLocaleString()}/${ctx.totalToEmbed.toLocaleString()} (${pct.toFixed(1)}%) | ${rate.toFixed(1)} chunks/s | ETA ${formatDuration(eta)}`
+              );
+            }
+            continue;
+          }
+        }
+      }
+
       if (ctx.verbose) {
         const err = batchEmbedResult.error;
         const cause = err.cause;
@@ -178,6 +311,9 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
           `\n[embed] Batch failed (${batch.length} chunks: ${titles}${batch.length > 3 ? "..." : ""}): ${err.message}${causeMsg ? ` - ${causeMsg}` : ""}\n`
         );
       }
+      pushErrorSamples([formattedError]);
+      suggestion =
+        "Try rerunning the same command. If failures persist, rerun with `gno --verbose embed --batch-size 1` to isolate failing chunks.";
       errors += batch.length;
       continue;
     }
@@ -190,6 +326,13 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
       process.stderr.write(
         `\n[embed] Batch fallback (${batch.length} chunks: ${titles}${batch.length > 3 ? "..." : ""}): ${batchEmbedResult.value.batchError ?? "unknown batch error"}\n`
       );
+    }
+    pushErrorSamples(batchEmbedResult.value.failureSamples);
+    suggestion ||= batchEmbedResult.value.retrySuggestion;
+    if (ctx.verbose && batchEmbedResult.value.failureSamples.length > 0) {
+      for (const sample of batchEmbedResult.value.failureSamples) {
+        process.stderr.write(`\n[embed] Sample failure: ${sample}\n`);
+      }
     }
 
     const vectors: VectorRow[] = [];
@@ -221,6 +364,9 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
           `\n[embed] Store failed: ${storeResult.error.message}\n`
         );
       }
+      pushErrorSamples([storeResult.error.message]);
+      suggestion ??=
+        "Store write failed. Rerun `gno embed` once more; if it repeats, run `gno doctor` and `gno vec sync`.";
       errors += vectors.length;
       continue;
     }
@@ -229,13 +375,15 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
 
     // Progress output
     if (ctx.showProgress) {
-      const pct = ((embedded + errors) / ctx.totalToEmbed) * 100;
+      const embeddedDisplay = Math.min(embedded, ctx.totalToEmbed);
+      const completed = Math.min(embedded + errors, ctx.totalToEmbed);
+      const pct = (completed / ctx.totalToEmbed) * 100;
       const elapsed = (Date.now() - startTime) / 1000;
       const rate = embedded / Math.max(elapsed, 0.001);
       const eta =
-        (ctx.totalToEmbed - embedded - errors) / Math.max(rate, 0.001);
+        Math.max(0, ctx.totalToEmbed - completed) / Math.max(rate, 0.001);
       process.stdout.write(
-        `\rEmbedding: ${embedded.toLocaleString()}/${ctx.totalToEmbed.toLocaleString()} (${pct.toFixed(1)}%) | ${rate.toFixed(1)} chunks/s | ETA ${formatDuration(eta)}`
+        `\rEmbedding: ${embeddedDisplay.toLocaleString()}/${ctx.totalToEmbed.toLocaleString()} (${pct.toFixed(1)}%) | ${rate.toFixed(1)} chunks/s | ETA ${formatDuration(eta)}`
       );
     }
   }
@@ -249,6 +397,8 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
     embedded,
     errors,
     duration: (Date.now() - startTime) / 1000,
+    errorSamples,
+    suggestion,
   };
 }
 
@@ -354,6 +504,7 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
         duration: 0,
         model: modelUri,
         searchAvailable: vecAvailable,
+        errorSamples: [],
       };
     }
 
@@ -366,6 +517,7 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
         duration: 0,
         model: modelUri,
         searchAvailable: vecAvailable,
+        errorSamples: [],
       };
     }
 
@@ -382,6 +534,27 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
       : undefined;
 
     const llm = new LlmAdapter(config);
+    const recreateEmbedPort = async () => {
+      if (embedPort) {
+        await embedPort.dispose();
+      }
+      await llm.getManager().dispose(modelUri);
+      const recreated = await llm.createEmbeddingPort(modelUri, {
+        policy,
+        onProgress: downloadProgress
+          ? (progress) => downloadProgress("embed", progress)
+          : undefined,
+      });
+      if (!recreated.ok) {
+        return { ok: false as const, error: recreated.error.message };
+      }
+      const initResult = await recreated.value.init();
+      if (!initResult.ok) {
+        await recreated.value.dispose();
+        return { ok: false as const, error: initResult.error.message };
+      }
+      return { ok: true as const, value: recreated.value };
+    };
     const embedResult = await llm.createEmbeddingPort(modelUri, {
       policy,
       onProgress: downloadProgress
@@ -428,6 +601,7 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
       showProgress: !options.json,
       totalToEmbed,
       verbose: options.verbose ?? false,
+      recreateEmbedPort,
     });
 
     if (!result.ok) {
@@ -447,10 +621,27 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
           }
         }
         vectorIndex.vecDirty = false;
-      } else if (!options.json) {
-        process.stdout.write(
-          `\n[vec] Sync failed: ${syncResult.error.message}\n`
-        );
+      } else {
+        if (!options.json) {
+          process.stdout.write(
+            `\n[vec] Sync failed: ${syncResult.error.message}\n`
+          );
+        }
+        return {
+          success: true,
+          embedded: result.embedded,
+          errors: result.errors,
+          duration: result.duration,
+          model: modelUri,
+          searchAvailable: vectorIndex.searchAvailable,
+          errorSamples: [
+            ...result.errorSamples,
+            syncResult.error.message,
+          ].slice(0, 5),
+          suggestion:
+            "Vector index sync failed after embedding. Rerun `gno embed` once more. If it repeats, run `gno vec sync`.",
+          syncError: syncResult.error.message,
+        };
       }
     }
 
@@ -461,6 +652,8 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
       duration: result.duration,
       model: modelUri,
       searchAvailable: vectorIndex.searchAvailable,
+      errorSamples: result.errorSamples,
+      suggestion: result.suggestion,
     };
   } finally {
     if (embedPort) {
@@ -585,6 +778,9 @@ export function formatEmbed(
         duration: result.duration,
         model: result.model,
         searchAvailable: result.searchAvailable,
+        errorSamples: result.errorSamples ?? [],
+        suggestion: result.suggestion,
+        syncError: result.syncError,
       },
       null,
       2
@@ -606,12 +802,24 @@ export function formatEmbed(
 
   if (result.errors > 0) {
     lines.push(`${result.errors} chunks failed to embed.`);
+    if ((result.errorSamples?.length ?? 0) > 0) {
+      for (const sample of result.errorSamples ?? []) {
+        lines.push(`Sample error: ${sample}`);
+      }
+    }
+    if (result.suggestion) {
+      lines.push(`Hint: ${result.suggestion}`);
+    }
   }
 
   if (!result.searchAvailable) {
     lines.push(
       "Warning: sqlite-vec not available. Embeddings stored but KNN search disabled."
     );
+  }
+
+  if (result.syncError) {
+    lines.push(`Vec sync error: ${result.syncError}`);
   }
 
   return lines.join("\n");

--- a/src/embed/batch.ts
+++ b/src/embed/batch.ts
@@ -14,7 +14,11 @@ export interface EmbedBatchRecoveryResult {
   batchFailed: boolean;
   batchError?: string;
   fallbackErrors: number;
+  failureSamples: string[];
+  retrySuggestion?: string;
 }
+
+const MAX_FAILURE_SAMPLES = 5;
 
 function errorMessage(error: unknown): string {
   if (
@@ -28,6 +32,27 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
+function formatFailureMessage(error: {
+  message: string;
+  cause?: unknown;
+}): string {
+  const cause = error.cause ? errorMessage(error.cause) : "";
+  return cause && cause !== error.message
+    ? `${error.message} - ${cause}`
+    : error.message;
+}
+
+function isDisposedFailure(message: string): boolean {
+  return message.toLowerCase().includes("object is disposed");
+}
+
+async function resetEmbeddingPort(
+  embedPort: EmbeddingPort
+): Promise<LlmResult<void>> {
+  await embedPort.dispose();
+  return embedPort.init();
+}
+
 export async function embedTextsWithRecovery(
   embedPort: EmbeddingPort,
   texts: string[]
@@ -39,13 +64,24 @@ export async function embedTextsWithRecovery(
         vectors: [],
         batchFailed: false,
         fallbackErrors: 0,
+        failureSamples: [],
       },
     };
   }
 
   const profile = getEmbeddingCompatibilityProfile(embedPort.modelUri);
   if (profile.batchEmbeddingTrusted) {
-    const batchResult = await embedPort.embedBatch(texts);
+    let batchResult = await embedPort.embedBatch(texts);
+    if (!batchResult.ok) {
+      const formattedBatchError = formatFailureMessage(batchResult.error);
+      if (isDisposedFailure(formattedBatchError)) {
+        const reset = await resetEmbeddingPort(embedPort);
+        if (!reset.ok) {
+          return reset;
+        }
+        batchResult = await embedPort.embedBatch(texts);
+      }
+    }
     if (batchResult.ok && batchResult.value.length === texts.length) {
       return {
         ok: true,
@@ -53,11 +89,14 @@ export async function embedTextsWithRecovery(
           vectors: batchResult.value,
           batchFailed: false,
           fallbackErrors: 0,
+          failureSamples: [],
         },
       };
     }
 
-    const recovered = await recoverIndividually(embedPort, texts);
+    const recovered = await recoverWithAdaptiveBatches(embedPort, texts, {
+      rootBatchAlreadyFailed: true,
+    });
     if (!recovered.ok) {
       return recovered;
     }
@@ -68,7 +107,11 @@ export async function embedTextsWithRecovery(
         batchFailed: true,
         batchError: batchResult.ok
           ? `Embedding count mismatch: got ${batchResult.value.length}, expected ${texts.length}`
-          : batchResult.error.message,
+          : formatFailureMessage(batchResult.error),
+        retrySuggestion:
+          recovered.value.fallbackErrors > 0
+            ? "Try rerunning the same command. If failures persist, rerun with `gno --verbose embed --batch-size 1` to isolate failing chunks."
+            : undefined,
       },
     };
   }
@@ -83,8 +126,111 @@ export async function embedTextsWithRecovery(
       ...recovered.value,
       batchFailed: true,
       batchError: "Batch embedding disabled for this compatibility profile",
+      retrySuggestion:
+        recovered.value.fallbackErrors > 0
+          ? "Some chunks still failed individually. Rerun with `gno --verbose embed --batch-size 1` for exact chunk errors."
+          : undefined,
     },
   };
+}
+
+async function recoverWithAdaptiveBatches(
+  embedPort: EmbeddingPort,
+  texts: string[],
+  options: { rootBatchAlreadyFailed?: boolean } = {}
+): Promise<
+  LlmResult<Omit<EmbedBatchRecoveryResult, "batchFailed" | "batchError">>
+> {
+  try {
+    const vectors: Array<number[] | null> = Array.from(
+      { length: texts.length },
+      () => null
+    );
+    const failureSamples: string[] = [];
+    let fallbackErrors = 0;
+
+    const recordFailure = (message: string): void => {
+      if (failureSamples.length < MAX_FAILURE_SAMPLES) {
+        failureSamples.push(message);
+      }
+    };
+
+    const processRange = async (
+      rangeTexts: string[],
+      offset: number,
+      batchAlreadyFailed = false
+    ): Promise<void> => {
+      if (rangeTexts.length === 0) {
+        return;
+      }
+
+      if (rangeTexts.length === 1) {
+        const result = await embedPort.embed(rangeTexts[0] ?? "");
+        if (result.ok) {
+          vectors[offset] = result.value;
+          return;
+        }
+        fallbackErrors += 1;
+        recordFailure(formatFailureMessage(result.error));
+        return;
+      }
+
+      let batchResult: Awaited<ReturnType<typeof embedPort.embedBatch>> | null =
+        null;
+      if (!batchAlreadyFailed) {
+        batchResult = await embedPort.embedBatch(rangeTexts);
+      }
+      if (
+        batchResult &&
+        batchResult.ok &&
+        batchResult.value.length === rangeTexts.length
+      ) {
+        for (const [index, vector] of batchResult.value.entries()) {
+          vectors[offset + index] = vector;
+        }
+        return;
+      }
+
+      const mid = Math.ceil(rangeTexts.length / 2);
+      await processRange(rangeTexts.slice(0, mid), offset);
+      await processRange(rangeTexts.slice(mid), offset + mid);
+    };
+
+    await processRange(texts, 0, options.rootBatchAlreadyFailed ?? false);
+
+    if (fallbackErrors === texts.length) {
+      const reinit = await resetEmbeddingPort(embedPort);
+      if (!reinit.ok) {
+        return reinit;
+      }
+
+      const retry = await recoverIndividually(embedPort, texts);
+      if (!retry.ok) {
+        return retry;
+      }
+      return {
+        ok: true,
+        value: retry.value,
+      };
+    }
+
+    return {
+      ok: true,
+      value: {
+        vectors,
+        fallbackErrors,
+        failureSamples,
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: inferenceFailedError(
+        embedPort.modelUri,
+        new Error(errorMessage(error))
+      ),
+    };
+  }
 }
 
 async function recoverIndividually(
@@ -95,6 +241,7 @@ async function recoverIndividually(
 > {
   try {
     const vectors: Array<number[] | null> = [];
+    const failureSamples: string[] = [];
     let fallbackErrors = 0;
 
     for (const text of texts) {
@@ -104,6 +251,9 @@ async function recoverIndividually(
       } else {
         vectors.push(null);
         fallbackErrors += 1;
+        if (failureSamples.length < MAX_FAILURE_SAMPLES) {
+          failureSamples.push(formatFailureMessage(result.error));
+        }
       }
     }
 
@@ -112,6 +262,7 @@ async function recoverIndividually(
       value: {
         vectors,
         fallbackErrors,
+        failureSamples,
       },
     };
   } catch (error) {

--- a/src/store/vector/sqlite-vec.ts
+++ b/src/store/vector/sqlite-vec.ts
@@ -117,10 +117,12 @@ export async function createVectorIndexPort(
   `);
 
   // Prepared statements for vec0 table (if available)
-  const upsertVecStmt = searchAvailable
-    ? db.prepare(
-        `INSERT OR REPLACE INTO ${tableName} (chunk_id, embedding) VALUES (?, ?)`
-      )
+  const deleteVecChunkStmt = searchAvailable
+    ? db.prepare(`DELETE FROM ${tableName} WHERE chunk_id = ?`)
+    : null;
+
+  const insertVecStmt = searchAvailable
+    ? db.prepare(`INSERT INTO ${tableName} (chunk_id, embedding) VALUES (?, ?)`)
     : null;
 
   const searchStmt = searchAvailable
@@ -175,12 +177,15 @@ export async function createVectorIndexPort(
       }
 
       // 2. Best-effort update vec0 (graceful degradation)
-      if (upsertVecStmt) {
+      if (deleteVecChunkStmt && insertVecStmt) {
         try {
           db.transaction(() => {
             for (const row of rows) {
               const chunkId = `${row.mirrorHash}:${row.seq}`;
-              upsertVecStmt.run(chunkId, encodeEmbedding(row.embedding));
+              // sqlite-vec vec0 tables do not reliably support OR REPLACE semantics.
+              // Delete first, then insert the fresh vector row.
+              deleteVecChunkStmt.run(chunkId);
+              insertVecStmt.run(chunkId, encodeEmbedding(row.embedding));
             }
           })();
         } catch (e) {

--- a/test/cli/embed.test.ts
+++ b/test/cli/embed.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatEmbed } from "../../src/cli/commands/embed";
+
+describe("formatEmbed", () => {
+  test("includes sample errors and hint when embedding fails partially", () => {
+    const output = formatEmbed(
+      {
+        success: true,
+        embedded: 100,
+        errors: 2,
+        duration: 12,
+        model: "hf:test/embed.gguf",
+        searchAvailable: true,
+        errorSamples: ["Inference failed for model: hf:test/embed.gguf"],
+        suggestion:
+          "Try rerunning the same command. If failures persist, rerun with `gno --verbose embed --batch-size 1` to isolate failing chunks.",
+      },
+      {}
+    );
+
+    expect(output).toContain("2 chunks failed to embed.");
+    expect(output).toContain(
+      "Sample error: Inference failed for model: hf:test/embed.gguf"
+    );
+    expect(output).toContain("Hint:");
+    expect(output).toContain("--batch-size 1");
+  });
+});

--- a/test/embed/batch.test.ts
+++ b/test/embed/batch.test.ts
@@ -9,13 +9,15 @@ function createEmbedPort(
     modelUri?: string;
     batchOk?: boolean;
     batchValues?: number[][];
+    batchFailsForLengths?: number[];
     singleFailures?: number[];
   } = {}
 ) {
   const failures = new Set(options.singleFailures ?? []);
+  const batchLengthFailures = new Set(options.batchFailsForLengths ?? []);
   let singleCall = 0;
   const embedBatch = mock(async (texts: string[]) => {
-    if (options.batchOk === false) {
+    if (options.batchOk === false || batchLengthFailures.has(texts.length)) {
       return {
         ok: false as const,
         error: {
@@ -100,6 +102,7 @@ describe("embedTextsWithRecovery", () => {
       [1.1, 1.2, 1.3],
     ]);
     expect(result.value.fallbackErrors).toBe(0);
+    expect(result.value.retrySuggestion).toBeUndefined();
     expect(embed).toHaveBeenCalledTimes(2);
   });
 
@@ -122,6 +125,8 @@ describe("embedTextsWithRecovery", () => {
       [2.1, 2.2, 2.3],
     ]);
     expect(result.value.fallbackErrors).toBe(1);
+    expect(result.value.failureSamples).toEqual(["single failed"]);
+    expect(result.value.retrySuggestion).toContain("--batch-size 1");
   });
 
   test("skips batch mode for untrusted compatibility profiles", async () => {
@@ -144,5 +149,92 @@ describe("embedTextsWithRecovery", () => {
     expect(result.value.batchError).toContain("disabled");
     expect(embedBatch).toHaveBeenCalledTimes(0);
     expect(embed).toHaveBeenCalledTimes(2);
+  });
+
+  test("downshifts to smaller batches before falling back to single-item embeds", async () => {
+    const embedPort = createEmbedPort({
+      batchFailsForLengths: [4],
+    });
+    const { embedBatch, embed } = embedPort as unknown as {
+      embedBatch: ReturnType<typeof mock>;
+      embed: ReturnType<typeof mock>;
+    };
+
+    const result = await embedTextsWithRecovery(embedPort, [
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.value.batchFailed).toBe(true);
+    expect(result.value.vectors).toEqual([
+      [0.1, 0.2, 0.3],
+      [1.1, 1.2, 1.3],
+      [0.1, 0.2, 0.3],
+      [1.1, 1.2, 1.3],
+    ]);
+    expect(embedBatch).toHaveBeenCalledTimes(3);
+    expect(embed).toHaveBeenCalledTimes(0);
+  });
+
+  test("resets the embedding port when a whole failed batch becomes unrecoverable", async () => {
+    let reset = false;
+    const embed = mock(async () => {
+      if (!reset) {
+        return {
+          ok: false as const,
+          error: {
+            code: "INFERENCE_FAILED" as const,
+            message: "single failed",
+            cause: "worker poisoned",
+            retryable: true,
+          },
+        };
+      }
+      return {
+        ok: true as const,
+        value: [0.5, 0.6, 0.7],
+      };
+    });
+    const embedBatch = mock(async () => ({
+      ok: false as const,
+      error: {
+        code: "INFERENCE_FAILED" as const,
+        message: "batch failed",
+        cause: "worker poisoned",
+        retryable: true,
+      },
+    }));
+    const init = mock(async () => ({ ok: true as const, value: undefined }));
+    const dispose = mock(async () => {
+      reset = true;
+    });
+    const embedPort = {
+      embed,
+      embedBatch,
+      init,
+      dispose,
+      modelUri: "hf:test/embed.gguf",
+      dimensions: () => 3,
+    } as unknown as EmbeddingPort;
+
+    const result = await embedTextsWithRecovery(embedPort, ["a", "b"]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(result.value.fallbackErrors).toBe(0);
+    expect(result.value.vectors).toEqual([
+      [0.5, 0.6, 0.7],
+      [0.5, 0.6, 0.7],
+    ]);
   });
 });

--- a/test/store/vector/sqlite-vec-works.test.ts
+++ b/test/store/vector/sqlite-vec-works.test.ts
@@ -229,4 +229,67 @@ describe("sqlite-vec integration", () => {
       db.close();
     }
   });
+
+  test("upsert replaces an existing vec row without leaving vecDirty behind", async () => {
+    if (isDarwin && mode === "unavailable" && !isCI) {
+      return;
+    }
+
+    const db = new Database(":memory:");
+
+    try {
+      db.exec(`
+        CREATE TABLE content_vectors (
+          mirror_hash TEXT NOT NULL,
+          seq INTEGER NOT NULL,
+          model TEXT NOT NULL,
+          embedding BLOB NOT NULL,
+          embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY (mirror_hash, seq, model)
+        );
+      `);
+
+      const result = await createVectorIndexPort(db, {
+        model: "replace-test",
+        dimensions: 4,
+      });
+
+      if (!(result.ok && result.value.searchAvailable)) {
+        return;
+      }
+
+      const port = result.value;
+
+      await port.upsertVectors([
+        {
+          mirrorHash: "doc1",
+          seq: 0,
+          model: "replace-test",
+          embedding: new Float32Array([1, 0, 0, 0]),
+        },
+      ]);
+
+      await port.upsertVectors([
+        {
+          mirrorHash: "doc1",
+          seq: 0,
+          model: "replace-test",
+          embedding: new Float32Array([0, 1, 0, 0]),
+        },
+      ]);
+
+      expect(port.vecDirty).toBe(false);
+
+      const searchResult = await port.searchNearest(
+        new Float32Array([0, 1, 0, 0]),
+        1
+      );
+      expect(searchResult.ok).toBe(true);
+      if (searchResult.ok) {
+        expect(searchResult.value[0]?.mirrorHash).toBe("doc1");
+      }
+    } finally {
+      db.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- switch sqlite-vec writes to delete+insert instead of unreliable upsert semantics
- harden embed batch recovery and disposed-port retries with clearer user-facing errors
- document rerun/reset guidance for same-model embed migrations

## Verification
- bun test
- bun run lint:check
- bun run docs:verify
- make -C website build
- live repro on growth-factors collection with patched local CLI