### PR TITLE
fix: unblock Windows CI and release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-21
+
+### Fixed
+
+- Fixed `gno collection clear-embeddings` to bootstrap the data directory before opening SQLite, which removes the Windows-only `unable to open database file` failure seen in CI and in fresh local environments.
+- Fixed publish export default output path resolution across platforms. `gno publish export` now resolves the user's Downloads directory more carefully: `USERPROFILE` on Windows, `XDG_DOWNLOAD_DIR` or `user-dirs.dirs` on Linux, and `~/Downloads` fallback on macOS/Linux when no override exists.
+- Fixed Windows-brittle benchmark and publish tests by removing hardcoded POSIX paths and raw `"bun"` executable assumptions.
+
 ## [1.0.5] - 2026-04-21
 
 ### Changed
@@ -1201,7 +1209,8 @@ Re-release of 1.0.2 with a CHANGELOG formatting fix so the Publish workflow's
 | 0.4.0   | 2026-01-01 | Web UI and REST API                        |
 | 0.1.0   | 2025-12-30 | Initial release with full search pipeline  |
 
-[Unreleased]: https://github.com/gmickel/gno/compare/v1.0.5...HEAD
+[Unreleased]: https://github.com/gmickel/gno/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/gmickel/gno/compare/v1.0.5...v1.1.0
 [1.0.5]: https://github.com/gmickel/gno/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/gmickel/gno/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/gmickel/gno/compare/v1.0.2...v1.0.3

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ gno search "incident review" --tags-all "status/active,team/platform"
 # Export a publish artifact for gno.sh
 gno publish export work-docs --out ~/Downloads/work-docs.json
 gno publish export "gno://work-docs/runbooks/deploy.md" --out ~/Downloads/deploy.json
-# Or let GNO choose ~/Downloads/<slug>-<YYYYMMDD>.json automatically
+# Or let GNO choose your Downloads folder automatically
 gno publish export work-docs
 ```
 
@@ -631,7 +631,7 @@ gno publish export "gno://work-docs/runbooks/deploy.md" \
   --passphrase "correct horse battery staple" \
   --out ~/Downloads/deploy-encrypted.json
 
-# Let GNO pick the path (~/Downloads/<slug>-<YYYYMMDD>.json)
+# Let GNO pick the path in your Downloads folder
 gno publish export work-docs
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmickel/gno",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Local semantic search for your documents. Index Markdown, PDF, and Office files with hybrid BM25 + vector search.",
   "keywords": [
     "embeddings",

--- a/src/cli/commands/collection/clear-embeddings.ts
+++ b/src/cli/commands/collection/clear-embeddings.ts
@@ -3,7 +3,7 @@
  */
 
 import { getIndexDbPath } from "../../../app/constants";
-import { loadConfig } from "../../../config";
+import { ensureDirectories, loadConfig } from "../../../config";
 import { resolveModelUri } from "../../../llm/registry";
 import { SqliteAdapter } from "../../../store/sqlite/adapter";
 import { CliError } from "../../errors";
@@ -31,6 +31,11 @@ export async function collectionClearEmbeddings(
   );
   if (!collection) {
     throw new CliError("VALIDATION", `Collection not found: ${name}`);
+  }
+
+  const ensureResult = await ensureDirectories();
+  if (!ensureResult.ok) {
+    throw new CliError("RUNTIME", ensureResult.error.message);
   }
 
   const store = new SqliteAdapter();

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -5,7 +5,6 @@
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { join } from "node:path";
 
@@ -15,6 +14,7 @@ import type {
 } from "../../publish/artifact";
 import type { SanitizeWarning } from "../../publish/obsidian-sanitize";
 
+import { resolveDownloadsDir } from "../../core/user-dirs";
 import { derivePublishArtifactFilename, slugify } from "../../publish/artifact";
 import { exportPublishArtifact } from "../../publish/export-service";
 import { formatSanitizeWarnings } from "../../publish/obsidian-sanitize";
@@ -50,16 +50,16 @@ function formatExportDateStamp(isoTimestamp: string): string {
   return isoTimestamp.slice(0, 10).replaceAll("-", "");
 }
 
-export function buildDefaultPublishExportPath(
+export async function buildDefaultPublishExportPath(
   artifact: PublishArtifact
-): string {
+): Promise<string> {
   const fileName = derivePublishArtifactFilename(artifact).replace(
     /\.json$/u,
     ""
   );
+  const downloadsDir = await resolveDownloadsDir();
   return join(
-    homedir(),
-    "Downloads",
+    downloadsDir,
     `${fileName}-${formatExportDateStamp(artifact.exportedAt)}.json`
   );
 }
@@ -114,7 +114,7 @@ export async function publishExport(
     }
 
     const outPath =
-      options.out?.trim() || buildDefaultPublishExportPath(artifact);
+      options.out?.trim() || (await buildDefaultPublishExportPath(artifact));
 
     await mkdir(dirname(outPath), { recursive: true });
     await writeFile(outPath, JSON.stringify(artifact, null, 2));

--- a/src/core/user-dirs.ts
+++ b/src/core/user-dirs.ts
@@ -1,0 +1,86 @@
+// node:os homedir: no Bun equivalent.
+import { homedir } from "node:os";
+// node:path join/normalize: no Bun path utilities.
+import { join, normalize } from "node:path";
+
+interface ResolveDownloadsDirDeps {
+  env?: Record<string, string | undefined>;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+  readTextFile?: (path: string) => Promise<string | null>;
+}
+
+const XDG_DOWNLOAD_DIR_REGEX = /^XDG_DOWNLOAD_DIR=(?:"([^"]+)"|([^\r\n#]+))$/mu;
+
+function expandEnvPath(
+  value: string,
+  env: Record<string, string | undefined>,
+  homeDir: string
+): string {
+  return normalize(
+    value
+      .trim()
+      .replaceAll(/\$HOME|\$\{HOME\}/gu, homeDir)
+      .replace(/^~(?=$|[\\/])/u, homeDir)
+      .replaceAll(
+        /%([^%]+)%/gu,
+        (_match, key: string) => env[key] ?? env[key.toUpperCase()] ?? ""
+      )
+  );
+}
+
+function parseXdgDownloadsDir(
+  fileContents: string,
+  env: Record<string, string | undefined>,
+  homeDir: string
+): string | null {
+  const match = fileContents.match(XDG_DOWNLOAD_DIR_REGEX);
+  const rawValue = match?.[1] ?? match?.[2];
+  if (!rawValue) {
+    return null;
+  }
+  return expandEnvPath(rawValue, env, homeDir);
+}
+
+async function defaultReadTextFile(path: string): Promise<string | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    return null;
+  }
+  return file.text();
+}
+
+export async function resolveDownloadsDir(
+  deps: ResolveDownloadsDirDeps = {}
+): Promise<string> {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const homeDir = deps.homeDir ?? homedir();
+  const readTextFile = deps.readTextFile ?? defaultReadTextFile;
+
+  if (platform === "linux") {
+    const explicit = env.XDG_DOWNLOAD_DIR?.trim();
+    if (explicit) {
+      return expandEnvPath(explicit, env, homeDir);
+    }
+
+    const xdgConfigHome =
+      env.XDG_CONFIG_HOME?.trim() || join(homeDir, ".config");
+    const userDirs = await readTextFile(join(xdgConfigHome, "user-dirs.dirs"));
+    if (userDirs) {
+      const parsed = parseXdgDownloadsDir(userDirs, env, homeDir);
+      if (parsed) {
+        return parsed;
+      }
+    }
+  }
+
+  if (platform === "win32") {
+    const userProfile = env.USERPROFILE?.trim();
+    if (userProfile) {
+      return join(userProfile, "Downloads");
+    }
+  }
+
+  return join(homeDir, "Downloads");
+}

--- a/test/cli/collection.test.ts
+++ b/test/cli/collection.test.ts
@@ -47,12 +47,14 @@ describe("collection CLI commands", () => {
 
     // Override config path env var
     process.env.GNO_CONFIG_DIR = join(TEST_DIR, "config");
+    process.env.GNO_DATA_DIR = join(TEST_DIR, "data");
   });
 
   afterEach(async () => {
     // Restore mocks
     process.stdout.write = originalWrite;
-    process.env.GNO_CONFIG_DIR = undefined;
+    Reflect.deleteProperty(process.env, "GNO_CONFIG_DIR");
+    Reflect.deleteProperty(process.env, "GNO_DATA_DIR");
 
     // Clean up temp dir
     await safeRm(TEST_DIR);
@@ -306,6 +308,9 @@ describe("collection CLI commands", () => {
 
       expect(stdoutOutput.join("")).toContain("Cleared");
       expect(stdoutOutput.join("")).toContain("Mode: stale");
+      expect(
+        await Bun.file(join(TEST_DIR, "data", "index-default.sqlite")).exists()
+      ).toBe(true);
     });
   });
 

--- a/test/cli/publish-export.test.ts
+++ b/test/cli/publish-export.test.ts
@@ -5,6 +5,7 @@ import {
   buildDefaultPublishExportPath,
   formatPublishExport,
 } from "../../src/cli/commands/publish";
+import { resolveDownloadsDir } from "../../src/core/user-dirs";
 import {
   buildEncryptedPublishArtifact,
   buildExportedMetadata,
@@ -93,7 +94,59 @@ describe("publish export helpers", () => {
     });
   });
 
-  it("builds default output paths in Downloads when --out is omitted", () => {
+  it("prefers USERPROFILE for Windows downloads paths", async () => {
+    const path = await resolveDownloadsDir({
+      env: {
+        HOME: "/msys/home/gordon",
+        USERPROFILE: "C:\\Users\\gordon",
+      },
+      homeDir: "/msys/home/gordon",
+      platform: "win32",
+    });
+
+    expect(path).toBe(join("C:\\Users\\gordon", "Downloads"));
+  });
+
+  it("honors XDG_DOWNLOAD_DIR on Linux", async () => {
+    const path = await resolveDownloadsDir({
+      env: {
+        HOME: "/home/gordon",
+        XDG_DOWNLOAD_DIR: "$HOME/Inbox",
+      },
+      homeDir: "/home/gordon",
+      platform: "linux",
+    });
+
+    expect(path).toBe("/home/gordon/Inbox");
+  });
+
+  it("reads localized Linux downloads dirs from user-dirs.dirs", async () => {
+    const path = await resolveDownloadsDir({
+      env: {
+        HOME: "/home/gordon",
+      },
+      homeDir: "/home/gordon",
+      platform: "linux",
+      readTextFile: async () =>
+        'XDG_DESKTOP_DIR="$HOME/Desktop"\nXDG_DOWNLOAD_DIR="$HOME/Téléchargements"\n',
+    });
+
+    expect(path).toBe("/home/gordon/Téléchargements");
+  });
+
+  it("falls back to home Downloads when no platform override exists", async () => {
+    const path = await resolveDownloadsDir({
+      env: {
+        HOME: "/Users/gordon",
+      },
+      homeDir: "/Users/gordon",
+      platform: "darwin",
+    });
+
+    expect(path).toBe("/Users/gordon/Downloads");
+  });
+
+  it("builds default output paths in the resolved downloads dir when --out is omitted", async () => {
     const artifact = {
       version: 1 as const,
       source: "atlas",
@@ -111,7 +164,7 @@ describe("publish export helpers", () => {
     };
 
     expect(derivePublishArtifactFilename(artifact)).toBe("atlas.json");
-    expect(buildDefaultPublishExportPath(artifact)).toEndWith(
+    expect(await buildDefaultPublishExportPath(artifact)).toEndWith(
       join("Downloads", "atlas-20260410.json")
     );
   });

--- a/test/cli/publish-export.test.ts
+++ b/test/cli/publish-export.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
 
 import {
   buildDefaultPublishExportPath,
@@ -110,8 +111,8 @@ describe("publish export helpers", () => {
     };
 
     expect(derivePublishArtifactFilename(artifact)).toBe("atlas.json");
-    expect(buildDefaultPublishExportPath(artifact)).toContain(
-      "/Downloads/atlas-20260410.json"
+    expect(buildDefaultPublishExportPath(artifact)).toEndWith(
+      join("Downloads", "atlas-20260410.json")
     );
   });
 

--- a/test/research/code-embedding-benchmark.test.ts
+++ b/test/research/code-embedding-benchmark.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 
 import fixtures from "../../evals/fixtures/code-embedding-benchmark/fixtures.json";
 import queries from "../../evals/fixtures/code-embedding-benchmark/queries.json";
@@ -7,6 +8,8 @@ interface QueryCase {
   id: string;
   relevantDocs: string[];
 }
+
+const REPO_ROOT = join(import.meta.dir, "../..");
 
 describe("code embedding benchmark fixtures", () => {
   test("all relevant docs exist in the corpus", async () => {
@@ -25,13 +28,13 @@ describe("code embedding benchmark fixtures", () => {
   test("benchmark script supports dry-run candidate resolution", () => {
     const result = Bun.spawnSync({
       cmd: [
-        "bun",
+        process.execPath,
         "scripts/code-embedding-benchmark.ts",
         "--candidate",
         "bge-m3-incumbent",
         "--dry-run",
       ],
-      cwd: "/Users/gordon/work/gno",
+      cwd: REPO_ROOT,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -48,7 +51,7 @@ describe("code embedding benchmark fixtures", () => {
   test("benchmark script supports fixture selection in dry-run mode", () => {
     const result = Bun.spawnSync({
       cmd: [
-        "bun",
+        process.execPath,
         "scripts/code-embedding-benchmark.ts",
         "--candidate",
         "bge-m3-incumbent",
@@ -56,7 +59,7 @@ describe("code embedding benchmark fixtures", () => {
         "repo-serve",
         "--dry-run",
       ],
-      cwd: "/Users/gordon/work/gno",
+      cwd: REPO_ROOT,
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## Summary
- fix Windows-only CI failures in collection clear-embeddings and portable test harness paths
- resolve publish export Downloads directory across Windows/Linux/macOS
- bump release to v1.1.0 with changelog entry

## Validation
- bun run prerelease

## Notes
- local tag v1.1.0 created and will be pushed after merge on main commit