### PR TITLE
Graph-Aware Retrieval and Agent Navigation

### DIFF
--- a/.flow/specs/fn-76-future-code-symbol-retrieval-and.md
+++ b/.flow/specs/fn-76-future-code-symbol-retrieval-and.md
@@ -2,13 +2,13 @@
 
 ## Problem
 
-GNO's current code retrieval is chunk-based. The near-term AST task (`fn-74-upstream-freshness-and-code-retrieval.4`) will decide whether real tree-sitter AST chunking is worth shipping. If AST chunking proves valuable, the next opportunity is symbol-aware retrieval and navigation: functions, classes, methods, interfaces/types, imports, and source outlines.
+GNO's current code retrieval is chunk-based. The AST task (`fn-74-upstream-freshness-and-code-retrieval.4`) rejected production tree-sitter chunking for now: the canonical fixture showed no retrieval-quality gain over heuristic code chunking (`nDCG@10` stayed `0.963`) while adding parser latency and package/install risk.
 
-This is future work, not a prerequisite for the AST benchmark. A fresh agent should start here only after the AST decision has landed or been explicitly revisited.
+This is future work, not part of the document graph retrieval foundation. A fresh agent should start here only after new benchmark or user-workflow evidence justifies revisiting symbol metadata.
 
 ## Goals
 
-- Use AST-derived metadata to improve code search, snippets, and navigation.
+- Use symbol metadata to improve code search, snippets, and navigation only when there is evidence it helps.
 - Expose source symbols in ways that help CLI, Web UI, MCP, and SDK workflows.
 - Keep document/chunk storage stable unless a schema change is justified by benchmark/user value.
 - Preserve fallback behavior for unsupported languages and parser failures.
@@ -18,10 +18,22 @@ This is future work, not a prerequisite for the AST benchmark. A fresh agent sho
 - Do not build a full LSP or static-analysis engine.
 - Do not require AST parsing for non-code documents.
 - Do not ship symbol surfaces without tests and retrieval-quality evidence.
+- Do not add symbol nodes to the document graph until graph consumers can keep document nodes primary and symbol nodes optional/derived.
 
 ## Key Context
 
 - Current chunker: `src/ingestion/chunker.ts`
 - Current ADR: `docs/adr/003-code-aware-chunking.md`
+- Symbol graph decision: `docs/adr/006-code-symbol-graph-foundation.md`
 - AST benchmark task: `fn-74-upstream-freshness-and-code-retrieval.4`
 - Existing related docs: `docs/guides/code-embeddings.md`, `docs/HOW-SEARCH-WORKS.md`
+
+## Reconsideration Criteria
+
+Reopen implementation only if one of these is true:
+
+- Larger code fixtures show durable nDCG/recall gains from AST or symbol metadata that heuristic chunking cannot match.
+- A concrete agent workflow needs exact function/class navigation that current query plus line-range `gno_get`/`gno_multi_get` cannot solve.
+- A fallback-safe symbol extractor can run for a small language set without unacceptable install, package, or platform risk.
+
+If implementation proceeds, start with optional derived metadata for TypeScript, TSX, JavaScript, JSX, Python, Go, and Rust. Unsupported languages and parser failures must fall back to current document/chunk retrieval without changing indexing behavior.

--- a/.flow/tasks/fn-76-future-code-symbol-retrieval-and.1.md
+++ b/.flow/tasks/fn-76-future-code-symbol-retrieval-and.1.md
@@ -4,7 +4,9 @@
 
 Design and, if justified, implement symbol-aware code retrieval after the AST chunking decision from `fn-74-upstream-freshness-and-code-retrieval.4` is complete.
 
-Start by reading the AST benchmark results and current chunking implementation. If AST chunking was rejected, this task should either close with the same evidence or define a narrower future criterion. If AST chunking shipped or remains promising, design a minimal symbol metadata path that helps retrieval/navigation without turning GNO into an LSP.
+Current decision context: AST chunking was rejected for production in `fn-74-upstream-freshness-and-code-retrieval.4`; the canonical fixture showed no retrieval-quality gain over heuristic chunking (`nDCG@10` stayed `0.963`) and added parser/package risk. `docs/adr/006-code-symbol-graph-foundation.md` therefore keeps code-symbol graph work deferred until stronger benchmark or workflow evidence exists.
+
+Start by reading the AST benchmark results, `docs/adr/006-code-symbol-graph-foundation.md`, and current chunking implementation. If no new evidence exists, close this task with the same deferred decision. If new evidence exists, design a minimal optional symbol metadata path that helps retrieval/navigation without turning GNO into an LSP.
 
 Candidate surfaces:
 
@@ -13,15 +15,18 @@ Candidate surfaces:
 - Web document outline for code files
 - MCP guidance/results that let agents retrieve exact function/class ranges
 - optional `gno symbols <ref>` or SDK helper only if it earns its keep
+- optional derived graph symbol nodes only if document graph consumers keep document nodes primary
 
 ## Acceptance
 
 - [ ] Re-anchor on `fn-74-upstream-freshness-and-code-retrieval.4` outcome before any implementation.
+- [ ] Re-anchor on `docs/adr/006-code-symbol-graph-foundation.md` and explain what new evidence changed.
 - [ ] Identify minimal symbol metadata needed for retrieval/navigation and where it belongs.
 - [ ] Decide whether schema/storage changes are necessary; if yes, update `spec/db/schema.sql` and migrations with compatibility notes.
-- [ ] Define supported language scope and parser-failure fallback.
+- [ ] Define supported language scope and parser-failure fallback; default candidate scope is TypeScript, TSX, JavaScript, JSX, Python, Go, and Rust.
 - [ ] Add tests for symbol extraction on TS/JS/Python/Go/Rust if implemented.
 - [ ] Add retrieval or UX proof that symbol metadata improves a real workflow before exposing broad public API.
+- [ ] Preserve document nodes as the primary graph nodes if any graph symbol metadata is exposed.
 - [ ] Update docs/specs/skills if user-facing or MCP-facing surfaces change.
 - [ ] Run relevant benchmark/gates before marking done.
 

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md
@@ -1,3 +1,10 @@
+---
+satisfies:
+  - R1
+  - R8
+  - R9
+---
+
 # Graph report and stats over existing document graph
 
 ## Description

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md
@@ -36,8 +36,11 @@ Testing focus:
 - Quality gates include targeted tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
+
 Implemented graph health reporting over the existing document graph, including hubs, bridge candidates, isolates, unresolved-link counts by type, edge-type totals, and truncation/similarity fallback metadata across CLI/API/MCP/Web UI surfaces. Updated GNO docs, schemas, tests, website content, and hosted gno.sh references.
+
 ## Evidence
+
 - Commits: f22b0e90d8424da30bab5c3e2c4ac388478529f6, gno.sh:54b038015e5acc28e417c055a758614c6d150dd3
 - Tests: bun test test/store/links.test.ts test/mcp/links-integration.test.ts test/spec/schemas/api-graph.test.ts test/mcp/tools/links.test.ts, bun run lint:check, bun run docs:verify, bun test, mise exec -- bun run website:build, cd /Users/gordon/work/gno.sh && bun run check, cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run build
 - PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md
@@ -36,9 +36,8 @@ Testing focus:
 - Quality gates include targeted tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
-
-_To be completed when the task is implemented._
-
+Implemented graph health reporting over the existing document graph, including hubs, bridge candidates, isolates, unresolved-link counts by type, edge-type totals, and truncation/similarity fallback metadata across CLI/API/MCP/Web UI surfaces. Updated GNO docs, schemas, tests, website content, and hosted gno.sh references.
 ## Evidence
-
-_To be completed when the task is implemented._
+- Commits: f22b0e90d8424da30bab5c3e2c4ac388478529f6, gno.sh:54b038015e5acc28e417c055a758614c6d150dd3
+- Tests: bun test test/store/links.test.ts test/mcp/links-integration.test.ts test/spec/schemas/api-graph.test.ts test/mcp/tools/links.test.ts, bun run lint:check, bun run docs:verify, bun test, mise exec -- bun run website:build, cd /Users/gordon/work/gno.sh && bun run check, cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run build
+- PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md
@@ -1,22 +1,30 @@
+---
+satisfies:
+  - R2
+  - R7
+---
+
 # MCP and CLI graph traversal tools plus skill guidance
 
 ## Description
 
 Expose graph navigation to agents and users through explicit tools/commands, then update GNO skill instructions so agents know when to use graph traversal instead of raw-file brute force.
 
-Core capabilities should cover neighbors, shortest/path-style relationship lookup, and graph stats/report access. Tool descriptions must encode agent guidance for relationship questions, missed obvious related docs, unfamiliar corpus navigation, and "how are X and Y connected?" prompts.
+Core capabilities should cover neighbors, shortest/path-style relationship lookup, and reuse of the shipped graph report/stats access in `gno_graph`. Tool descriptions must encode agent guidance for relationship questions, missed obvious related docs, unfamiliar corpus navigation, and "how are X and Y connected?" prompts.
 
 Docs, Web UI updates when affected, and hosted website updates are part of this task, including MCP docs, skill docs, CLI/API docs where relevant, and `~/work/gno.sh` website content.
 
 ## Implementation Notes
 
-Start from `src/mcp/tools/links.ts`, `src/mcp/tools/index.ts`, `src/cli/commands/graph.ts`, `src/store/sqlite/adapter.ts` `getGraph`, and the agent skill source files in `assets/skill/`.
+<!-- Updated by plan-sync: fn-79-graph-aware-retrieval-and-agent.1 shipped graph report/stats through existing `gno_graph` / `gno graph` `GraphResult.report` + `meta`, not a separate stats surface -->
+
+Start from `src/mcp/tools/links.ts`, `src/mcp/tools/index.ts`, `src/cli/commands/graph.ts`, `src/store/sqlite/adapter.ts` `getGraph`, `src/store/types.ts` `GraphResult`/`GraphReport`/`GraphMeta`, and the agent skill source files in `assets/skill/`.
 
 Expected tools/commands:
 
 - Neighbor lookup for a document/reference, optionally filtered by edge type/confidence once task 3 lands.
 - Relationship/path lookup between two document refs or graph concepts using current document graph nodes.
-- Graph stats/report access for agents.
+- Reuse `gno_graph` for graph report/stats access; extend around its `report`/`meta` contract instead of adding a second stats tool unless a concrete gap appears.
 
 Agent guidance must land in both MCP tool descriptions and skill docs. The intended agent behavior is: use `gno_query` for normal retrieval, use graph tools for relationship/path/corpus-navigation questions, use `gno_links`/`gno_backlinks`/`gno_similar` for local expansion, then use `gno_get` for targeted reads.
 
@@ -29,8 +37,8 @@ Testing focus:
 
 ## Acceptance
 
-- MCP exposes graph navigation tools for neighbors, relationship/path lookup, and graph stats/report access.
-- CLI or API surfaces exist where appropriate and remain consistent with existing graph output contracts.
+- MCP exposes graph navigation tools for neighbors and relationship/path lookup, while reusing the existing `gno_graph` graph report/stats access.
+- CLI or API surfaces exist where appropriate and remain consistent with the shipped `gno_graph` / `gno graph` output contract.
 - MCP tool descriptions explain when agents should use graph tools versus `gno_query`, `gno_links`, `gno_backlinks`, `gno_similar`, and `gno_get`.
 - GNO skill instructions define the retrieval order: status when freshness is uncertain, query first, graph/link expansion for relationship context, then targeted document reads.
 - Tests cover MCP schemas, formatted tool output, validation errors, and empty/missing graph cases.

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md
@@ -46,8 +46,11 @@ Testing focus:
 - Quality gates include targeted MCP/CLI tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
+
 Exposed graph neighbor and shortest-path traversal through MCP tools and `gno graph`, reusing the existing graph report/meta contract. Updated agent skill guidance, CLI/MCP docs/specs, hosted website copy, and regression tests for schemas, formatted output, and CLI JSON output.
+
 ## Evidence
+
 - Commits: 88a6a6d2beda15e9ab343a7a49864187390ae6f3, 50b2c308a18c0355acc185d78c3ccea6fe6673a7
 - Tests: bun run lint:check, bun test, bun run docs:verify, bun run website:build (failed: missing Bundler 2.5.22 for website/Gemfile.lock), cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run lint, cd /Users/gordon/work/gno.sh && bun test, cd /Users/gordon/work/gno.sh && bun run build
 - PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md
@@ -46,9 +46,8 @@ Testing focus:
 - Quality gates include targeted MCP/CLI tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
-
-_To be completed when the task is implemented._
-
+Exposed graph neighbor and shortest-path traversal through MCP tools and `gno graph`, reusing the existing graph report/meta contract. Updated agent skill guidance, CLI/MCP docs/specs, hosted website copy, and regression tests for schemas, formatted output, and CLI JSON output.
 ## Evidence
-
-_To be completed when the task is implemented._
+- Commits: 88a6a6d2beda15e9ab343a7a49864187390ae6f3, 50b2c308a18c0355acc185d78c3ccea6fe6673a7
+- Tests: bun run lint:check, bun test, bun run docs:verify, bun run website:build (failed: missing Bundler 2.5.22 for website/Gemfile.lock), cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run lint, cd /Users/gordon/work/gno.sh && bun test, cd /Users/gordon/work/gno.sh && bun run build
+- PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md
@@ -50,9 +50,8 @@ Testing focus:
 - Quality gates include store/API/MCP tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
-
-_To be completed when the task is implemented._
-
+Added graph edge confidence and audit metadata across the store graph contract, CLI/MCP output, Web UI graph legend/styling, schemas, docs, and agent skill guidance. Edges now distinguish explicit, inferred, ambiguous, and similarity relationships with report-level audit rollups.
 ## Evidence
-
-_To be completed when the task is implemented._
+- Commits: db0a84aa7437d305d884a088eb2443cb3fc3542b, gno.sh:29022397df79c1de5679b38170d99eadd903f6aa
+- Tests: bun run lint:check, bun test, bun run docs:verify, cd website && mise exec -- make build, cd /Users/gordon/repos/autoresearch-gno-skill && uv run eval.py > run.log 2>&1 (score 100.0, 48/48)
+- PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md
@@ -50,8 +50,11 @@ Testing focus:
 - Quality gates include store/API/MCP tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
+
 Added graph edge confidence and audit metadata across the store graph contract, CLI/MCP output, Web UI graph legend/styling, schemas, docs, and agent skill guidance. Edges now distinguish explicit, inferred, ambiguous, and similarity relationships with report-level audit rollups.
+
 ## Evidence
+
 - Commits: db0a84aa7437d305d884a088eb2443cb3fc3542b, gno.sh:29022397df79c1de5679b38170d99eadd903f6aa
 - Tests: bun run lint:check, bun test, bun run docs:verify, cd website && mise exec -- make build, cd /Users/gordon/repos/autoresearch-gno-skill && uv run eval.py > run.log 2>&1 (score 100.0, 48/48)
 - PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md
@@ -1,3 +1,8 @@
+---
+satisfies:
+  - R3
+---
+
 # Edge confidence and graph audit metadata
 
 ## Description
@@ -10,7 +15,9 @@ Docs, Web UI updates when affected, and hosted website updates are part of this 
 
 ## Implementation Notes
 
-Build on the graph report/traversal contracts from tasks 1 and 2. Avoid a second graph representation unless a schema migration is explicitly justified.
+<!-- Updated by plan-sync: fn-79-graph-aware-retrieval-and-agent.1 named the shipped graph contract `GraphResult.report`/`meta` with `bridgeCandidates`, `unresolvedLinks`, and `edgeTypes` -->
+
+Build on the shipped `GraphResult.report` / `GraphMeta` contract from task 1 and traversal surfaces from task 2. Prefer extending `GraphLink`, `GraphReport`, and `GraphMeta` over adding a second graph representation unless a schema migration is explicitly justified.
 
 Suggested confidence model:
 
@@ -21,7 +28,7 @@ Suggested confidence model:
 
 Expected user surfaces:
 
-- Graph report/stats confidence breakdown.
+- Confidence metadata on graph edges plus report-level rollups in `gno_graph` / `gno graph` output.
 - MCP/CLI graph output with confidence metadata where useful.
 - Web UI graph edge styling/legend updates when confidence is visible to users.
 
@@ -37,7 +44,7 @@ Testing focus:
 
 - Graph edges expose confidence/audit metadata or an equivalent documented derivation for explicit, inferred, ambiguous, and similarity relationships.
 - Existing graph consumers remain compatible or receive a documented schema/version update with migration tests.
-- Graph report/stats and MCP graph tools surface confidence/audit information where useful.
+- `gno_graph` / `gno graph` output and MCP graph tools surface confidence/audit information where useful.
 - Tests cover explicit links, inferred path/title fallback matches, similarity edges with scores, unresolved links, and ambiguous/collision cases.
 - User-facing docs, affected Web UI surfaces, and hosted website content in `~/work/gno.sh` are updated where applicable.
 - Quality gates include store/API/MCP tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md
@@ -51,8 +51,11 @@ Testing focus:
 - Quality gates include targeted retrieval tests/evals, `bun run lint:check`, `bun test`, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
+
 Implemented bounded graph-aware retrieval expansion for hybrid query, with confidence-weighted one-hop graph candidates, explain metadata, and noGraph controls across CLI, MCP, API, and Web UI. Updated schemas, docs, website content, skill guidance, and regression tests for graph recall, fallback, bounds, ranking, and rerank interaction.
+
 ## Evidence
+
 - Commits: b5e5aef3c2638abdb589e5ec61a4d4acb1b4b2b6, gno.sh:034fd99ee79e74a46e036c615716ae178b389dee
 - Tests: bun run lint:check, bun run typecheck, bun test, bun run docs:verify, bun test test/pipeline/hybrid-doc-lookup.test.ts test/serve/public/pages/Search.dom.test.tsx, cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run build, bun run website:build (failed: missing Ruby bundler 2.5.22 after docs sync)
 - PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md
@@ -1,14 +1,21 @@
+---
+satisfies:
+  - R4
+---
+
 # Bounded graph-aware retrieval expansion in gno_query
 
 ## Description
 
 Use graph structure as a retrieval adjunct inside `gno_query`: retrieve candidates first, expand bounded one-hop or policy-driven graph neighbors, then score/rerank the combined candidate set without replacing the existing hybrid pipeline.
 
-The behavior must degrade to current retrieval when graph data, embeddings, or similarity edges are unavailable. Expansion should prefer explicit links over inferred/similar edges and must expose enough explain/debug output to understand when graph expansion changed the candidate set.
+The behavior must degrade to current retrieval when graph data, embeddings, or similarity edges are unavailable. Expansion should prefer explicit links over inferred, ambiguous, or similarity edges and must expose enough explain/debug output to understand when graph expansion changed the candidate set.
 
 Docs, Web UI updates when affected, and hosted website updates are part of this task, including search docs, MCP docs, and `~/work/gno.sh` website content.
 
 ## Implementation Notes
+
+<!-- Updated by plan-sync: fn-79-graph-aware-retrieval-and-agent.3 shipped `GraphLink.confidence`/`audit` and `GraphResult.report.edgeConfidence`/`audit`; retrieval expansion should weight `explicit`, `inferred`, `ambiguous`, and `similarity` edges against those concrete fields. -->
 
 Start from `src/pipeline/hybrid.ts`, `src/mcp/tools/query.ts`, `src/cli/commands/query.ts`, and graph access in `src/store/sqlite/adapter.ts`.
 
@@ -16,7 +23,7 @@ Design goal: graph expansion is a candidate-generation/ranking signal, not a rep
 
 - run the current BM25/vector candidate path;
 - select a bounded seed set from top candidates;
-- expand one hop through graph edges using confidence-aware weights;
+- expand one hop through `GraphResult.links` using `confidence`/`audit`-aware weights;
 - dedupe candidates;
 - send the combined set through existing scoring/rerank behavior where feasible;
 - expose explain metadata for graph candidates and fallback reasons.
@@ -28,7 +35,7 @@ Testing focus:
 - Query where a linked neighbor improves recall.
 - Query where graph expansion is unavailable and output matches current behavior.
 - Candidate cap enforcement.
-- Explicit-link neighbor outranking inferred/similar neighbor when all else is equal.
+- Explicit-link neighbor outranking inferred, ambiguous, or similarity neighbors when all else is equal.
 - Explain metadata and MCP/CLI output stability.
 - Retrieval eval update or documented reason why deterministic unit coverage is sufficient for the slice.
 
@@ -36,7 +43,7 @@ Testing focus:
 
 - `gno_query` can use bounded graph expansion as an optional/default-safe retrieval adjunct, depending on the design decision made during implementation.
 - Candidate expansion is bounded and avoids graph-wide explosion.
-- Explicit link neighbors receive stronger treatment than inferred/similarity neighbors.
+- Explicit link neighbors receive stronger treatment than inferred, ambiguous, or similarity neighbors.
 - Explain/debug output identifies graph expansion activity, candidate counts, and fallback reasons.
 - Tests cover improved recall scenarios, no-graph fallback, no-embedding fallback, bounded expansion limits, and rerank/scoring interactions.
 - Retrieval evals are updated or added where appropriate to measure graph expansion impact.

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md
@@ -51,9 +51,8 @@ Testing focus:
 - Quality gates include targeted retrieval tests/evals, `bun run lint:check`, `bun test`, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
-
-_To be completed when the task is implemented._
-
+Implemented bounded graph-aware retrieval expansion for hybrid query, with confidence-weighted one-hop graph candidates, explain metadata, and noGraph controls across CLI, MCP, API, and Web UI. Updated schemas, docs, website content, skill guidance, and regression tests for graph recall, fallback, bounds, ranking, and rerank interaction.
 ## Evidence
-
-_To be completed when the task is implemented._
+- Commits: b5e5aef3c2638abdb589e5ec61a4d4acb1b4b2b6, gno.sh:034fd99ee79e74a46e036c615716ae178b389dee
+- Tests: bun run lint:check, bun run typecheck, bun test, bun run docs:verify, bun test test/pipeline/hybrid-doc-lookup.test.ts test/serve/public/pages/Search.dom.test.tsx, cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run build, bun run website:build (failed: missing Ruby bundler 2.5.22 after docs sync)
+- PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md
@@ -50,9 +50,8 @@ Testing focus:
 - Quality gates include graph-analysis tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
-
-_To be completed when the task is implemented._
-
+Implemented deterministic graph community detection and surfaced community IDs/summaries through graph reports, MCP formatting, schemas, the Web UI legend/filter, docs, skill guidance, and hosted gno.sh content. Added coverage for multi-community graphs, isolates, sparse graphs, large-graph skip behavior, and stable assignments.
 ## Evidence
-
-_To be completed when the task is implemented._
+- Commits: d6035eb39271b8caf02221fb29252d784142cb7f, gno.sh:2fb94d34c0409ee9d92dfd2e366d0ffcf0d48280
+- Tests: bun run lint:check, bun run typecheck, bun test, bun test test/core/graph-analysis.test.ts test/store/links.test.ts test/spec/schemas/api-graph.test.ts test/mcp/links-integration.test.ts test/pipeline/hybrid-doc-lookup.test.ts, bun run docs:verify, bun run website:build (failed: missing Ruby bundler 2.5.22 after docs sync), GNO_DATA_DIR=/tmp/gno-graph-ui-smoke bun run serve -- --port 3999 + agent-browser open http://localhost:3999/graph && agent-browser snapshot -i, cd /Users/gordon/work/gno.sh && bun run check, cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run build
+- PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md
@@ -1,3 +1,8 @@
+---
+satisfies:
+  - R5
+---
+
 # Community detection and graph-analysis integration
 
 ## Description
@@ -10,7 +15,9 @@ Docs, Web UI updates when affected, and hosted website updates are part of this 
 
 ## Implementation Notes
 
-Start from the stabilized graph report/confidence output from tasks 1-3 and the Web UI graph surface at `src/serve/public/pages/GraphView.tsx`.
+<!-- Updated by plan-sync: fn-79-graph-aware-retrieval-and-agent.1 established `gno_graph` / `gno graph` as the graph-report surface via `GraphResult.report` + `meta` -->
+
+Start from the stabilized `GraphResult.report` / `GraphMeta` and confidence output from tasks 1-3 plus the Web UI graph surface at `src/serve/public/pages/GraphView.tsx`.
 
 Implementation should be pragmatic:
 
@@ -20,8 +27,8 @@ Implementation should be pragmatic:
 
 Expected user surfaces:
 
-- Graph report community summary.
-- MCP graph report/stats community metadata.
+- `gno_graph` / `gno graph` report community summary.
+- `gno_graph` community metadata for MCP consumers.
 - Web UI graph community colors/legend/filtering or an explicit decision not to expose UI controls yet, with rationale.
 
 Testing focus:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md
@@ -50,8 +50,11 @@ Testing focus:
 - Quality gates include graph-analysis tests, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
+
 Implemented deterministic graph community detection and surfaced community IDs/summaries through graph reports, MCP formatting, schemas, the Web UI legend/filter, docs, skill guidance, and hosted gno.sh content. Added coverage for multi-community graphs, isolates, sparse graphs, large-graph skip behavior, and stable assignments.
+
 ## Evidence
+
 - Commits: d6035eb39271b8caf02221fb29252d784142cb7f, gno.sh:2fb94d34c0409ee9d92dfd2e366d0ffcf0d48280
 - Tests: bun run lint:check, bun run typecheck, bun test, bun test test/core/graph-analysis.test.ts test/store/links.test.ts test/spec/schemas/api-graph.test.ts test/mcp/links-integration.test.ts test/pipeline/hybrid-doc-lookup.test.ts, bun run docs:verify, bun run website:build (failed: missing Ruby bundler 2.5.22 after docs sync), GNO_DATA_DIR=/tmp/gno-graph-ui-smoke bun run serve -- --port 3999 + agent-browser open http://localhost:3999/graph && agent-browser snapshot -i, cd /Users/gordon/work/gno.sh && bun run check, cd /Users/gordon/work/gno.sh && bun run typecheck, cd /Users/gordon/work/gno.sh && bun run build
 - PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md
@@ -1,3 +1,8 @@
+---
+satisfies:
+  - R6
+---
+
 # Scoped code-symbol graph foundation
 
 ## Description

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md
@@ -41,8 +41,11 @@ Testing focus if implemented:
 - Quality gates include targeted tests or decision evidence, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
+
 Reconciled code-symbol graph work with the existing fn-76 future symbol retrieval epic and the fn-74 AST benchmark outcome. Added ADR-006 to defer code-symbol graph nodes until stronger benchmark or workflow evidence exists, keeping document graph retrieval stable and document nodes primary.
+
 ## Evidence
+
 - Commits: 2a1068d90dafba29c544f6d35588c362f31f481b
 - Tests: bun run lint:check, bun run typecheck, bun test, bun test test/ingestion/ast-chunking-benchmark.test.ts test/ingestion/chunker.test.ts test/ingestion/sync-code-chunking.test.ts test/core/graph-analysis.test.ts, bun run docs:verify, bun run website:build (failed: missing Bundler 2.5.22 after docs sync; docs sync step completed), bun run website:sync-docs (failed: script not found)
 - PRs:

--- a/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md
+++ b/.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md
@@ -41,9 +41,8 @@ Testing focus if implemented:
 - Quality gates include targeted tests or decision evidence, `bun run lint:check`, `bun test` where feasible, docs verification, and website sync/check commands relevant to changed docs.
 
 ## Done summary
-
-_To be completed when the task is implemented._
-
+Reconciled code-symbol graph work with the existing fn-76 future symbol retrieval epic and the fn-74 AST benchmark outcome. Added ADR-006 to defer code-symbol graph nodes until stronger benchmark or workflow evidence exists, keeping document graph retrieval stable and document nodes primary.
 ## Evidence
-
-_To be completed when the task is implemented._
+- Commits: 2a1068d90dafba29c544f6d35588c362f31f481b
+- Tests: bun run lint:check, bun run typecheck, bun test, bun test test/ingestion/ast-chunking-benchmark.test.ts test/ingestion/chunker.test.ts test/ingestion/sync-code-chunking.test.ts test/core/graph-analysis.test.ts, bun run docs:verify, bun run website:build (failed: missing Bundler 2.5.22 after docs sync; docs sync step completed), bun run website:sync-docs (failed: script not found)
+- PRs:

--- a/assets/skill/SKILL.md
+++ b/assets/skill/SKILL.md
@@ -133,13 +133,21 @@ gno search "error handling" --json | jq -r '.results[].uri' | xargs gno multi-ge
 
 ## MCP Retrieval Strategy
 
-When using GNO through MCP, prefer `gno_query` first for normal questions. It returns snippets plus `uri`, `docid`, and often `line`; follow with `gno_get` using `fromLine`/`lineCount` for a bounded read, or `gno_multi_get` to batch top result refs.
+When using GNO through MCP, prefer this retrieval order:
+
+1. Check `gno_status` first when freshness, missing vectors, or stale results are plausible.
+2. Use `gno_query` first for normal content questions. It returns snippets plus `uri`, `docid`, and often `line`.
+3. Use graph/link expansion for relationship context: `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors.
+4. Use `gno_get` with `fromLine`/`lineCount` for targeted reads, or `gno_multi_get` to batch top refs.
 
 Use narrower tools when the request tells you to:
 
 - `gno_search`: exact phrase, filename, identifier, stack trace, error text
 - `gno_vsearch`: conceptual similarity when exact wording differs
 - `gno_status`: stale results, missing embeddings, vector unavailable
+- `gno_graph`: graph report/stats, hubs, isolates, unresolved links, unfamiliar corpus overview
+- `gno_graph_neighbors`: relationship/corpus-navigation questions around a known document
+- `gno_graph_path`: "how are X and Y connected?" questions
 
 For ambiguous terms, pass `intent` instead of bloating the query text. For typed retrieval, use `queryModes`: `term` for lexical anchors, `intent` for disambiguation, one `hyde` for a hypothetical answer/document.
 
@@ -164,6 +172,8 @@ gno similar gno://notes/auth.md --threshold 0.85
 # Knowledge graph
 gno graph --json
 gno graph -c notes --similar   # Include similarity edges
+gno graph --neighbors gno://notes/auth.md
+gno graph --from gno://notes/a.md --to gno://notes/b.md
 ```
 
 ## Global Flags

--- a/assets/skill/SKILL.md
+++ b/assets/skill/SKILL.md
@@ -136,7 +136,7 @@ gno search "error handling" --json | jq -r '.results[].uri' | xargs gno multi-ge
 When using GNO through MCP, prefer this retrieval order:
 
 1. Check `gno_status` first when freshness, missing vectors, or stale results are plausible.
-2. Use `gno_query` first for normal content questions. It returns snippets plus `uri`, `docid`, and often `line`.
+2. Use `gno_query` first for normal content questions. It returns snippets plus `uri`, `docid`, and often `line`; it also adds bounded one-hop graph neighbors from top seeds when graph data exists.
 3. Use graph/link expansion for relationship context: `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors. Prefer `explicit` graph edges over `inferred`, `ambiguous`, or `similarity` edges when confidence matters.
 4. Use `gno_get` with `fromLine`/`lineCount` for targeted reads, or `gno_multi_get` to batch top refs.
 

--- a/assets/skill/SKILL.md
+++ b/assets/skill/SKILL.md
@@ -137,7 +137,7 @@ When using GNO through MCP, prefer this retrieval order:
 
 1. Check `gno_status` first when freshness, missing vectors, or stale results are plausible.
 2. Use `gno_query` first for normal content questions. It returns snippets plus `uri`, `docid`, and often `line`.
-3. Use graph/link expansion for relationship context: `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors.
+3. Use graph/link expansion for relationship context: `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors. Prefer `explicit` graph edges over `inferred`, `ambiguous`, or `similarity` edges when confidence matters.
 4. Use `gno_get` with `fromLine`/`lineCount` for targeted reads, or `gno_multi_get` to batch top refs.
 
 Use narrower tools when the request tells you to:
@@ -145,7 +145,7 @@ Use narrower tools when the request tells you to:
 - `gno_search`: exact phrase, filename, identifier, stack trace, error text
 - `gno_vsearch`: conceptual similarity when exact wording differs
 - `gno_status`: stale results, missing embeddings, vector unavailable
-- `gno_graph`: graph report/stats, hubs, isolates, unresolved links, unfamiliar corpus overview
+- `gno_graph`: graph report/stats, hubs, isolates, unresolved links, edge confidence/audit, unfamiliar corpus overview
 - `gno_graph_neighbors`: relationship/corpus-navigation questions around a known document
 - `gno_graph_path`: "how are X and Y connected?" questions
 

--- a/assets/skill/SKILL.md
+++ b/assets/skill/SKILL.md
@@ -145,7 +145,7 @@ Use narrower tools when the request tells you to:
 - `gno_search`: exact phrase, filename, identifier, stack trace, error text
 - `gno_vsearch`: conceptual similarity when exact wording differs
 - `gno_status`: stale results, missing embeddings, vector unavailable
-- `gno_graph`: graph report/stats, hubs, isolates, unresolved links, edge confidence/audit, unfamiliar corpus overview
+- `gno_graph`: graph report/stats, hubs, isolates, unresolved links, edge confidence/audit, communities, unfamiliar corpus overview
 - `gno_graph_neighbors`: relationship/corpus-navigation questions around a known document
 - `gno_graph_path`: "how are X and Y connected?" questions
 

--- a/assets/skill/cli-reference.md
+++ b/assets/skill/cli-reference.md
@@ -304,6 +304,8 @@ Generate knowledge graph of document connections.
 
 ```bash
 gno graph [options]
+gno graph --neighbors <ref> [--direction both|out|in]
+gno graph --from <ref> --to <ref> [--max-depth 6]
 ```
 
 | Option             | Default | Description                    |
@@ -315,6 +317,10 @@ gno graph [options]
 | `--threshold`      | 0.7     | Similarity threshold (0-1)     |
 | `--linked-only`    | true    | Exclude isolated nodes         |
 | `--similar-top-k`  | 5       | Similar docs per node (max 20) |
+| `--neighbors`      | -       | Show graph neighbors for ref   |
+| `--direction`      | both    | Neighbor direction             |
+| `--from`, `--to`   | -       | Find shortest graph path       |
+| `--max-depth`      | 6       | Max path hops                  |
 | `--json`           | -       | JSON output                    |
 
 **Edge types**: `wiki` (wiki links), `markdown` (md links), `similar` (vector similarity).

--- a/assets/skill/cli-reference.md
+++ b/assets/skill/cli-reference.md
@@ -154,7 +154,7 @@ gno query <query> [options]
 
 | Flag         | Time  | Description                    |
 | ------------ | ----- | ------------------------------ |
-| `--fast`     | ~0.7s | Skip expansion and reranking   |
+| `--fast`     | ~0.7s | Skip expansion, graph, rerank  |
 | (default)    | ~2-3s | Skip expansion, with reranking |
 | `--thorough` | ~5-8s | Full pipeline with expansion   |
 
@@ -164,6 +164,7 @@ Additional options:
 | ------------- | --------------------------------- |
 | `--no-expand` | Disable query expansion           |
 | `--no-rerank` | Disable reranking                 |
+| `--no-graph`  | Disable graph-neighbor candidates |
 | `--explain`   | Print retrieval details to stderr |
 
 ### gno ask

--- a/assets/skill/cli-reference.md
+++ b/assets/skill/cli-reference.md
@@ -324,6 +324,7 @@ gno graph --from <ref> --to <ref> [--max-depth 6]
 | `--json`           | -       | JSON output                    |
 
 **Edge types**: `wiki` (wiki links), `markdown` (md links), `similar` (vector similarity).
+JSON edges include `confidence` (`explicit`, `inferred`, `ambiguous`, `similarity`) and `audit` metadata so agents can prefer exact links over fallback or collision-prone matches.
 
 **Web UI**: Access interactive graph at `http://localhost:3000/graph` via `gno serve`.
 

--- a/assets/skill/mcp-reference.md
+++ b/assets/skill/mcp-reference.md
@@ -53,6 +53,17 @@ gno mcp install -t claude-code -s project # Project scope
 gno mcp status
 ```
 
+## Retrieval Order
+
+For normal questions, start with `gno_query`, then read targeted snippets with
+`gno_get` or batch refs with `gno_multi_get`. Check `gno_status` first when
+freshness or embeddings may be stale.
+
+Use graph tools for relationship context: `gno_graph` for corpus report/stats,
+`gno_graph_neighbors` for nearby incoming/outgoing graph context, and
+`gno_graph_path` for "how are X and Y connected?" questions. Use
+`gno_links`, `gno_backlinks`, and `gno_similar` for one-document expansion.
+
 ## Uninstall
 
 ```bash

--- a/assets/skill/mcp-reference.md
+++ b/assets/skill/mcp-reference.md
@@ -56,8 +56,10 @@ gno mcp status
 ## Retrieval Order
 
 For normal questions, start with `gno_query`, then read targeted snippets with
-`gno_get` or batch refs with `gno_multi_get`. Check `gno_status` first when
-freshness or embeddings may be stale.
+`gno_get` or batch refs with `gno_multi_get`. `gno_query` already does bounded
+one-hop graph expansion from top seeds; pass `noGraph: true` only when comparing
+pure BM25/vector retrieval. Check `gno_status` first when freshness or
+embeddings may be stale.
 
 Use graph tools for relationship context: `gno_graph` for corpus report/stats,
 `gno_graph_neighbors` for nearby incoming/outgoing graph context, and

--- a/assets/skill/mcp-reference.md
+++ b/assets/skill/mcp-reference.md
@@ -62,6 +62,7 @@ pure BM25/vector retrieval. Check `gno_status` first when freshness or
 embeddings may be stale.
 
 Use graph tools for relationship context: `gno_graph` for corpus report/stats,
+community summaries,
 `gno_graph_neighbors` for nearby incoming/outgoing graph context, and
 `gno_graph_path` for "how are X and Y connected?" questions. Use
 `gno_links`, `gno_backlinks`, and `gno_similar` for one-document expansion.

--- a/assets/skill/mcp-reference.md
+++ b/assets/skill/mcp-reference.md
@@ -63,6 +63,8 @@ Use graph tools for relationship context: `gno_graph` for corpus report/stats,
 `gno_graph_neighbors` for nearby incoming/outgoing graph context, and
 `gno_graph_path` for "how are X and Y connected?" questions. Use
 `gno_links`, `gno_backlinks`, and `gno_similar` for one-document expansion.
+Graph edges include confidence/audit metadata; prefer `explicit` edges when
+answers depend on link certainty.
 
 ## Uninstall
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1184,6 +1184,25 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
       "weight": 0.85
     }
   ],
+  "report": {
+    "hubs": [
+      {
+        "id": "#abc123",
+        "uri": "gno://notes/readme.md",
+        "title": "Project README",
+        "collection": "notes",
+        "relPath": "readme.md",
+        "degree": 5
+      }
+    ],
+    "bridgeCandidates": [],
+    "isolated": { "total": 3, "examples": [] },
+    "unresolvedLinks": {
+      "total": 2,
+      "byType": { "wiki": 2, "markdown": 0 }
+    },
+    "edgeTypes": { "wiki": 55, "markdown": 12, "similar": 0 }
+  },
   "meta": {
     "collection": null,
     "nodeLimit": 2000,
@@ -1204,20 +1223,25 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
 }
 ```
 
-| Field                   | Description                                      |
-| :---------------------- | :----------------------------------------------- |
-| `nodes[].id`            | Document ID (hash)                               |
-| `nodes[].uri`           | Virtual URI                                      |
-| `nodes[].title`         | Document title                                   |
-| `nodes[].collection`    | Source collection                                |
-| `nodes[].relPath`       | Relative path in collection                      |
-| `nodes[].degree`        | Number of connections (in + out)                 |
-| `links[].source`        | Source node ID                                   |
-| `links[].target`        | Target node ID                                   |
-| `links[].type`          | Link type: `wiki`, `markdown`, or `similar`      |
-| `links[].weight`        | Edge weight (count for links, score for similar) |
-| `meta.truncated`        | True if results hit limit                        |
-| `meta.similarAvailable` | True if similarity edges can be computed         |
+| Field                     | Description                                      |
+| :------------------------ | :----------------------------------------------- |
+| `nodes[].id`              | Document ID (hash)                               |
+| `nodes[].uri`             | Virtual URI                                      |
+| `nodes[].title`           | Document title                                   |
+| `nodes[].collection`      | Source collection                                |
+| `nodes[].relPath`         | Relative path in collection                      |
+| `nodes[].degree`          | Number of connections (in + out)                 |
+| `links[].source`          | Source node ID                                   |
+| `links[].target`          | Target node ID                                   |
+| `links[].type`            | Link type: `wiki`, `markdown`, or `similar`      |
+| `links[].weight`          | Edge weight (count for links, score for similar) |
+| `report.hubs`             | Highest-degree documents                         |
+| `report.bridgeCandidates` | Documents with both incoming and outgoing links  |
+| `report.isolated`         | Count and examples of documents with no links    |
+| `report.unresolvedLinks`  | Count of links whose target could not resolve    |
+| `report.edgeTypes`        | Edge counts by `wiki`, `markdown`, and `similar` |
+| `meta.truncated`          | True if results hit limit                        |
+| `meta.similarAvailable`   | True if similarity edges can be computed         |
 
 **Example**:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1567,6 +1567,7 @@ Combined BM25 + vector search with optional reranking. **Recommended for best re
   ],
   "noExpand": false,
   "noRerank": false,
+  "noGraph": false,
   "tagsAll": "backend",
   "tagsAny": "auth,security"
 }
@@ -1589,6 +1590,7 @@ Combined BM25 + vector search with optional reranking. **Recommended for best re
 | `queryModes`     | array   | —       | Optional structured mode entries (`term`, `intent`, `hyde`)                                                                      |
 | `noExpand`       | boolean | false   | Disable query expansion                                                                                                          |
 | `noRerank`       | boolean | false   | Disable cross-encoder reranking                                                                                                  |
+| `noGraph`        | boolean | false   | Disable bounded one-hop graph neighbor expansion                                                                                 |
 | `tagsAll`        | string  | —       | Comma-separated tags (must have ALL)                                                                                             |
 | `tagsAny`        | string  | —       | Comma-separated tags (must have ANY)                                                                                             |
 
@@ -1598,6 +1600,7 @@ Combined BM25 + vector search with optional reranking. **Recommended for best re
 - `intent` is orthogonal to `queryModes`: intent steers scoring/prompting, while query modes inject caller-provided retrieval expansions.
 - `queryModes` is optional and only needed for explicit retrieval intent control.
 - If `queryModes` is provided, generated expansion is skipped and provided entries are used directly.
+- By default, `/api/query` can add capped one-hop graph neighbors after initial retrieval. Explicit links are weighted above inferred, ambiguous, and similarity edges. Set `noGraph` to disable this adjunct.
 - `query` can also be a multi-line structured query document using `term:`, `intent:`, and `hyde:` lines. See [Structured Query Syntax](./SYNTAX.md).
 
 **Response**:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1167,7 +1167,8 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
       "title": "Project README",
       "collection": "notes",
       "relPath": "readme.md",
-      "degree": 5
+      "degree": 5,
+      "communityId": "c1"
     }
   ],
   "links": [
@@ -1210,7 +1211,23 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
       "ambiguous": 1,
       "similarity": 0
     },
-    "audit": { "inferredEdges": 6, "ambiguousEdges": 1, "similarityEdges": 0 }
+    "audit": { "inferredEdges": 6, "ambiguousEdges": 1, "similarityEdges": 0 },
+    "communities": {
+      "total": 2,
+      "algorithm": "deterministic-label-propagation",
+      "skipped": false,
+      "assignments": { "#abc123": "c1" },
+      "top": [
+        {
+          "id": "c1",
+          "label": "Project README",
+          "size": 12,
+          "edgeCount": 18,
+          "density": 0.27,
+          "topNodes": []
+        }
+      ]
+    }
   },
   "meta": {
     "collection": null,
@@ -1240,12 +1257,14 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
 | `nodes[].collection`      | Source collection                                                                      |
 | `nodes[].relPath`         | Relative path in collection                                                            |
 | `nodes[].degree`          | Number of connections (in + out)                                                       |
+| `nodes[].communityId`     | Optional deterministic community id                                                    |
 | `links[].source`          | Source node ID                                                                         |
 | `links[].target`          | Target node ID                                                                         |
 | `links[].type`            | Link type: `wiki`, `markdown`, or `similar`                                            |
 | `links[].weight`          | Edge weight (count for links, score for similar)                                       |
 | `links[].confidence`      | `explicit`, `inferred`, `ambiguous`, or `similarity`                                   |
 | `links[].audit`           | Resolution metadata such as exact title/path, fallback, ambiguity, or similarity score |
+| `report.communities`      | Deterministic cluster summary; skipped with warning for very large returned graphs     |
 | `report.hubs`             | Highest-degree documents                                                               |
 | `report.bridgeCandidates` | Documents with both incoming and outgoing links                                        |
 | `report.isolated`         | Count and examples of documents with no links                                          |

--- a/docs/API.md
+++ b/docs/API.md
@@ -1181,7 +1181,9 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
       "source": "#abc123",
       "target": "#ghi789",
       "type": "similar",
-      "weight": 0.85
+      "weight": 0.85,
+      "confidence": "similarity",
+      "audit": { "resolution": "similarity", "score": 0.85 }
     }
   ],
   "report": {
@@ -1201,7 +1203,14 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
       "total": 2,
       "byType": { "wiki": 2, "markdown": 0 }
     },
-    "edgeTypes": { "wiki": 55, "markdown": 12, "similar": 0 }
+    "edgeTypes": { "wiki": 55, "markdown": 12, "similar": 0 },
+    "edgeConfidence": {
+      "explicit": 60,
+      "inferred": 6,
+      "ambiguous": 1,
+      "similarity": 0
+    },
+    "audit": { "inferredEdges": 6, "ambiguousEdges": 1, "similarityEdges": 0 }
   },
   "meta": {
     "collection": null,
@@ -1223,25 +1232,29 @@ Returns a knowledge graph of document links (wiki links, markdown links, and opt
 }
 ```
 
-| Field                     | Description                                      |
-| :------------------------ | :----------------------------------------------- |
-| `nodes[].id`              | Document ID (hash)                               |
-| `nodes[].uri`             | Virtual URI                                      |
-| `nodes[].title`           | Document title                                   |
-| `nodes[].collection`      | Source collection                                |
-| `nodes[].relPath`         | Relative path in collection                      |
-| `nodes[].degree`          | Number of connections (in + out)                 |
-| `links[].source`          | Source node ID                                   |
-| `links[].target`          | Target node ID                                   |
-| `links[].type`            | Link type: `wiki`, `markdown`, or `similar`      |
-| `links[].weight`          | Edge weight (count for links, score for similar) |
-| `report.hubs`             | Highest-degree documents                         |
-| `report.bridgeCandidates` | Documents with both incoming and outgoing links  |
-| `report.isolated`         | Count and examples of documents with no links    |
-| `report.unresolvedLinks`  | Count of links whose target could not resolve    |
-| `report.edgeTypes`        | Edge counts by `wiki`, `markdown`, and `similar` |
-| `meta.truncated`          | True if results hit limit                        |
-| `meta.similarAvailable`   | True if similarity edges can be computed         |
+| Field                     | Description                                                                            |
+| :------------------------ | :------------------------------------------------------------------------------------- |
+| `nodes[].id`              | Document ID (hash)                                                                     |
+| `nodes[].uri`             | Virtual URI                                                                            |
+| `nodes[].title`           | Document title                                                                         |
+| `nodes[].collection`      | Source collection                                                                      |
+| `nodes[].relPath`         | Relative path in collection                                                            |
+| `nodes[].degree`          | Number of connections (in + out)                                                       |
+| `links[].source`          | Source node ID                                                                         |
+| `links[].target`          | Target node ID                                                                         |
+| `links[].type`            | Link type: `wiki`, `markdown`, or `similar`                                            |
+| `links[].weight`          | Edge weight (count for links, score for similar)                                       |
+| `links[].confidence`      | `explicit`, `inferred`, `ambiguous`, or `similarity`                                   |
+| `links[].audit`           | Resolution metadata such as exact title/path, fallback, ambiguity, or similarity score |
+| `report.hubs`             | Highest-degree documents                                                               |
+| `report.bridgeCandidates` | Documents with both incoming and outgoing links                                        |
+| `report.isolated`         | Count and examples of documents with no links                                          |
+| `report.unresolvedLinks`  | Count of links whose target could not resolve                                          |
+| `report.edgeTypes`        | Edge counts by `wiki`, `markdown`, and `similar`                                       |
+| `report.edgeConfidence`   | Edge counts by confidence class                                                        |
+| `report.audit`            | Rollups for inferred, ambiguous, and similarity edges                                  |
+| `meta.truncated`          | True if results hit limit                                                              |
+| `meta.similarAvailable`   | True if similarity edges can be computed                                               |
 
 **Example**:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,6 +96,8 @@ User query
     │
     ▼ Chunk-level Vector Search (sqlite-vec KNN)
     │
+    ▼ Bounded graph expansion (top seeds → one-hop neighbors)
+    │
     ▼ RRF Fusion (k=60, 2× weight for original, tiered bonus)
     │
     ▼ [Optional] Rerank best chunk per document (Qwen3, 4K chars)
@@ -108,12 +110,14 @@ User query
 ### Retrieval V2 Controls
 
 - **Structured query modes**: callers can pass explicit `term`, `intent`, and `hyde` entries.
+- **Graph expansion**: hybrid query uses the current document graph as a bounded candidate-generation signal. It starts from top BM25/vector seeds, follows one-hop neighbors, caps added candidates, and weights explicit links above inferred, ambiguous, or similarity edges.
 - **Compatibility**: existing query calls still work; structured modes are opt-in.
 - **Mode behavior**: when structured modes are present, generated expansion is skipped for that query.
 
 ### Observability Surfaces
 
 - `--explain` includes per-stage timings (`lang`, `expansion`, `bm25`, `vector`, `fusion`, `rerank`, `assembly`, `total`).
+- `--explain` includes graph expansion seed/candidate counts, edge-confidence counts, and fallback reasons.
 - Explain output includes fallback + cache counters for retrieval diagnostics.
 - Result explain lines include score components (bm25/vector/fusion/rerank/blended).
 - `gno ask --json` may include `meta.answerContext` with selected/dropped source explain details.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -827,6 +827,8 @@ gno graph --dot                     # Graphviz DOT format
 gno graph --mermaid                 # Mermaid diagram format
 gno graph -c notes                  # Single collection
 gno graph --include-similar         # Add similarity edges
+gno graph --neighbors gno://notes/auth.md
+gno graph --from gno://notes/a.md --to gno://notes/b.md
 ```
 
 Options:
@@ -838,6 +840,10 @@ Options:
 - `--threshold <num>` - Similarity threshold (default: 0.7)
 - `--include-isolated` - Include nodes with no links
 - `--similar-top-k <n>` - Similar docs per node (default: 5)
+- `--neighbors <ref>` - Show incoming/outgoing graph neighbors for a document/node
+- `--direction <both|out|in>` - Neighbor direction (default: `both`)
+- `--from <ref>` / `--to <ref>` - Find shortest relationship path
+- `--max-depth <n>` - Max path hops for `--from`/`--to` (default: 6)
 - `--json` - JSON output (default)
 - `--dot` - Graphviz DOT format
 - `--mermaid` - Mermaid diagram format

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -823,7 +823,8 @@ Options:
 
 Export knowledge graph of document links (wiki links, markdown links, similarity edges).
 JSON output includes a `report` block with hubs, bridge candidates, isolated
-documents, unresolved-link counts, and edge-type totals.
+documents, unresolved-link counts, edge-type totals, and deterministic
+community summaries.
 
 ```bash
 gno graph                           # JSON output (default)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -166,6 +166,7 @@ gno query "auth" --fast              # Fastest: ~0.7s
 gno query "auth" --thorough          # Full pipeline: ~5-8s
 gno query "auth" --tags-all work,backend   # Filter by tags
 gno query "performance" --intent "web performance and latency"
+gno query "auth" --no-graph          # Disable graph-neighbor candidates
 gno query "auth flow" --query-mode term:"jwt refresh token" --query-mode intent:"how refresh token rotation works"
 gno query $'auth flow\nterm: "refresh token"\nintent: token rotation'
 ```
@@ -173,7 +174,7 @@ gno query $'auth flow\nterm: "refresh token"\nintent: token rotation'
 **Search modes**:
 
 - **Default** (~2-3s on slim): Preset-aware balanced mode. On `slim` / `slim-tuned`, uses expansion + reranking; on larger presets, keeps reranking on and expansion off by default.
-- `--fast` (~0.7s): Skip both expansion and reranking. Use for quick lookups.
+- `--fast` (~0.7s): Skip query expansion, graph expansion, and reranking. Use for quick lookups.
 - `--thorough` (~5-8s): Expansion + reranking with a wider candidate pool. Best recall.
 
 **Pipeline features**:
@@ -181,15 +182,17 @@ gno query $'auth flow\nterm: "refresh token"\nintent: token rotation'
 - **Strong signal detection**: Skips expensive LLM expansion when BM25 has confident match
 - **2× weight for original query**: Prevents dilution by LLM-generated variants
 - **Tiered top-rank bonus**: +0.05 for #1, +0.02 for #2-3
+- **Graph-aware expansion**: Adds capped one-hop neighbors from top seeds; explicit links outrank inferred, ambiguous, and similarity edges
 - **Chunk-level reranking**: Best chunk per doc (4K max) for 25× faster reranking
 - **Lexical top-hit protection**: Preserves original BM25 #1 exact hits against rerank-only demotion
 
 Additional options:
 
-- `--fast` - Skip expansion and reranking (fastest, ~0.7s)
+- `--fast` - Skip query expansion, graph expansion, and reranking (fastest, ~0.7s)
 - `--thorough` - Use the widest retrieval/rerank budget (slower, best recall)
 - `--no-expand` - Disable query expansion
 - `--no-rerank` - Disable cross-encoder reranking
+- `--no-graph` - Disable bounded one-hop graph neighbor expansion
 - `--intent <text>` - Disambiguating context for ambiguous queries. Steers expansion, rerank chunk/snippet choice, and disables strong-signal bypass, but is not searched directly.
 - `--exclude <values>` - Hard-prune docs containing any comma-separated term in title/path/body
 - `-C, --candidate-limit <n>` - Max candidates passed to reranking (default: 20)
@@ -207,6 +210,7 @@ Additional options:
 - Existing calls keep working (`gno query "..."`, `--fast`, `--thorough`, `--no-expand`, `--no-rerank`).
 - `--intent` is orthogonal to `--query-mode`: intent steers scoring/prompting, while query modes inject caller-provided retrieval expansions.
 - `--query-mode` is opt-in for explicit intent control and replaces generated expansion for that query.
+- Graph-neighbor expansion is default-safe: if graph data, embeddings, or similarity edges are unavailable, query falls back to the normal BM25/vector path.
 - Use `term` for exact lexical constraints, `intent` for semantic reformulations, and `hyde` for one hypothetical answer passage.
 - Multi-line structured query documents are also supported. See [Structured Query Syntax](./SYNTAX.md).
 - In terminal output, `gno search`, `gno vsearch`, and `gno query` can wrap the visible `gno://...` URI in an OSC 8 hyperlink when stdout is a TTY. Configure the target with `editorUriTemplate` in `~/.config/gno/index.yml` or override it with `GNO_EDITOR_URI_TEMPLATE`. Env override wins. If unset, GNO falls back to `file://` links using absolute paths when available.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -818,6 +818,8 @@ Options:
 ### gno graph
 
 Export knowledge graph of document links (wiki links, markdown links, similarity edges).
+JSON output includes a `report` block with hubs, bridge candidates, isolated
+documents, unresolved-link counts, and edge-type totals.
 
 ```bash
 gno graph                           # JSON output (default)

--- a/docs/HOW-SEARCH-WORKS.md
+++ b/docs/HOW-SEARCH-WORKS.md
@@ -288,13 +288,28 @@ The document appearing in both lists wins, even if another document ranked #1 in
 
 Not all searches are equal. Original queries get **2× weight** to prevent dilution by LLM-generated variants:
 
-| Source          | Weight | Reasoning                  |
-| --------------- | ------ | -------------------------- |
-| Original BM25   | 2.0    | Direct match to user query |
-| Original Vector | 2.0    | Direct semantic match      |
-| BM25 variants   | 1.0    | LLM-generated, less direct |
-| Vector variants | 1.0    | LLM-generated, less direct |
-| HyDE passage    | 1.4    | Powerful but indirect      |
+| Source          | Weight | Reasoning                     |
+| --------------- | ------ | ----------------------------- |
+| Original BM25   | 2.0    | Direct match to user query    |
+| Original Vector | 2.0    | Direct semantic match         |
+| BM25 variants   | 1.0    | LLM-generated, less direct    |
+| Vector variants | 1.0    | LLM-generated, less direct    |
+| HyDE passage    | 1.4    | Powerful but indirect         |
+| Graph neighbors | 0.8    | Linked context from top seeds |
+
+## Graph-Aware Candidate Expansion
+
+`gno query` also uses the document graph as a retrieval adjunct. After BM25 and vector candidates are found, GNO takes the top seeds, follows a bounded one-hop set of graph neighbors, and feeds those added candidates back through fusion and reranking.
+
+This is not graph traversal mode. Missing graph data, missing embeddings, or unavailable similarity edges degrade to the normal hybrid path. Explicit wiki/markdown links are weighted above inferred path fallbacks, ambiguous matches, and vector-similarity edges.
+
+Use `gno query "topic" --explain` to inspect graph activity:
+
+```text
+[explain] graph: seeds=5, candidates=4/20, explicit=3, inferred=1, ambiguous=0, similarity=0
+```
+
+Use `--no-graph` when you need to compare pure BM25/vector retrieval without graph-neighbor candidates.
 
 ### Tiered Top-Rank Bonus
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -821,7 +821,9 @@ similarTopK: 5             # Similar docs per node (1-20, default: 5)
 
 Returns graph data with nodes (documents), links (edges), and a report with
 hubs, bridge candidates, isolated documents, unresolved links, and edge-type
-counts. Each edge also includes `confidence` (`explicit`, `inferred`,
+counts. The report also includes deterministic community summaries and node
+`communityId` assignments when the returned graph is small enough to analyze.
+Each edge also includes `confidence` (`explicit`, `inferred`,
 `ambiguous`, or `similarity`) and `audit` metadata describing exact matches,
 fallback matches, collision-prone matches, or similarity scores.
 
@@ -831,6 +833,7 @@ fallback matches, collision-prone matches, or similarity scores.
 - Build custom visualizations
 - Analyze knowledge graph structure
 - Find highly connected "hub" documents
+- Spot clusters/communities for agent navigation
 
 ### gno_graph_neighbors
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -821,7 +821,9 @@ similarTopK: 5             # Similar docs per node (1-20, default: 5)
 
 Returns graph data with nodes (documents), links (edges), and a report with
 hubs, bridge candidates, isolated documents, unresolved links, and edge-type
-counts. Edge types: `wiki`, `markdown`, `similar`.
+counts. Each edge also includes `confidence` (`explicit`, `inferred`,
+`ambiguous`, or `similarity`) and `audit` metadata describing exact matches,
+fallback matches, collision-prone matches, or similarity scores.
 
 **Use cases**:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -830,6 +830,38 @@ counts. Edge types: `wiki`, `markdown`, `similar`.
 - Analyze knowledge graph structure
 - Find highly connected "hub" documents
 
+### gno_graph_neighbors
+
+Find graph neighbors for a document or graph node.
+
+```
+ref: "notes/readme.md"     # URI, #docid, collection/path, relPath, or exact title
+direction: "both"          # "both", "out", or "in" (default: "both")
+collection: "notes"        # Optional: filter to single collection
+includeSimilar: false      # Optional: include similarity edges
+```
+
+Use this when an agent already has a seed document and needs relationship
+context, nearby references, or likely missed related docs. For normal content
+questions, start with `gno_query`; follow graph neighbors with `gno_get` on the
+returned refs.
+
+### gno_graph_path
+
+Find the shortest relationship path between two documents or graph nodes.
+
+```
+from: "notes/a.md"         # Starting ref
+to: "notes/b.md"           # Target ref
+maxDepth: 6                # Max hops (1-12, default: 6)
+collection: "notes"        # Optional
+includeSimilar: false      # Optional
+```
+
+Use this for "how are X and Y connected?" prompts. If either endpoint is
+unknown, run `gno_query` first to find candidate refs, then use `gno_get` on
+path nodes for grounded evidence.
+
 ## Resources
 
 Access documents via GNO URIs:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -819,7 +819,9 @@ linkedOnly: true           # Exclude isolated nodes (default: true)
 similarTopK: 5             # Similar docs per node (1-20, default: 5)
 ```
 
-Returns graph data with nodes (documents) and links (edges). Edge types: `wiki`, `markdown`, `similar`.
+Returns graph data with nodes (documents), links (edges), and a report with
+hubs, bridge candidates, isolated documents, unresolved links, and edge-type
+counts. Edge types: `wiki`, `markdown`, `similar`.
 
 **Use cases**:
 

--- a/docs/WEB-UI.md
+++ b/docs/WEB-UI.md
@@ -468,6 +468,7 @@ The Graph page (`/graph`) provides an interactive visualization of document rela
 - Three edge types: wiki links, markdown links, similarity edges
 - Collection filter dropdown
 - Similarity toggle (when embeddings available)
+- Header health stats for top degree, unresolved links, and isolated documents
 - Truncation warning when graph exceeds limits
 - Click any node to navigate to that document
 

--- a/docs/WEB-UI.md
+++ b/docs/WEB-UI.md
@@ -467,6 +467,7 @@ The Graph page (`/graph`) provides an interactive visualization of document rela
 - Nodes represent documents, edges represent links
 - Three edge types: wiki links, markdown links, similarity edges
 - Collection filter dropdown
+- Community color legend and filter when graph analysis is available
 - Similarity toggle (when embeddings available)
 - Header health stats for top degree, unresolved links, and isolated documents
 - Truncation warning when graph exceeds limits

--- a/docs/adr/006-code-symbol-graph-foundation.md
+++ b/docs/adr/006-code-symbol-graph-foundation.md
@@ -1,0 +1,74 @@
+# ADR-006: Code-Symbol Graph Foundation
+
+**Status**: deferred
+**Date**: 2026-05-09
+**Author**: Gordon Mickel
+
+## Context
+
+`fn-79-graph-aware-retrieval-and-agent` added document graph reporting,
+traversal tools, confidence metadata, bounded graph-aware retrieval expansion,
+and community detection. The remaining question was whether to add code-symbol
+nodes to that graph now.
+
+GNO already has a future symbol retrieval epic:
+`fn-76-future-code-symbol-retrieval-and`. That epic is explicitly gated on the
+AST chunking decision from `fn-74-upstream-freshness-and-code-retrieval.4`.
+
+The AST benchmark decision is now available. The canonical fixture showed no
+retrieval-quality gain from tree-sitter chunking over the current heuristic
+chunker:
+
+| Mode      | Recall@5 | Recall@10 | nDCG@10 |   MRR | parse ms | chunks | fallbacks |
+| --------- | -------: | --------: | ------: | ----: | -------: | -----: | --------: |
+| Heuristic |    1.000 |     1.000 |   0.963 | 0.950 |      0.0 |      9 |         0 |
+| AST       |    1.000 |     1.000 |   0.963 | 0.950 |     17.1 |      8 |         2 |
+
+The AST path also added parser latency and package/install risk through
+tree-sitter WASM grammar assets. Production indexing therefore remains on the
+lighter heuristic code-aware chunker.
+
+## Decision
+
+Do not ship code-symbol graph nodes in the document graph now.
+
+Document nodes remain the primary graph nodes. Symbol nodes stay future derived
+metadata owned by `fn-76-future-code-symbol-retrieval-and`, not a parallel
+schema inside the graph-aware retrieval epic.
+
+## Boundaries For Future Work
+
+Any future code-symbol graph foundation must start as a narrow, optional layer:
+
+- Document nodes remain primary; symbol nodes are derived from indexed
+  documents or chunks.
+- Supported languages must stay deliberately small. The first candidate set is
+  the current code-aware chunker scope: TypeScript, TSX, JavaScript, JSX,
+  Python, Go, and Rust.
+- Unsupported languages must fall back to current document/chunk retrieval.
+- Parser failures must fall back without breaking indexing.
+- No full LSP, type checker, cross-file symbol resolver, or all-language static
+  analysis engine.
+- No MCP, CLI, Web UI, or SDK symbol surface should ship without retrieval or
+  navigation evidence.
+
+## Reconsideration Criteria
+
+Reopen symbol graph implementation only when one of these is true:
+
+- Larger code retrieval fixtures show durable quality gains from AST or symbol
+  metadata, especially nDCG/recall improvements that heuristic chunking cannot
+  match.
+- A concrete agent workflow needs exact function/class navigation and cannot be
+  solved with current query plus line-range `gno_get`/`gno_multi_get`.
+- A fallback-safe symbol extractor can run without adding unacceptable install,
+  package, or platform risk.
+
+## Consequences
+
+Graph-aware retrieval remains stable and document-centric. Existing graph
+consumers do not need to handle mixed document/symbol node types.
+
+The concrete follow-up is to refine and execute
+`fn-76-future-code-symbol-retrieval-and.1` only after new evidence meets the
+criteria above.

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -2025,7 +2025,9 @@ Schema: `graph.schema.json`
       "source": "#abc123",
       "target": "#def456",
       "type": "wiki",
-      "weight": 1
+      "weight": 1,
+      "confidence": "explicit",
+      "audit": { "resolution": "exact-title", "matchCount": 1 }
     }
   ],
   "report": {
@@ -2045,7 +2047,14 @@ Schema: `graph.schema.json`
       "total": 5,
       "byType": { "wiki": 4, "markdown": 1 }
     },
-    "edgeTypes": { "wiki": 280, "markdown": 40, "similar": 0 }
+    "edgeTypes": { "wiki": 280, "markdown": 40, "similar": 0 },
+    "edgeConfidence": {
+      "explicit": 300,
+      "inferred": 18,
+      "ambiguous": 2,
+      "similarity": 0
+    },
+    "audit": { "inferredEdges": 18, "ambiguousEdges": 2, "similarityEdges": 0 }
   },
   "meta": {
     "collection": null,

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -635,7 +635,7 @@ Hybrid search combining BM25 and vector retrieval with optional expansion and re
 **Synopsis:**
 
 ```bash
-gno query <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--no-expand] [--no-rerank] [--query-mode <mode:text>]... [--explain] [--json|--files|--csv|--md|--xml]
+gno query <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--no-expand] [--no-rerank] [--no-graph] [--query-mode <mode:text>]... [--explain] [--json|--files|--csv|--md|--xml]
 ```
 
 **Options:** Same as `gno search`, plus:
@@ -645,6 +645,7 @@ gno query <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <dat
 |--------|------|-------------|
 | `--no-expand` | boolean | Disable query expansion |
 | `--no-rerank` | boolean | Disable cross-encoder reranking |
+| `--no-graph` | boolean | Disable bounded one-hop graph neighbor expansion |
 | `--intent` | string | Disambiguating context for ambiguous queries; steers expansion, rerank chunk/snippet choice, and disables strong-signal bypass without being searched directly |
 | `--exclude` | string | Hard-prune docs containing any comma-separated term in title/path/body |
 | `-C, --candidate-limit` | integer | Max candidates passed to reranking (default 20) |
@@ -654,9 +655,11 @@ gno query <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <dat
 **Compatibility / Migration:**
 
 - Legacy query invocations remain valid (`gno query "<text>"`, `--fast`, `--thorough`, `--no-expand`, `--no-rerank`).
+- `--fast` skips query expansion, graph expansion, and reranking.
 - `--intent` is orthogonal to `--query-mode`: intent steers scoring/prompting, while query modes inject caller-provided retrieval expansions.
 - `--query-mode` is optional and additive to the command surface.
 - If one or more `--query-mode` entries are provided, generated expansion is bypassed and provided entries are used as retrieval intents.
+- By default, `gno query` can add a capped one-hop graph-neighbor candidate set after BM25/vector retrieval. Explicit links are weighted above inferred, ambiguous, or similarity edges. Use `--no-graph` to disable this adjunct.
 
 **Explain Output (stderr):**
 
@@ -664,6 +667,7 @@ gno query <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <dat
 [explain] expansion: enabled (3 lexical, 2 semantic variants)
 [explain] bm25: 45 candidates
 [explain] vector: 38 candidates
+[explain] graph: seeds=5, candidates=4/20, explicit=3, inferred=1, ambiguous=0, similarity=0
 [explain] fusion: RRF k=60, 52 unique candidates
 [explain] rerank: top 20 reranked
 [explain] result 1: score=0.92 (bm25=0.85, vec=0.78, rerank=0.95)

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -1998,6 +1998,7 @@ gno graph [-c, --collection <name>] [--limit <num>] [--edge-limit <num>] [--simi
 **Behavior:**
 
 - Returns nodes (documents) and links (edges) as graph data
+- Includes a graph report with hubs, bridge candidates, isolated documents, unresolved links, and edge-type counts
 - Edges include wiki links, markdown links, and optionally similarity edges
 - Node degree reflects total unique connections (in + out)
 - When collection is filtered, degree may reflect links outside the filter
@@ -2027,6 +2028,25 @@ Schema: `graph.schema.json`
       "weight": 1
     }
   ],
+  "report": {
+    "hubs": [
+      {
+        "id": "#abc123",
+        "uri": "gno://notes/note.md",
+        "title": "My Note",
+        "collection": "notes",
+        "relPath": "note.md",
+        "degree": 5
+      }
+    ],
+    "bridgeCandidates": [],
+    "isolated": { "total": 2, "examples": [] },
+    "unresolvedLinks": {
+      "total": 5,
+      "byType": { "wiki": 4, "markdown": 1 }
+    },
+    "edgeTypes": { "wiki": 280, "markdown": 40, "similar": 0 }
+  },
   "meta": {
     "collection": null,
     "nodeLimit": 2000,

--- a/spec/evals.md
+++ b/spec/evals.md
@@ -1014,6 +1014,15 @@ JSON contains:
 - All eval results with scores
 - Traces for debugging
 
+## Graph-Aware Retrieval Coverage
+
+Bounded graph expansion in `gno_query` is covered by deterministic unit tests
+instead of the broad retrieval eval fixtures. The current eval corpus is focused
+on textual relevance judgments and does not carry stable wiki/markdown graph
+edges with confidence/audit metadata. Unit coverage asserts linked-neighbor
+recall, no-graph fallback, no-embedding fallback, candidate caps, confidence
+ordering, and rerank interaction without LLM or fixture drift.
+
 ## Acceptance Criteria
 
 ### EPIC 11 Complete When:

--- a/spec/mcp.md
+++ b/spec/mcp.md
@@ -1046,8 +1046,9 @@ Get knowledge graph of document connections plus graph-health report fields.
 
 The structured response includes `report.hubs`, `report.bridgeCandidates`,
 `report.isolated`, `report.unresolvedLinks`, `report.edgeTypes`,
-`report.edgeConfidence`, and per-edge `confidence` / `audit` metadata so agents
-can assess graph health and trust before deeper traversal.
+`report.edgeConfidence`, `report.communities`, node `communityId` assignments,
+and per-edge `confidence` / `audit` metadata so agents can assess graph health,
+clusters, and trust before deeper traversal.
 
 **Response:**
 
@@ -1067,7 +1068,8 @@ can assess graph health and trust before deeper traversal.
         "title": "README",
         "collection": "notes",
         "relPath": "readme.md",
-        "degree": 12
+        "degree": 12,
+        "communityId": "c1"
       }
     ],
     "links": [

--- a/spec/mcp.md
+++ b/spec/mcp.md
@@ -981,7 +981,7 @@ Find semantically similar documents using vector embeddings.
 
 ### gno_graph
 
-Get knowledge graph of document connections (nodes and edges).
+Get knowledge graph of document connections plus graph-health report fields.
 
 **Input Schema:**
 
@@ -1037,6 +1037,10 @@ Get knowledge graph of document connections (nodes and edges).
 ```
 
 **Output Schema:** `gno://schemas/graph@1.0`
+
+The structured response includes `report.hubs`, `report.bridgeCandidates`,
+`report.isolated`, `report.unresolvedLinks`, and `report.edgeTypes` so agents
+can assess graph health before deeper traversal.
 
 **Response:**
 

--- a/spec/mcp.md
+++ b/spec/mcp.md
@@ -379,6 +379,11 @@ Hybrid search combining BM25 and vector retrieval with optional expansion and re
       "description": "Enable cross-encoder reranking",
       "default": true
     },
+    "noGraph": {
+      "type": "boolean",
+      "description": "Disable bounded one-hop graph neighbor expansion",
+      "default": false
+    },
     "fast": {
       "type": "boolean",
       "description": "Fast mode: skip expansion and reranking (~0.7s)",
@@ -414,6 +419,7 @@ Compatibility / migration notes:
 - `intent` is orthogonal to `queryModes`: intent steers scoring/prompting, while query modes inject caller-provided retrieval expansions.
 - `candidateLimit` tunes rerank cost without changing retrieval contracts.
 - `exclude` hard-prunes matching docs after retrieval using title/path/body text.
+- `gno_query` can add capped one-hop graph neighbors after initial retrieval. Explicit links receive stronger treatment than inferred, ambiguous, or similarity edges; set `noGraph` to disable this adjunct.
 - `queryModes` is optional; use it only when clients need explicit retrieval intent control.
 - When `queryModes` is present, generated expansion is skipped and provided entries are used directly.
 

--- a/spec/mcp.md
+++ b/spec/mcp.md
@@ -1099,6 +1099,49 @@ can assess graph health before deeper traversal.
 
 ---
 
+### gno_graph_neighbors
+
+Find incoming and outgoing graph neighbors for one document/node.
+
+**Input Schema:** same graph filter fields as `gno_graph`, plus:
+
+```json
+{
+  "ref": "notes/readme.md",
+  "direction": "both"
+}
+```
+
+- `ref`: URI, `#docid`, `collection/path`, `relPath`, or exact title.
+- `direction`: `both`, `out`, or `in` (default: `both`).
+
+Use for relationship questions, missed related docs, and corpus navigation after
+`gno_query` finds a seed document. Follow with `gno_get` for evidence.
+
+---
+
+### gno_graph_path
+
+Find the shortest relationship path between two documents/nodes.
+
+**Input Schema:** same graph filter fields as `gno_graph`, plus:
+
+```json
+{
+  "from": "notes/a.md",
+  "to": "notes/b.md",
+  "maxDepth": 6
+}
+```
+
+- `from`, `to`: URI, `#docid`, `collection/path`, `relPath`, or exact title.
+- `maxDepth`: maximum hops to search (1-12, default: 6).
+
+Use for "how are X and Y connected?" prompts. Run `gno_query` first when either
+endpoint is unknown, then read path nodes with `gno_get`.
+
+---
+
 ### gno_add_collection
 
 Add a folder as a new collection and start indexing (write-enabled).

--- a/spec/mcp.md
+++ b/spec/mcp.md
@@ -1039,8 +1039,9 @@ Get knowledge graph of document connections plus graph-health report fields.
 **Output Schema:** `gno://schemas/graph@1.0`
 
 The structured response includes `report.hubs`, `report.bridgeCandidates`,
-`report.isolated`, `report.unresolvedLinks`, and `report.edgeTypes` so agents
-can assess graph health before deeper traversal.
+`report.isolated`, `report.unresolvedLinks`, `report.edgeTypes`,
+`report.edgeConfidence`, and per-edge `confidence` / `audit` metadata so agents
+can assess graph health and trust before deeper traversal.
 
 **Response:**
 

--- a/spec/output-schemas/graph.schema.json
+++ b/spec/output-schemas/graph.schema.json
@@ -37,6 +37,10 @@
             "type": "integer",
             "description": "Total degree (in + out unique neighbors)",
             "minimum": 0
+          },
+          "communityId": {
+            "type": "string",
+            "description": "Optional deterministic community id"
           }
         }
       }
@@ -117,7 +121,8 @@
         "unresolvedLinks",
         "edgeTypes",
         "edgeConfidence",
-        "audit"
+        "audit",
+        "communities"
       ],
       "properties": {
         "hubs": {
@@ -193,6 +198,27 @@
             "inferredEdges": { "type": "integer", "minimum": 0 },
             "ambiguousEdges": { "type": "integer", "minimum": 0 },
             "similarityEdges": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "communities": {
+          "type": "object",
+          "description": "Deterministic community analysis over returned nodes",
+          "required": ["total", "algorithm", "skipped", "assignments", "top"],
+          "properties": {
+            "total": { "type": "integer", "minimum": 0 },
+            "algorithm": {
+              "type": "string",
+              "enum": ["deterministic-label-propagation"]
+            },
+            "skipped": { "type": "boolean" },
+            "assignments": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            },
+            "top": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/community" }
+            }
           }
         }
       }
@@ -319,6 +345,25 @@
           "type": "integer",
           "description": "Total degree (in + out unique neighbors)",
           "minimum": 0
+        },
+        "communityId": {
+          "type": "string",
+          "description": "Optional deterministic community id"
+        }
+      }
+    },
+    "community": {
+      "type": "object",
+      "required": ["id", "label", "size", "edgeCount", "density", "topNodes"],
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "size": { "type": "integer", "minimum": 1 },
+        "edgeCount": { "type": "integer", "minimum": 0 },
+        "density": { "type": "number", "minimum": 0 },
+        "topNodes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/reportNode" }
         }
       }
     }

--- a/spec/output-schemas/graph.schema.json
+++ b/spec/output-schemas/graph.schema.json
@@ -4,7 +4,7 @@
   "title": "GNO Graph",
   "description": "Knowledge graph of document links",
   "type": "object",
-  "required": ["nodes", "links", "meta"],
+  "required": ["nodes", "links", "report", "meta"],
   "properties": {
     "nodes": {
       "type": "array",
@@ -65,6 +65,73 @@
             "type": "number",
             "description": "Edge weight (link count or similarity score)",
             "minimum": 0
+          }
+        }
+      }
+    },
+    "report": {
+      "type": "object",
+      "description": "Graph health and topology report",
+      "required": [
+        "hubs",
+        "bridgeCandidates",
+        "isolated",
+        "unresolvedLinks",
+        "edgeTypes"
+      ],
+      "properties": {
+        "hubs": {
+          "type": "array",
+          "description": "Highest-degree documents",
+          "items": { "$ref": "#/definitions/reportNode" }
+        },
+        "bridgeCandidates": {
+          "type": "array",
+          "description": "Bridge-like documents with both incoming and outgoing links",
+          "items": { "$ref": "#/definitions/reportNode" }
+        },
+        "isolated": {
+          "type": "object",
+          "required": ["total", "examples"],
+          "properties": {
+            "total": {
+              "type": "integer",
+              "description": "Total isolated active documents in scope",
+              "minimum": 0
+            },
+            "examples": {
+              "type": "array",
+              "description": "Example isolated documents",
+              "items": { "$ref": "#/definitions/reportNode" }
+            }
+          }
+        },
+        "unresolvedLinks": {
+          "type": "object",
+          "required": ["total", "byType"],
+          "properties": {
+            "total": {
+              "type": "integer",
+              "description": "Total unresolved wiki/markdown links in scope",
+              "minimum": 0
+            },
+            "byType": {
+              "type": "object",
+              "required": ["wiki", "markdown"],
+              "properties": {
+                "wiki": { "type": "integer", "minimum": 0 },
+                "markdown": { "type": "integer", "minimum": 0 }
+              }
+            }
+          }
+        },
+        "edgeTypes": {
+          "type": "object",
+          "required": ["wiki", "markdown", "similar"],
+          "properties": {
+            "wiki": { "type": "integer", "minimum": 0 },
+            "markdown": { "type": "integer", "minimum": 0 },
+            "similar": { "type": "integer", "minimum": 0 }
           }
         }
       }
@@ -158,6 +225,39 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "reportNode": {
+      "type": "object",
+      "required": ["id", "uri", "collection", "relPath", "degree"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Document ID (#hex)"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Document URI (gno://collection/path)"
+        },
+        "title": {
+          "type": ["string", "null"],
+          "description": "Document title"
+        },
+        "collection": {
+          "type": "string",
+          "description": "Collection name"
+        },
+        "relPath": {
+          "type": "string",
+          "description": "Relative path within collection"
+        },
+        "degree": {
+          "type": "integer",
+          "description": "Total degree (in + out unique neighbors)",
+          "minimum": 0
         }
       }
     }

--- a/spec/output-schemas/graph.schema.json
+++ b/spec/output-schemas/graph.schema.json
@@ -46,7 +46,14 @@
       "description": "Graph edges between documents",
       "items": {
         "type": "object",
-        "required": ["source", "target", "type", "weight"],
+        "required": [
+          "source",
+          "target",
+          "type",
+          "weight",
+          "confidence",
+          "audit"
+        ],
         "properties": {
           "source": {
             "type": "string",
@@ -65,6 +72,37 @@
             "type": "number",
             "description": "Edge weight (link count or similarity score)",
             "minimum": 0
+          },
+          "confidence": {
+            "type": "string",
+            "enum": ["explicit", "inferred", "ambiguous", "similarity"],
+            "description": "Trust classification for retrieval and agent audit"
+          },
+          "audit": {
+            "type": "object",
+            "description": "Metadata explaining how the edge was derived",
+            "required": ["resolution"],
+            "properties": {
+              "resolution": {
+                "type": "string",
+                "enum": [
+                  "exact-title",
+                  "exact-path",
+                  "path-fallback",
+                  "ambiguous-fallback",
+                  "similarity"
+                ]
+              },
+              "matchCount": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
           }
         }
       }
@@ -77,7 +115,9 @@
         "bridgeCandidates",
         "isolated",
         "unresolvedLinks",
-        "edgeTypes"
+        "edgeTypes",
+        "edgeConfidence",
+        "audit"
       ],
       "properties": {
         "hubs": {
@@ -132,6 +172,27 @@
             "wiki": { "type": "integer", "minimum": 0 },
             "markdown": { "type": "integer", "minimum": 0 },
             "similar": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "edgeConfidence": {
+          "type": "object",
+          "description": "Edge confidence counts before edge-limit truncation",
+          "required": ["explicit", "inferred", "ambiguous", "similarity"],
+          "properties": {
+            "explicit": { "type": "integer", "minimum": 0 },
+            "inferred": { "type": "integer", "minimum": 0 },
+            "ambiguous": { "type": "integer", "minimum": 0 },
+            "similarity": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "audit": {
+          "type": "object",
+          "description": "Graph audit rollups for fallback and similarity edges",
+          "required": ["inferredEdges", "ambiguousEdges", "similarityEdges"],
+          "properties": {
+            "inferredEdges": { "type": "integer", "minimum": 0 },
+            "ambiguousEdges": { "type": "integer", "minimum": 0 },
+            "similarityEdges": { "type": "integer", "minimum": 0 }
           }
         }
       }

--- a/spec/output-schemas/search-results.schema.json
+++ b/spec/output-schemas/search-results.schema.json
@@ -233,6 +233,54 @@
           "description": "Max candidates sent to reranking (if applicable)",
           "minimum": 1
         },
+        "graphExpansion": {
+          "type": "object",
+          "description": "Bounded one-hop graph retrieval expansion summary",
+          "required": [
+            "enabled",
+            "seedCount",
+            "candidateCount",
+            "maxCandidates",
+            "edgeConfidence",
+            "fallbackReasons"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether graph expansion added candidates"
+            },
+            "seedCount": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of top retrieval seeds used for graph expansion"
+            },
+            "candidateCount": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of graph neighbors added to the candidate set"
+            },
+            "maxCandidates": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Graph candidate cap applied"
+            },
+            "edgeConfidence": {
+              "type": "object",
+              "required": ["explicit", "inferred", "ambiguous", "similarity"],
+              "properties": {
+                "explicit": { "type": "integer", "minimum": 0 },
+                "inferred": { "type": "integer", "minimum": 0 },
+                "ambiguous": { "type": "integer", "minimum": 0 },
+                "similarity": { "type": "integer", "minimum": 0 }
+              }
+            },
+            "fallbackReasons": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Reasons graph expansion did not add candidates, if any"
+            }
+          }
+        },
         "exclude": {
           "type": "array",
           "description": "Explicit exclusion terms applied",

--- a/src/cli/commands/graph.ts
+++ b/src/cli/commands/graph.ts
@@ -32,11 +32,54 @@ export interface GraphOptions {
   similarTopK?: number;
   /** Output format: json (default), dot, mermaid */
   format?: "json" | "dot" | "mermaid";
+  /** Show neighbors for a graph node/ref */
+  neighbors?: string;
+  /** Neighbor direction */
+  direction?: "both" | "out" | "in";
+  /** Path start graph node/ref */
+  from?: string;
+  /** Path target graph node/ref */
+  to?: string;
+  /** Max path hops */
+  maxDepth?: number;
 }
 
 export type GraphCommandResult =
   | { success: true; data: GraphResult }
+  | { success: true; data: GraphNeighborsCliResult }
+  | { success: true; data: GraphPathCliResult }
   | { success: false; error: string; isValidation?: boolean };
+
+type GraphNode = GraphResult["nodes"][number];
+type GraphLink = GraphResult["links"][number];
+
+interface GraphNeighborCliItem {
+  node: GraphNode;
+  direction: "out" | "in";
+  edge: GraphLink;
+}
+
+interface GraphNeighborsCliResult {
+  source: GraphNode;
+  neighbors: GraphNeighborCliItem[];
+  meta: GraphResult["meta"] & {
+    mode: "neighbors";
+    direction: "both" | "out" | "in";
+    totalNeighbors: number;
+  };
+}
+
+interface GraphPathCliResult {
+  from: GraphNode;
+  to: GraphNode;
+  path: { nodes: GraphNode[]; edges: GraphLink[] } | null;
+  meta: GraphResult["meta"] & {
+    mode: "path";
+    maxDepth: number;
+    found: boolean;
+    hops: number;
+  };
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Command: graph
@@ -74,10 +117,160 @@ export async function graph(
       return { success: false, error: result.error.message };
     }
 
+    if (options.neighbors) {
+      const source = resolveGraphNode(result.value, options.neighbors);
+      if (!source) {
+        return {
+          success: false,
+          error: `Graph node not found: ${options.neighbors}`,
+          isValidation: true,
+        };
+      }
+      const direction = options.direction ?? "both";
+      const neighbors = getGraphNeighbors(result.value, source, direction);
+      return {
+        success: true,
+        data: {
+          source,
+          neighbors,
+          meta: {
+            ...result.value.meta,
+            mode: "neighbors",
+            direction,
+            totalNeighbors: neighbors.length,
+          },
+        },
+      };
+    }
+
+    if (options.from || options.to) {
+      if (!(options.from && options.to)) {
+        return {
+          success: false,
+          error: "--from and --to must be used together",
+          isValidation: true,
+        };
+      }
+      const from = resolveGraphNode(result.value, options.from);
+      const to = resolveGraphNode(result.value, options.to);
+      if (!from || !to) {
+        return {
+          success: false,
+          error: `Graph node not found: ${from ? options.to : options.from}`,
+          isValidation: true,
+        };
+      }
+      const maxDepth = options.maxDepth ?? 6;
+      const path = findShortestPath(result.value, from, to, maxDepth);
+      return {
+        success: true,
+        data: {
+          from,
+          to,
+          path,
+          meta: {
+            ...result.value.meta,
+            mode: "path",
+            maxDepth,
+            found: path !== null,
+            hops: path ? path.edges.length : 0,
+          },
+        },
+      };
+    }
+
     return { success: true, data: result.value };
   } finally {
     await store.close();
   }
+}
+
+function resolveGraphNode(
+  graphResult: GraphResult,
+  ref: string
+): GraphNode | null {
+  const normalized = ref.trim().toLowerCase();
+  return (
+    graphResult.nodes.find((node) => {
+      const title = node.title?.toLowerCase();
+      return (
+        node.id.toLowerCase() === normalized ||
+        node.uri.toLowerCase() === normalized ||
+        node.relPath.toLowerCase() === normalized ||
+        `${node.collection}/${node.relPath}`.toLowerCase() === normalized ||
+        title === normalized
+      );
+    }) ?? null
+  );
+}
+
+function getGraphNeighbors(
+  graphResult: GraphResult,
+  source: GraphNode,
+  direction: "both" | "out" | "in"
+): GraphNeighborCliItem[] {
+  const nodesById = new Map(graphResult.nodes.map((node) => [node.id, node]));
+  const neighbors: GraphNeighborCliItem[] = [];
+  for (const edge of graphResult.links) {
+    if (direction !== "in" && edge.source === source.id) {
+      const node = nodesById.get(edge.target);
+      if (node) neighbors.push({ node, direction: "out", edge });
+    }
+    if (direction !== "out" && edge.target === source.id) {
+      const node = nodesById.get(edge.source);
+      if (node) neighbors.push({ node, direction: "in", edge });
+    }
+  }
+  return neighbors.sort((a, b) => a.node.uri.localeCompare(b.node.uri));
+}
+
+function findShortestPath(
+  graphResult: GraphResult,
+  from: GraphNode,
+  to: GraphNode,
+  maxDepth: number
+): { nodes: GraphNode[]; edges: GraphLink[] } | null {
+  const nodesById = new Map(graphResult.nodes.map((node) => [node.id, node]));
+  const adjacency = new Map<string, Array<{ next: string; edge: GraphLink }>>();
+  for (const edge of graphResult.links) {
+    const sourceEdges = adjacency.get(edge.source) ?? [];
+    sourceEdges.push({ next: edge.target, edge });
+    adjacency.set(edge.source, sourceEdges);
+
+    const targetEdges = adjacency.get(edge.target) ?? [];
+    targetEdges.push({ next: edge.source, edge });
+    adjacency.set(edge.target, targetEdges);
+  }
+
+  const queue: Array<{ id: string; edges: GraphLink[] }> = [
+    { id: from.id, edges: [] },
+  ];
+  const visited = new Set([from.id]);
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) break;
+    if (current.id === to.id) {
+      const nodeIds = [from.id];
+      let cursor = from.id;
+      for (const edge of current.edges) {
+        cursor = edge.source === cursor ? edge.target : edge.source;
+        nodeIds.push(cursor);
+      }
+      return {
+        nodes: nodeIds
+          .map((id) => nodesById.get(id))
+          .filter((node): node is GraphNode => node !== undefined),
+        edges: current.edges,
+      };
+    }
+    if (current.edges.length >= maxDepth) continue;
+    for (const { next, edge } of adjacency.get(current.id) ?? []) {
+      if (visited.has(next)) continue;
+      visited.add(next);
+      queue.push({ id: next, edges: [...current.edges, edge] });
+    }
+  }
+  return null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -177,6 +370,36 @@ export function formatGraph(
   }
 
   const { data } = result;
+
+  if ("neighbors" in data) {
+    if (options.format === "json" || !options.format) {
+      return JSON.stringify(data, null, 2);
+    }
+    if (data.neighbors.length === 0) {
+      return `No graph neighbors found for ${data.source.uri} (direction=${data.meta.direction})`;
+    }
+    const lines = [
+      `Found ${data.neighbors.length} graph neighbors for ${data.source.uri}:`,
+      "",
+    ];
+    for (const item of data.neighbors) {
+      const title = item.node.title ? ` "${item.node.title}"` : "";
+      lines.push(
+        `  [${item.direction}] ${item.node.uri}${title} (${item.edge.type}, weight: ${item.edge.weight})`
+      );
+    }
+    return lines.join("\n");
+  }
+
+  if ("path" in data) {
+    if (options.format === "json" || !options.format) {
+      return JSON.stringify(data, null, 2);
+    }
+    if (!data.path) {
+      return `No graph path found from ${data.from.uri} to ${data.to.uri} within ${data.meta.maxDepth} hops`;
+    }
+    return `Graph path (${data.meta.hops} hops):\n${data.path.nodes.map((node) => node.uri).join(" -> ")}`;
+  }
 
   switch (options.format) {
     case "dot":

--- a/src/cli/commands/graph.ts
+++ b/src/cli/commands/graph.ts
@@ -312,10 +312,18 @@ export function formatDot(result: GraphResult): string {
   for (const link of result.links) {
     const style =
       link.type === "similar"
-        ? ' [style=dashed, color="#888888", dir=none]'
-        : "";
+        ? 'style=dashed, color="#888888", dir=none'
+        : link.confidence === "ambiguous"
+          ? 'style=dotted, color="#d97706"'
+          : link.confidence === "inferred"
+            ? 'style=dashed, color="#64748b"'
+            : "";
+    const attrs = [
+      style,
+      `label="${escapeDot(`${link.type}/${link.confidence}`)}"`,
+    ].filter(Boolean);
     lines.push(
-      `  "${escapeDot(link.source)}" -> "${escapeDot(link.target)}"${style};`
+      `  "${escapeDot(link.source)}" -> "${escapeDot(link.target)}" [${attrs.join(", ")}];`
     );
   }
 
@@ -347,7 +355,9 @@ export function formatMermaid(result: GraphResult): string {
     const sourceId = nodeIds.get(link.source) ?? link.source;
     const targetId = nodeIds.get(link.target) ?? link.target;
     const arrow = link.type === "similar" ? "---" : "-->";
-    lines.push(`  ${sourceId} ${arrow} ${targetId}`);
+    lines.push(
+      `  ${sourceId} ${arrow}|${escapeMermaid(`${link.type}/${link.confidence}`)}| ${targetId}`
+    );
   }
 
   return lines.join("\n");
@@ -385,7 +395,7 @@ export function formatGraph(
     for (const item of data.neighbors) {
       const title = item.node.title ? ` "${item.node.title}"` : "";
       lines.push(
-        `  [${item.direction}] ${item.node.uri}${title} (${item.edge.type}, weight: ${item.edge.weight})`
+        `  [${item.direction}] ${item.node.uri}${title} (${item.edge.type}, ${item.edge.confidence}, weight: ${item.edge.weight})`
       );
     }
     return lines.join("\n");

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -539,6 +539,7 @@ function wireSearchCommands(program: Command): void {
     )
     .option("--no-expand", "disable query expansion")
     .option("--no-rerank", "disable reranking")
+    .option("--no-graph", "disable graph neighbor expansion")
     .option(
       "--query-mode <mode:text>",
       "structured mode entry (repeatable): term:<text>, intent:<text>, or hyde:<text>",
@@ -655,6 +656,7 @@ function wireSearchCommands(program: Command): void {
         lineNumbers: Boolean(cmdOpts.lineNumbers),
         noExpand: depthPolicy.noExpand,
         noRerank: depthPolicy.noRerank,
+        noGraph: Boolean(cmdOpts.fast) || cmdOpts.graph === false,
         candidateLimit: depthPolicy.candidateLimit,
         queryModes,
         explain: Boolean(cmdOpts.explain),

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2223,6 +2223,11 @@ function wireGraphCommand(program: Command): void {
     .option("--threshold <n>", "similarity threshold (default 0.7)")
     .option("--include-isolated", "include nodes with no links")
     .option("--similar-top-k <n>", "similar docs per node (default 5)")
+    .option("--neighbors <ref>", "show graph neighbors for document/node ref")
+    .option("--direction <dir>", "neighbor direction: both, out, in", "both")
+    .option("--from <ref>", "path start document/node ref")
+    .option("--to <ref>", "path target document/node ref")
+    .option("--max-depth <n>", "max path hops (default 6)")
     .option("--json", "JSON output (default)")
     .option("--dot", "Graphviz DOT output")
     .option("--mermaid", "Mermaid diagram output")
@@ -2259,6 +2264,25 @@ function wireGraphCommand(program: Command): void {
       const similarTopK = cmdOpts.similarTopK
         ? parsePositiveInt("similar-top-k", cmdOpts.similarTopK)
         : undefined;
+      const maxDepth = cmdOpts.maxDepth
+        ? parsePositiveInt("max-depth", cmdOpts.maxDepth)
+        : undefined;
+      if (
+        cmdOpts.direction !== "both" &&
+        cmdOpts.direction !== "out" &&
+        cmdOpts.direction !== "in"
+      ) {
+        throw new CliError(
+          "VALIDATION",
+          "--direction must be one of: both, out, in"
+        );
+      }
+      if (cmdOpts.neighbors && (cmdOpts.from || cmdOpts.to)) {
+        throw new CliError(
+          "VALIDATION",
+          "--neighbors cannot be combined with --from/--to"
+        );
+      }
 
       const { graph, formatGraph } = await import("./commands/graph.js");
       const result = await graph({
@@ -2271,6 +2295,11 @@ function wireGraphCommand(program: Command): void {
         includeIsolated: Boolean(cmdOpts.includeIsolated),
         similarTopK,
         format,
+        neighbors: cmdOpts.neighbors as string | undefined,
+        direction: cmdOpts.direction as "both" | "out" | "in",
+        from: cmdOpts.from as string | undefined,
+        to: cmdOpts.to as string | undefined,
+        maxDepth,
       });
 
       if (!result.success) {

--- a/src/core/graph-analysis.ts
+++ b/src/core/graph-analysis.ts
@@ -1,0 +1,201 @@
+import type { GraphLink, GraphNode } from "../store/types";
+
+export interface GraphCommunity {
+  id: string;
+  label: string;
+  size: number;
+  edgeCount: number;
+  density: number;
+  topNodes: Array<
+    Pick<
+      GraphNode,
+      "id" | "uri" | "title" | "collection" | "relPath" | "degree"
+    >
+  >;
+}
+
+export interface GraphCommunityAnalysis {
+  total: number;
+  algorithm: "deterministic-label-propagation";
+  skipped: boolean;
+  assignments: Record<string, string>;
+  communities: GraphCommunity[];
+  warnings: string[];
+}
+
+const DEFAULT_COMMUNITY_NODE_CAP = 2000;
+const MAX_ITERATIONS = 8;
+
+const confidenceFactor = (confidence: GraphLink["confidence"]): number => {
+  switch (confidence) {
+    case "explicit":
+      return 1;
+    case "inferred":
+      return 0.75;
+    case "ambiguous":
+      return 0.5;
+    case "similarity":
+      return 0.35;
+  }
+};
+
+const edgeStrength = (edge: GraphLink): number =>
+  Math.max(0.01, edge.weight) * confidenceFactor(edge.confidence);
+
+export function analyzeGraphCommunities(
+  nodes: GraphNode[],
+  links: GraphLink[],
+  options: { nodeCap?: number } = {}
+): GraphCommunityAnalysis {
+  const nodeCap = options.nodeCap ?? DEFAULT_COMMUNITY_NODE_CAP;
+  if (nodes.length === 0) {
+    return {
+      total: 0,
+      algorithm: "deterministic-label-propagation",
+      skipped: false,
+      assignments: {},
+      communities: [],
+      warnings: [],
+    };
+  }
+
+  if (nodes.length > nodeCap) {
+    return {
+      total: 0,
+      algorithm: "deterministic-label-propagation",
+      skipped: true,
+      assignments: {},
+      communities: [],
+      warnings: [
+        `Community detection skipped: graph has ${nodes.length} nodes (cap ${nodeCap})`,
+      ],
+    };
+  }
+
+  const sortedNodes = [...nodes].sort((a, b) => a.id.localeCompare(b.id));
+  const nodeIds = new Set(sortedNodes.map((node) => node.id));
+  const adjacency = new Map<string, Map<string, number>>();
+  for (const node of sortedNodes) {
+    adjacency.set(node.id, new Map());
+  }
+
+  for (const edge of links) {
+    if (!(nodeIds.has(edge.source) && nodeIds.has(edge.target))) continue;
+    if (edge.source === edge.target) continue;
+    const strength = edgeStrength(edge);
+    const sourceNeighbors = adjacency.get(edge.source);
+    const targetNeighbors = adjacency.get(edge.target);
+    if (!(sourceNeighbors && targetNeighbors)) continue;
+    sourceNeighbors.set(
+      edge.target,
+      (sourceNeighbors.get(edge.target) ?? 0) + strength
+    );
+    targetNeighbors.set(
+      edge.source,
+      (targetNeighbors.get(edge.source) ?? 0) + strength
+    );
+  }
+
+  const labels = new Map(sortedNodes.map((node) => [node.id, node.id]));
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    let changed = false;
+    for (const node of sortedNodes) {
+      const neighbors = adjacency.get(node.id);
+      if (!neighbors || neighbors.size === 0) continue;
+
+      const scores = new Map<string, number>();
+      for (const [neighborId, strength] of neighbors) {
+        const label = labels.get(neighborId) ?? neighborId;
+        scores.set(label, (scores.get(label) ?? 0) + strength);
+      }
+
+      const currentLabel = labels.get(node.id) ?? node.id;
+      let bestLabel = currentLabel;
+      let bestScore = scores.get(currentLabel) ?? 0;
+      for (const [candidate, score] of [...scores.entries()].sort((a, b) =>
+        a[0].localeCompare(b[0])
+      )) {
+        if (
+          score > bestScore ||
+          (score === bestScore && candidate < bestLabel)
+        ) {
+          bestLabel = candidate;
+          bestScore = score;
+        }
+      }
+      if (bestLabel !== currentLabel) {
+        labels.set(node.id, bestLabel);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  const groups = new Map<string, GraphNode[]>();
+  for (const node of sortedNodes) {
+    const label = labels.get(node.id) ?? node.id;
+    const group = groups.get(label) ?? [];
+    group.push(node);
+    groups.set(label, group);
+  }
+
+  const edgeCountByLabel = new Map<string, number>();
+  for (const edge of links) {
+    const sourceLabel = labels.get(edge.source);
+    const targetLabel = labels.get(edge.target);
+    if (!sourceLabel || sourceLabel !== targetLabel) continue;
+    edgeCountByLabel.set(
+      sourceLabel,
+      (edgeCountByLabel.get(sourceLabel) ?? 0) + 1
+    );
+  }
+
+  const orderedGroups = [...groups.entries()].sort((a, b) => {
+    const sizeDelta = b[1].length - a[1].length;
+    if (sizeDelta !== 0) return sizeDelta;
+    const aUri = a[1][0]?.uri ?? a[0];
+    const bUri = b[1][0]?.uri ?? b[0];
+    return aUri.localeCompare(bUri);
+  });
+
+  const labelToCommunityId = new Map<string, string>();
+  const communities = orderedGroups.map(([label, group], index) => {
+    const communityId = `c${index + 1}`;
+    labelToCommunityId.set(label, communityId);
+    const sortedGroup = [...group].sort(
+      (a, b) => b.degree - a.degree || a.uri.localeCompare(b.uri)
+    );
+    const edgeCount = edgeCountByLabel.get(label) ?? 0;
+    const maxUndirectedEdges = (group.length * (group.length - 1)) / 2;
+    return {
+      id: communityId,
+      label: sortedGroup[0]?.title ?? sortedGroup[0]?.relPath ?? communityId,
+      size: group.length,
+      edgeCount,
+      density: maxUndirectedEdges > 0 ? edgeCount / maxUndirectedEdges : 0,
+      topNodes: sortedGroup.slice(0, 5).map((node) => ({
+        id: node.id,
+        uri: node.uri,
+        title: node.title,
+        collection: node.collection,
+        relPath: node.relPath,
+        degree: node.degree,
+      })),
+    };
+  });
+
+  const assignments: Record<string, string> = {};
+  for (const node of sortedNodes) {
+    const label = labels.get(node.id) ?? node.id;
+    assignments[node.id] = labelToCommunityId.get(label) ?? "c0";
+  }
+
+  return {
+    total: communities.length,
+    algorithm: "deterministic-label-propagation",
+    skipped: false,
+    assignments,
+    communities: communities.slice(0, 10),
+    warnings: [],
+  };
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -453,6 +453,10 @@ export const queryInputSchema = z.object({
     .boolean()
     .optional()
     .describe("Override: enable/disable cross-encoder reranking"),
+  noGraph: z
+    .boolean()
+    .optional()
+    .describe("Disable bounded one-hop graph neighbor expansion"),
   tagsAll: z.array(z.string()).optional().describe("Require ALL of these tags"),
   tagsAny: z.array(z.string()).optional().describe("Require ANY of these tags"),
 });

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -21,6 +21,8 @@ import { handleJobStatus } from "./job-status";
 import {
   handleBacklinks,
   handleGraph,
+  handleGraphNeighbors,
+  handleGraphPath,
   handleLinks,
   handleSimilar,
 } from "./links";
@@ -637,6 +639,40 @@ const graphInputSchema = z.object({
     .describe("Max similar docs per node when includeSimilar=true"),
 });
 
+const graphNeighborsInputSchema = graphInputSchema.extend({
+  ref: z
+    .string()
+    .trim()
+    .min(1, "Reference cannot be empty")
+    .describe(
+      "Document/node reference: gno URI, #docid, collection/path, relPath, or exact title"
+    ),
+  direction: z
+    .enum(["both", "out", "in"])
+    .default("both")
+    .describe("Which graph edges to follow from the reference node"),
+});
+
+const graphPathInputSchema = graphInputSchema.extend({
+  from: z
+    .string()
+    .trim()
+    .min(1, "From reference cannot be empty")
+    .describe("Starting document/node reference"),
+  to: z
+    .string()
+    .trim()
+    .min(1, "To reference cannot be empty")
+    .describe("Target document/node reference"),
+  maxDepth: z
+    .number()
+    .int()
+    .min(1)
+    .max(12)
+    .default(6)
+    .describe("Maximum relationship hops to search"),
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tool Result Type
 // ─────────────────────────────────────────────────────────────────────────────
@@ -798,30 +834,44 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
 
   server.tool(
     "gno_links",
-    "Get outgoing wiki ([[links]]) and markdown links from a document.",
+    "Get outgoing wiki ([[links]]) and markdown links from one document. Use after gno_query when you need immediate local expansion from a known source document; use gno_graph_neighbors for bidirectional graph navigation.",
     linksInputSchema.shape,
     (args) => handleLinks(args, ctx)
   );
 
   server.tool(
     "gno_backlinks",
-    "Find all documents that link TO a given document (incoming references).",
+    "Find all documents that link TO a given document. Use after gno_query/gno_get to discover incoming references around a known target; use gno_graph_path for 'how are X and Y connected?' questions.",
     backlinksInputSchema.shape,
     (args) => handleBacklinks(args, ctx)
   );
 
   server.tool(
     "gno_similar",
-    "Find semantically similar documents using vector embeddings. Requires embeddings to exist for source document.",
+    "Find semantically similar documents using vector embeddings. Use for local expansion when wording differs; use gno_query as the default retrieval entry point and gno_graph_neighbors/path for explicit relationship questions.",
     similarInputSchema.shape,
     (args) => handleSimilar(args, ctx)
   );
 
   server.tool(
     "gno_graph",
-    "Get knowledge graph of document connections (wiki links, markdown links, optional similarity edges).",
+    "Get graph report/stats plus nodes/edges for corpus navigation. Use for unfamiliar corpus structure, hubs/isolates/unresolved links, or custom graph analysis; do not replace normal retrieval with this. Start with gno_query for content questions, then graph tools for relationship context, then gno_get for targeted reads.",
     graphInputSchema.shape,
     (args) => handleGraph(args, ctx)
+  );
+
+  server.tool(
+    "gno_graph_neighbors",
+    "Find graph neighbors around a document/node. Use for relationship questions, missed obvious related docs, or unfamiliar corpus navigation after gno_query identifies a seed; returns incoming/outgoing wiki, markdown, and optional similarity edges. Follow with gno_get for targeted reads.",
+    graphNeighborsInputSchema.shape,
+    (args) => handleGraphNeighbors(args, ctx)
+  );
+
+  server.tool(
+    "gno_graph_path",
+    "Find the shortest relationship path between two documents/nodes. Use for prompts like 'how are X and Y connected?' or to explain corpus relationships. Use gno_query for finding candidate refs first, then gno_get on path nodes for evidence.",
+    graphPathInputSchema.shape,
+    (args) => handleGraphPath(args, ctx)
   );
 
   if (ctx.enableWrite) {

--- a/src/mcp/tools/links.ts
+++ b/src/mcp/tools/links.ts
@@ -725,6 +725,19 @@ function formatGraphResult(data: GraphResult): string {
     lines.push(`  ${confidence}: ${count}`);
   }
 
+  if (report.communities.skipped) {
+    lines.push("");
+    lines.push("Communities: skipped for graph size");
+  } else {
+    lines.push("");
+    lines.push(`Communities: ${report.communities.total}`);
+    for (const community of report.communities.top.slice(0, 5)) {
+      lines.push(
+        `  ${community.id}: ${community.label} (${community.size} docs, ${community.edgeCount} internal edges)`
+      );
+    }
+  }
+
   lines.push("");
   lines.push(
     `Unresolved links: ${report.unresolvedLinks.total} (wiki: ${report.unresolvedLinks.byType.wiki}, markdown: ${report.unresolvedLinks.byType.markdown})`

--- a/src/mcp/tools/links.ts
+++ b/src/mcp/tools/links.ts
@@ -636,7 +636,7 @@ interface GraphInput {
 }
 
 function formatGraphResult(data: GraphResult): string {
-  const { nodes, links, meta } = data;
+  const { meta, report } = data;
   const lines: string[] = [];
 
   lines.push(
@@ -659,22 +659,31 @@ function formatGraphResult(data: GraphResult): string {
 
   lines.push("");
   lines.push("Top nodes by degree:");
-  const topNodes = [...nodes].sort((a, b) => b.degree - a.degree).slice(0, 10);
-  for (const node of topNodes) {
+  for (const node of report.hubs) {
     const title = node.title ? ` "${node.title}"` : "";
     lines.push(`  [${node.id}] ${node.uri}${title} (degree: ${node.degree})`);
   }
 
-  const edgeTypes = new Map<string, number>();
-  for (const link of links) {
-    edgeTypes.set(link.type, (edgeTypes.get(link.type) ?? 0) + 1);
+  if (report.bridgeCandidates.length > 0) {
+    lines.push("");
+    lines.push("Bridge candidates:");
+    for (const node of report.bridgeCandidates) {
+      const title = node.title ? ` "${node.title}"` : "";
+      lines.push(`  [${node.id}] ${node.uri}${title} (degree: ${node.degree})`);
+    }
   }
 
   lines.push("");
   lines.push("Edge breakdown:");
-  for (const [type, count] of edgeTypes) {
+  for (const [type, count] of Object.entries(report.edgeTypes)) {
     lines.push(`  ${type}: ${count}`);
   }
+
+  lines.push("");
+  lines.push(
+    `Unresolved links: ${report.unresolvedLinks.total} (wiki: ${report.unresolvedLinks.byType.wiki}, markdown: ${report.unresolvedLinks.byType.markdown})`
+  );
+  lines.push(`Isolated documents: ${report.isolated.total}`);
 
   return lines.join("\n");
 }

--- a/src/mcp/tools/links.ts
+++ b/src/mcp/tools/links.ts
@@ -720,10 +720,17 @@ function formatGraphResult(data: GraphResult): string {
   for (const [type, count] of Object.entries(report.edgeTypes)) {
     lines.push(`  ${type}: ${count}`);
   }
+  lines.push("Confidence:");
+  for (const [confidence, count] of Object.entries(report.edgeConfidence)) {
+    lines.push(`  ${confidence}: ${count}`);
+  }
 
   lines.push("");
   lines.push(
     `Unresolved links: ${report.unresolvedLinks.total} (wiki: ${report.unresolvedLinks.byType.wiki}, markdown: ${report.unresolvedLinks.byType.markdown})`
+  );
+  lines.push(
+    `Audit: inferred ${report.audit.inferredEdges}, ambiguous ${report.audit.ambiguousEdges}, similarity ${report.audit.similarityEdges}`
   );
   lines.push(`Isolated documents: ${report.isolated.total}`);
 
@@ -834,7 +841,7 @@ function formatGraphNeighborsResult(data: GraphNeighborsResult): string {
   for (const item of data.neighbors) {
     const title = item.node.title ? ` "${item.node.title}"` : "";
     lines.push(
-      `  [${item.direction}] ${item.node.uri}${title} (${item.edge.type}, weight: ${item.edge.weight})`
+      `  [${item.direction}] ${item.node.uri}${title} (${item.edge.type}, ${item.edge.confidence}, weight: ${item.edge.weight})`
     );
   }
   return lines.join("\n");

--- a/src/mcp/tools/links.ts
+++ b/src/mcp/tools/links.ts
@@ -10,6 +10,8 @@ import type {
   BacklinkRow,
   DocLinkRow,
   DocumentRow,
+  GraphLink,
+  GraphNode,
   GraphResult,
 } from "../../store/types";
 import type { ToolContext } from "../server";
@@ -635,6 +637,46 @@ interface GraphInput {
   similarTopK?: number;
 }
 
+interface GraphNeighborsInput extends GraphInput {
+  ref: string;
+  direction?: "both" | "out" | "in";
+}
+
+interface GraphPathInput extends GraphInput {
+  from: string;
+  to: string;
+  maxDepth?: number;
+}
+
+interface GraphNeighbor {
+  node: GraphNode;
+  direction: "out" | "in";
+  edge: GraphLink;
+}
+
+interface GraphNeighborsResult {
+  source: GraphNode;
+  neighbors: GraphNeighbor[];
+  meta: GraphResult["meta"] & {
+    direction: "both" | "out" | "in";
+    totalNeighbors: number;
+  };
+}
+
+interface GraphPathResult {
+  from: GraphNode;
+  to: GraphNode;
+  path: {
+    nodes: GraphNode[];
+    edges: GraphLink[];
+  } | null;
+  meta: GraphResult["meta"] & {
+    maxDepth: number;
+    found: boolean;
+    hops: number;
+  };
+}
+
 function formatGraphResult(data: GraphResult): string {
   const { meta, report } = data;
   const lines: string[] = [];
@@ -727,5 +769,231 @@ export function handleGraph(
       return result.value;
     },
     formatGraphResult
+  );
+}
+
+async function getValidatedGraph(
+  args: GraphInput,
+  ctx: ToolContext
+): Promise<GraphResult> {
+  let collection: string | undefined;
+  if (args.collection) {
+    collection = normalizeCollectionName(args.collection);
+    const exists = ctx.collections.some(
+      (c) => c.name.toLowerCase() === collection?.toLowerCase()
+    );
+    if (!exists) {
+      throw new Error(
+        `${MCP_ERRORS.NOT_FOUND.code}: Collection not found: ${args.collection}`
+      );
+    }
+  }
+
+  const result = await ctx.store.getGraph({
+    collection,
+    limitNodes: args.limit ?? 2000,
+    limitEdges: args.edgeLimit ?? 10000,
+    includeSimilar: args.includeSimilar ?? false,
+    threshold: args.threshold ?? 0.7,
+    linkedOnly: args.linkedOnly ?? true,
+    similarTopK: args.similarTopK ?? 5,
+  });
+
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+
+  return result.value;
+}
+
+function resolveGraphNode(graph: GraphResult, ref: string): GraphNode | null {
+  const normalized = ref.trim().toLowerCase();
+  return (
+    graph.nodes.find((node) => {
+      const title = node.title?.toLowerCase();
+      return (
+        node.id.toLowerCase() === normalized ||
+        node.uri.toLowerCase() === normalized ||
+        node.relPath.toLowerCase() === normalized ||
+        `${node.collection}/${node.relPath}`.toLowerCase() === normalized ||
+        title === normalized
+      );
+    }) ?? null
+  );
+}
+
+function formatGraphNeighborsResult(data: GraphNeighborsResult): string {
+  if (data.neighbors.length === 0) {
+    return `No graph neighbors found for ${data.source.uri} (direction=${data.meta.direction})`;
+  }
+
+  const lines = [
+    `Found ${data.neighbors.length} graph neighbors for ${data.source.uri}:`,
+    "",
+  ];
+  for (const item of data.neighbors) {
+    const title = item.node.title ? ` "${item.node.title}"` : "";
+    lines.push(
+      `  [${item.direction}] ${item.node.uri}${title} (${item.edge.type}, weight: ${item.edge.weight})`
+    );
+  }
+  return lines.join("\n");
+}
+
+export function handleGraphNeighbors(
+  args: GraphNeighborsInput,
+  ctx: ToolContext
+): Promise<ToolResult> {
+  return runTool(
+    ctx,
+    "gno_graph_neighbors",
+    async () => {
+      const graph = await getValidatedGraph(args, ctx);
+      const source = resolveGraphNode(graph, args.ref);
+      if (!source) {
+        throw new Error(
+          `${MCP_ERRORS.NOT_FOUND.code}: Graph node not found: ${args.ref}`
+        );
+      }
+
+      const direction = args.direction ?? "both";
+      const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+      const neighbors: GraphNeighbor[] = [];
+
+      for (const edge of graph.links) {
+        if (direction !== "in" && edge.source === source.id) {
+          const node = nodesById.get(edge.target);
+          if (node) neighbors.push({ node, direction: "out", edge });
+        }
+        if (direction !== "out" && edge.target === source.id) {
+          const node = nodesById.get(edge.source);
+          if (node) neighbors.push({ node, direction: "in", edge });
+        }
+      }
+
+      neighbors.sort((a, b) => {
+        if (a.direction !== b.direction) {
+          return a.direction.localeCompare(b.direction);
+        }
+        if (a.edge.type !== b.edge.type) {
+          return a.edge.type.localeCompare(b.edge.type);
+        }
+        return a.node.uri.localeCompare(b.node.uri);
+      });
+
+      return {
+        source,
+        neighbors,
+        meta: {
+          ...graph.meta,
+          direction,
+          totalNeighbors: neighbors.length,
+        },
+      };
+    },
+    formatGraphNeighborsResult
+  );
+}
+
+function findShortestPath(
+  graph: GraphResult,
+  from: GraphNode,
+  to: GraphNode,
+  maxDepth: number
+): { nodes: GraphNode[]; edges: GraphLink[] } | null {
+  const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+  const adjacency = new Map<string, Array<{ next: string; edge: GraphLink }>>();
+  for (const edge of graph.links) {
+    const sourceEdges = adjacency.get(edge.source) ?? [];
+    sourceEdges.push({ next: edge.target, edge });
+    adjacency.set(edge.source, sourceEdges);
+
+    const reverseEdges = adjacency.get(edge.target) ?? [];
+    reverseEdges.push({ next: edge.source, edge });
+    adjacency.set(edge.target, reverseEdges);
+  }
+
+  const queue: Array<{ id: string; pathEdges: GraphLink[] }> = [
+    { id: from.id, pathEdges: [] },
+  ];
+  const visited = new Set([from.id]);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) break;
+    if (current.id === to.id) {
+      const nodeIds = [from.id];
+      let cursor = from.id;
+      for (const edge of current.pathEdges) {
+        cursor = edge.source === cursor ? edge.target : edge.source;
+        nodeIds.push(cursor);
+      }
+      return {
+        nodes: nodeIds
+          .map((id) => nodesById.get(id))
+          .filter((node): node is GraphNode => node !== undefined),
+        edges: current.pathEdges,
+      };
+    }
+    if (current.pathEdges.length >= maxDepth) continue;
+
+    const edges = adjacency.get(current.id) ?? [];
+    edges.sort((a, b) => a.next.localeCompare(b.next));
+    for (const { next, edge } of edges) {
+      if (visited.has(next)) continue;
+      visited.add(next);
+      queue.push({ id: next, pathEdges: [...current.pathEdges, edge] });
+    }
+  }
+
+  return null;
+}
+
+function formatGraphPathResult(data: GraphPathResult): string {
+  if (!data.path) {
+    return `No graph path found from ${data.from.uri} to ${data.to.uri} within ${data.meta.maxDepth} hops`;
+  }
+
+  const route = data.path.nodes.map((node) => node.uri).join(" -> ");
+  return `Graph path (${data.meta.hops} hops):\n${route}`;
+}
+
+export function handleGraphPath(
+  args: GraphPathInput,
+  ctx: ToolContext
+): Promise<ToolResult> {
+  return runTool(
+    ctx,
+    "gno_graph_path",
+    async () => {
+      const graph = await getValidatedGraph(args, ctx);
+      const from = resolveGraphNode(graph, args.from);
+      if (!from) {
+        throw new Error(
+          `${MCP_ERRORS.NOT_FOUND.code}: Graph node not found: ${args.from}`
+        );
+      }
+      const to = resolveGraphNode(graph, args.to);
+      if (!to) {
+        throw new Error(
+          `${MCP_ERRORS.NOT_FOUND.code}: Graph node not found: ${args.to}`
+        );
+      }
+
+      const maxDepth = args.maxDepth ?? 6;
+      const path = findShortestPath(graph, from, to, maxDepth);
+      return {
+        from,
+        to,
+        path,
+        meta: {
+          ...graph.meta,
+          maxDepth,
+          found: path !== null,
+          hops: path ? path.edges.length : 0,
+        },
+      };
+    },
+    formatGraphPathResult
   );
 }

--- a/src/mcp/tools/query.ts
+++ b/src/mcp/tools/query.ts
@@ -50,6 +50,7 @@ interface QueryInput {
   thorough?: boolean;
   expand?: boolean;
   rerank?: boolean;
+  noGraph?: boolean;
   tagsAll?: string[];
   tagsAny?: string[];
 }
@@ -271,6 +272,7 @@ export function handleQuery(
           author: args.author,
           noExpand,
           noRerank,
+          noGraph: args.noGraph || args.fast,
           queryModes,
           tagsAll: normalizeTagFilters(args.tagsAll),
           tagsAny: normalizeTagFilters(args.tagsAny),

--- a/src/pipeline/explain.ts
+++ b/src/pipeline/explain.ts
@@ -175,6 +175,7 @@ interface StageTimingsInput {
   expansionMs: number;
   bm25Ms: number;
   vectorMs: number;
+  graphMs: number;
   fusionMs: number;
   rerankMs: number;
   assemblyMs: number;
@@ -190,6 +191,7 @@ export function explainTimings(timings: StageTimingsInput): ExplainLine {
       `expansion=${fmt(timings.expansionMs)}`,
       `bm25=${fmt(timings.bm25Ms)}`,
       `vector=${fmt(timings.vectorMs)}`,
+      `graph=${fmt(timings.graphMs)}`,
       `fusion=${fmt(timings.fusionMs)}`,
       `rerank=${fmt(timings.rerankMs)}`,
       `assembly=${fmt(timings.assemblyMs)}`,

--- a/src/pipeline/fusion.ts
+++ b/src/pipeline/fusion.ts
@@ -62,6 +62,7 @@ export function rrfFuse(
       i.source === "vector_variant" ||
       i.source === "hyde"
   );
+  const graphInputs = inputs.filter((i) => i.source === "graph");
 
   // Process BM25 sources
   // Original query gets 2x weight to prevent dilution by expansion variants
@@ -132,6 +133,33 @@ export function rrfFuse(
       }
 
       // Add RRF contribution
+      candidate.fusionScore += rrfContribution(result.rank, config.k, weight);
+      if (!candidate.sources.includes(input.source)) {
+        candidate.sources.push(input.source);
+      }
+    }
+  }
+
+  // Process graph expansion sources.
+  for (const input of graphInputs) {
+    const weight = config.bm25Weight * 0.8;
+
+    for (const result of input.results) {
+      const key = `${result.mirrorHash}:${result.seq}`;
+      let candidate = candidates.get(key);
+
+      if (!candidate) {
+        candidate = {
+          mirrorHash: result.mirrorHash,
+          seq: result.seq,
+          bm25Rank: null,
+          vecRank: null,
+          fusionScore: 0,
+          sources: [],
+        };
+        candidates.set(key, candidate);
+      }
+
       candidate.fusionScore += rrfContribution(result.rank, config.k, weight);
       if (!candidate.sources.includes(input.source)) {
         candidate.sources.push(input.source);

--- a/src/pipeline/graph-retrieval.ts
+++ b/src/pipeline/graph-retrieval.ts
@@ -5,12 +5,15 @@
  */
 
 import type {
+  ChunkRow,
   DocumentRow,
   GraphEdgeConfidence,
   GraphLink,
   StorePort,
 } from "../store/types";
 import type { FusionCandidate } from "./types";
+
+import { isWithinTemporalRange } from "./temporal";
 
 export interface GraphRetrievalMeta {
   attempted: boolean;
@@ -50,6 +53,102 @@ const confidenceWeight = (confidence: GraphEdgeConfidence): number => {
     case "similarity":
       return 0.25;
   }
+};
+
+const matchesDocumentFilters = (
+  doc: DocumentRow,
+  options: {
+    since?: string;
+    until?: string;
+    categories?: string[];
+    author?: string;
+  }
+): boolean => {
+  if (
+    !isWithinTemporalRange(doc.sourceMtime, {
+      since: options.since,
+      until: options.until,
+    })
+  ) {
+    return false;
+  }
+  if (
+    options.author &&
+    !doc.author?.toLowerCase().includes(options.author.toLowerCase())
+  ) {
+    return false;
+  }
+  if (options.categories?.length) {
+    const allowed = new Set(options.categories.map((c) => c.toLowerCase()));
+    const contentTypeMatch = doc.contentType
+      ? allowed.has(doc.contentType.toLowerCase())
+      : false;
+    const categoryMatch = (doc.categories ?? []).some((c) =>
+      allowed.has(c.toLowerCase())
+    );
+    if (!contentTypeMatch && !categoryMatch) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const filterDocsByTags = async (
+  store: StorePort,
+  docs: DocumentRow[],
+  options: { tagsAll?: string[]; tagsAny?: string[] }
+): Promise<DocumentRow[]> => {
+  if (!options.tagsAll?.length && !options.tagsAny?.length) {
+    return docs;
+  }
+
+  const tagsResult = await store.getTagsBatch(docs.map((doc) => doc.id));
+  if (!tagsResult.ok) {
+    return [];
+  }
+
+  return docs.filter((doc) => {
+    const docTags = new Set(
+      (tagsResult.value.get(doc.id) ?? []).map((tag) => tag.tag)
+    );
+    if (options.tagsAll?.length) {
+      const hasAll = options.tagsAll.every((tag) => docTags.has(tag));
+      if (!hasAll) {
+        return false;
+      }
+    }
+    if (options.tagsAny?.length) {
+      const hasAny = options.tagsAny.some((tag) => docTags.has(tag));
+      if (!hasAny) {
+        return false;
+      }
+    }
+    return true;
+  });
+};
+
+const chooseCandidateSeq = (
+  doc: DocumentRow,
+  chunks: ChunkRow[],
+  preferredSeqByHash: Map<string, number>,
+  lang?: string
+): number | null => {
+  if (!doc.mirrorHash) {
+    return null;
+  }
+
+  const preferredSeq = preferredSeqByHash.get(doc.mirrorHash);
+  if (preferredSeq !== undefined) {
+    const preferredChunk = chunks.find((chunk) => chunk.seq === preferredSeq);
+    if (preferredChunk && (!lang || preferredChunk.language === lang)) {
+      return preferredSeq;
+    }
+  }
+
+  const chunk = lang
+    ? chunks.find((candidate) => candidate.language === lang)
+    : chunks[0];
+  return chunk?.seq ?? null;
 };
 
 const createMeta = (
@@ -95,6 +194,13 @@ export async function expandGraphCandidates(
     limit?: number;
     candidateLimit?: number;
     disabled?: boolean;
+    lang?: string;
+    tagsAll?: string[];
+    tagsAny?: string[];
+    since?: string;
+    until?: string;
+    categories?: string[];
+    author?: string;
   } = {}
 ): Promise<GraphRetrievalResult> {
   const maxCandidates = Math.max(
@@ -122,6 +228,12 @@ export async function expandGraphCandidates(
   meta.attempted = true;
   const seedCandidates = fusedCandidates.slice(0, GRAPH_SEED_LIMIT);
   const seedHashes = [...new Set(seedCandidates.map((c) => c.mirrorHash))];
+  const preferredSeqByHash = new Map<string, number>();
+  for (const candidate of fusedCandidates) {
+    if (!preferredSeqByHash.has(candidate.mirrorHash)) {
+      preferredSeqByHash.set(candidate.mirrorHash, candidate.seq);
+    }
+  }
   const seedDocsResult = await store.getDocumentsByMirrorHashes(seedHashes, {
     collection: options.collection,
     activeOnly: true,
@@ -204,19 +316,46 @@ export async function expandGraphCandidates(
     return { candidates: [], meta };
   }
 
-  const docs: DocumentRow[] = [];
-  for (const docid of rankedNeighborDocids) {
-    const docResult = await store.getDocumentByDocid(docid);
-    if (docResult.ok && docResult.value?.mirrorHash) {
-      docs.push(docResult.value);
-    }
+  const docsResult = await store.getDocumentsByDocids(rankedNeighborDocids, {
+    collection: options.collection,
+    activeOnly: true,
+  });
+  if (!docsResult.ok) {
+    meta.fallbackReasons.push("graph_neighbor_lookup_failed");
+    return { candidates: [], meta };
+  }
+
+  const metadataFilteredDocs = docsResult.value.filter(
+    (doc) => doc.mirrorHash && matchesDocumentFilters(doc, options)
+  );
+  const docs = await filterDocsByTags(store, metadataFilteredDocs, options);
+  const hashes = docs
+    .map((doc) => doc.mirrorHash)
+    .filter((hash): hash is string => Boolean(hash));
+  const chunksResult = await store.getChunksBatch(hashes);
+  if (!chunksResult.ok) {
+    meta.fallbackReasons.push("graph_neighbor_chunks_failed");
+    return { candidates: [], meta };
   }
 
   const docByDocid = new Map(docs.map((doc) => [doc.docid, doc]));
   const candidates = rankedNeighborDocids
     .map((docid) => docByDocid.get(docid))
     .filter((doc): doc is DocumentRow => Boolean(doc?.mirrorHash))
-    .map((doc) => ({ mirrorHash: doc.mirrorHash as string, seq: 0 }));
+    .map((doc) => {
+      const mirrorHash = doc.mirrorHash as string;
+      const seq = chooseCandidateSeq(
+        doc,
+        chunksResult.value.get(mirrorHash) ?? [],
+        preferredSeqByHash,
+        options.lang
+      );
+      return seq === null ? null : { mirrorHash, seq };
+    })
+    .filter(
+      (candidate): candidate is { mirrorHash: string; seq: number } =>
+        candidate !== null
+    );
 
   meta.enabled = candidates.length > 0;
   meta.candidateCount = candidates.length;

--- a/src/pipeline/graph-retrieval.ts
+++ b/src/pipeline/graph-retrieval.ts
@@ -309,7 +309,6 @@ export async function expandGraphCandidates(
 
   const rankedNeighborDocids = [...neighborScores.entries()]
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .slice(0, maxCandidates)
     .map(([docid]) => docid);
   if (rankedNeighborDocids.length === 0) {
     meta.fallbackReasons.push("graph_no_new_candidates");
@@ -329,7 +328,12 @@ export async function expandGraphCandidates(
     (doc) => doc.mirrorHash && matchesDocumentFilters(doc, options)
   );
   const docs = await filterDocsByTags(store, metadataFilteredDocs, options);
-  const hashes = docs
+  const docByDocid = new Map(docs.map((doc) => [doc.docid, doc]));
+  const rankedDocs = rankedNeighborDocids
+    .map((docid) => docByDocid.get(docid))
+    .filter((doc): doc is DocumentRow => Boolean(doc?.mirrorHash))
+    .slice(0, maxCandidates);
+  const hashes = rankedDocs
     .map((doc) => doc.mirrorHash)
     .filter((hash): hash is string => Boolean(hash));
   const chunksResult = await store.getChunksBatch(hashes);
@@ -338,10 +342,7 @@ export async function expandGraphCandidates(
     return { candidates: [], meta };
   }
 
-  const docByDocid = new Map(docs.map((doc) => [doc.docid, doc]));
-  const candidates = rankedNeighborDocids
-    .map((docid) => docByDocid.get(docid))
-    .filter((doc): doc is DocumentRow => Boolean(doc?.mirrorHash))
+  const candidates = rankedDocs
     .map((doc) => {
       const mirrorHash = doc.mirrorHash as string;
       const seq = chooseCandidateSeq(

--- a/src/pipeline/graph-retrieval.ts
+++ b/src/pipeline/graph-retrieval.ts
@@ -1,0 +1,228 @@
+/**
+ * Bounded graph expansion for hybrid retrieval.
+ *
+ * @module src/pipeline/graph-retrieval
+ */
+
+import type {
+  DocumentRow,
+  GraphEdgeConfidence,
+  GraphLink,
+  StorePort,
+} from "../store/types";
+import type { FusionCandidate } from "./types";
+
+export interface GraphRetrievalMeta {
+  attempted: boolean;
+  enabled: boolean;
+  seedCount: number;
+  candidateCount: number;
+  maxCandidates: number;
+  edgeConfidence: Record<GraphEdgeConfidence, number>;
+  fallbackReasons: string[];
+}
+
+export interface GraphRetrievalResult {
+  candidates: Array<{ mirrorHash: string; seq: number }>;
+  meta: GraphRetrievalMeta;
+}
+
+const GRAPH_SEED_LIMIT = 5;
+const GRAPH_CANDIDATE_LIMIT = 20;
+const GRAPH_NODE_LIMIT = 2000;
+const GRAPH_EDGE_LIMIT = 10000;
+
+const EMPTY_EDGE_CONFIDENCE: Record<GraphEdgeConfidence, number> = {
+  explicit: 0,
+  inferred: 0,
+  ambiguous: 0,
+  similarity: 0,
+};
+
+const confidenceWeight = (confidence: GraphEdgeConfidence): number => {
+  switch (confidence) {
+    case "explicit":
+      return 1;
+    case "inferred":
+      return 0.65;
+    case "ambiguous":
+      return 0.35;
+    case "similarity":
+      return 0.25;
+  }
+};
+
+const createMeta = (
+  overrides: Partial<GraphRetrievalMeta> = {}
+): GraphRetrievalMeta => ({
+  attempted: false,
+  enabled: false,
+  seedCount: 0,
+  candidateCount: 0,
+  maxCandidates: GRAPH_CANDIDATE_LIMIT,
+  edgeConfidence: { ...EMPTY_EDGE_CONFIDENCE },
+  fallbackReasons: [],
+  ...overrides,
+});
+
+const addEdgeCandidate = (
+  scores: Map<string, number>,
+  link: GraphLink,
+  neighborDocid: string,
+  seedRank: number,
+  edgeConfidence: Record<GraphEdgeConfidence, number>
+): void => {
+  edgeConfidence[link.confidence] += 1;
+  const seedWeight = 1 / seedRank;
+  const edgeWeight =
+    link.confidence === "similarity"
+      ? Math.max(0, Math.min(1, link.weight))
+      : Math.max(1, link.weight);
+  const score = confidenceWeight(link.confidence) * edgeWeight * seedWeight;
+  const current = scores.get(neighborDocid) ?? 0;
+  scores.set(neighborDocid, current + score);
+};
+
+/**
+ * Expand top retrieval candidates through one-hop graph neighbors.
+ */
+export async function expandGraphCandidates(
+  store: StorePort,
+  fusedCandidates: FusionCandidate[],
+  options: {
+    collection?: string;
+    includeSimilar?: boolean;
+    limit?: number;
+    candidateLimit?: number;
+    disabled?: boolean;
+  } = {}
+): Promise<GraphRetrievalResult> {
+  const maxCandidates = Math.max(
+    1,
+    Math.min(
+      GRAPH_CANDIDATE_LIMIT,
+      options.candidateLimit ?? options.limit ?? GRAPH_CANDIDATE_LIMIT
+    )
+  );
+  const meta = createMeta({ maxCandidates });
+
+  if (options.disabled) {
+    meta.fallbackReasons.push("graph_disabled");
+    return { candidates: [], meta };
+  }
+  if (fusedCandidates.length === 0) {
+    meta.fallbackReasons.push("graph_no_seed_candidates");
+    return { candidates: [], meta };
+  }
+  if (typeof store.getGraph !== "function") {
+    meta.fallbackReasons.push("graph_unavailable");
+    return { candidates: [], meta };
+  }
+
+  meta.attempted = true;
+  const seedCandidates = fusedCandidates.slice(0, GRAPH_SEED_LIMIT);
+  const seedHashes = [...new Set(seedCandidates.map((c) => c.mirrorHash))];
+  const seedDocsResult = await store.getDocumentsByMirrorHashes(seedHashes, {
+    collection: options.collection,
+    activeOnly: true,
+  });
+  if (!seedDocsResult.ok || seedDocsResult.value.length === 0) {
+    meta.fallbackReasons.push("graph_seed_lookup_empty");
+    return { candidates: [], meta };
+  }
+
+  const seedByDocid = new Map<string, { doc: DocumentRow; rank: number }>();
+  const seedDocids = new Set<string>();
+  for (const doc of seedDocsResult.value) {
+    if (!doc.mirrorHash) {
+      continue;
+    }
+    const rank =
+      seedCandidates.findIndex(
+        (candidate) => candidate.mirrorHash === doc.mirrorHash
+      ) + 1;
+    if (rank <= 0) {
+      continue;
+    }
+    seedByDocid.set(doc.docid, { doc, rank });
+    seedDocids.add(doc.docid);
+  }
+  meta.seedCount = seedDocids.size;
+  if (seedDocids.size === 0) {
+    meta.fallbackReasons.push("graph_seed_lookup_empty");
+    return { candidates: [], meta };
+  }
+
+  const graphResult = await store.getGraph({
+    collection: options.collection,
+    limitNodes: GRAPH_NODE_LIMIT,
+    limitEdges: GRAPH_EDGE_LIMIT,
+    includeSimilar: options.includeSimilar ?? false,
+    linkedOnly: true,
+  });
+  if (!graphResult.ok) {
+    meta.fallbackReasons.push("graph_query_failed");
+    return { candidates: [], meta };
+  }
+  if (graphResult.value.links.length === 0) {
+    meta.fallbackReasons.push("graph_empty");
+    return { candidates: [], meta };
+  }
+
+  const neighborScores = new Map<string, number>();
+  const edgeConfidence = { ...EMPTY_EDGE_CONFIDENCE };
+  for (const link of graphResult.value.links) {
+    const sourceSeed = seedByDocid.get(link.source);
+    const targetSeed = seedByDocid.get(link.target);
+    if (sourceSeed && !seedDocids.has(link.target)) {
+      addEdgeCandidate(
+        neighborScores,
+        link,
+        link.target,
+        sourceSeed.rank,
+        edgeConfidence
+      );
+    }
+    if (targetSeed && !seedDocids.has(link.source)) {
+      addEdgeCandidate(
+        neighborScores,
+        link,
+        link.source,
+        targetSeed.rank,
+        edgeConfidence
+      );
+    }
+  }
+  meta.edgeConfidence = edgeConfidence;
+
+  const rankedNeighborDocids = [...neighborScores.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, maxCandidates)
+    .map(([docid]) => docid);
+  if (rankedNeighborDocids.length === 0) {
+    meta.fallbackReasons.push("graph_no_new_candidates");
+    return { candidates: [], meta };
+  }
+
+  const docs: DocumentRow[] = [];
+  for (const docid of rankedNeighborDocids) {
+    const docResult = await store.getDocumentByDocid(docid);
+    if (docResult.ok && docResult.value?.mirrorHash) {
+      docs.push(docResult.value);
+    }
+  }
+
+  const docByDocid = new Map(docs.map((doc) => [doc.docid, doc]));
+  const candidates = rankedNeighborDocids
+    .map((docid) => docByDocid.get(docid))
+    .filter((doc): doc is DocumentRow => Boolean(doc?.mirrorHash))
+    .map((doc) => ({ mirrorHash: doc.mirrorHash as string, seq: 0 }));
+
+  meta.enabled = candidates.length > 0;
+  meta.candidateCount = candidates.length;
+  if (candidates.length === 0) {
+    meta.fallbackReasons.push("graph_neighbor_lookup_empty");
+  }
+
+  return { candidates, meta };
+}

--- a/src/pipeline/hybrid.ts
+++ b/src/pipeline/hybrid.ts
@@ -270,6 +270,7 @@ export async function searchHybrid(
     expansionMs: 0,
     bm25Ms: 0,
     vectorMs: 0,
+    graphMs: 0,
     fusionMs: 0,
     rerankMs: 0,
     assemblyMs: 0,
@@ -546,21 +547,32 @@ export async function searchHybrid(
     options.candidateLimit ?? pipelineConfig.rerankCandidates;
   let fusedCandidates = rrfFuse(rankedInputs, pipelineConfig.rrf);
 
+  timings.fusionMs = performance.now() - fusionStartedAt;
+  const graphStartedAt = performance.now();
   const graphExpansion = await expandGraphCandidates(store, fusedCandidates, {
     collection: options.collection,
     includeSimilar: vectorAvailable,
     limit,
     candidateLimit,
     disabled: options.noGraph,
+    lang: options.lang,
+    tagsAll: options.tagsAll,
+    tagsAny: options.tagsAny,
+    since: temporalRange.since,
+    until: temporalRange.until,
+    categories: options.categories,
+    author: options.author,
   });
+  timings.graphMs = performance.now() - graphStartedAt;
   if (graphExpansion.candidates.length > 0) {
+    const graphFusionStartedAt = performance.now();
     rankedInputs.push(toRankedInput("graph", graphExpansion.candidates));
     fusedCandidates = rrfFuse(rankedInputs, pipelineConfig.rrf);
+    timings.fusionMs += performance.now() - graphFusionStartedAt;
   }
   if (graphExpansion.meta.fallbackReasons.length > 0) {
     counters.fallbackEvents.push(...graphExpansion.meta.fallbackReasons);
   }
-  timings.fusionMs = performance.now() - fusionStartedAt;
   explainLines.push({
     stage: "graph",
     message: graphExpansion.meta.attempted

--- a/src/pipeline/hybrid.ts
+++ b/src/pipeline/hybrid.ts
@@ -37,6 +37,7 @@ import {
   explainVector,
 } from "./explain";
 import { type RankedInput, rrfFuse, toRankedInput } from "./fusion";
+import { expandGraphCandidates } from "./graph-retrieval";
 import { selectBestChunkForSteering } from "./intent";
 import { detectQueryLanguage } from "./query-language";
 import {
@@ -541,8 +542,31 @@ export async function searchHybrid(
   // 3. RRF Fusion
   // ─────────────────────────────────────────────────────────────────────────
   const fusionStartedAt = performance.now();
-  const fusedCandidates = rrfFuse(rankedInputs, pipelineConfig.rrf);
+  const candidateLimit =
+    options.candidateLimit ?? pipelineConfig.rerankCandidates;
+  let fusedCandidates = rrfFuse(rankedInputs, pipelineConfig.rrf);
+
+  const graphExpansion = await expandGraphCandidates(store, fusedCandidates, {
+    collection: options.collection,
+    includeSimilar: vectorAvailable,
+    limit,
+    candidateLimit,
+    disabled: options.noGraph,
+  });
+  if (graphExpansion.candidates.length > 0) {
+    rankedInputs.push(toRankedInput("graph", graphExpansion.candidates));
+    fusedCandidates = rrfFuse(rankedInputs, pipelineConfig.rrf);
+  }
+  if (graphExpansion.meta.fallbackReasons.length > 0) {
+    counters.fallbackEvents.push(...graphExpansion.meta.fallbackReasons);
+  }
   timings.fusionMs = performance.now() - fusionStartedAt;
+  explainLines.push({
+    stage: "graph",
+    message: graphExpansion.meta.attempted
+      ? `seeds=${graphExpansion.meta.seedCount}, candidates=${graphExpansion.meta.candidateCount}/${graphExpansion.meta.maxCandidates}, explicit=${graphExpansion.meta.edgeConfidence.explicit}, inferred=${graphExpansion.meta.edgeConfidence.inferred}, ambiguous=${graphExpansion.meta.edgeConfidence.ambiguous}, similarity=${graphExpansion.meta.edgeConfidence.similarity}`
+      : `skipped (${graphExpansion.meta.fallbackReasons.join(", ") || "disabled"})`,
+  });
   explainLines.push(
     explainFusion(pipelineConfig.rrf.k, fusedCandidates.length)
   );
@@ -551,8 +575,6 @@ export async function searchHybrid(
   // 4. Reranking
   // ─────────────────────────────────────────────────────────────────────────
   const rerankStartedAt = performance.now();
-  const candidateLimit =
-    options.candidateLimit ?? pipelineConfig.rerankCandidates;
   const rerankResult = await rerankCandidates(
     { rerankPort: options.noRerank ? null : rerankPort, store },
     query,
@@ -888,6 +910,14 @@ export async function searchHybrid(
       categories: options.categories,
       author: options.author,
       candidateLimit,
+      graphExpansion: {
+        enabled: graphExpansion.meta.enabled,
+        seedCount: graphExpansion.meta.seedCount,
+        candidateCount: graphExpansion.meta.candidateCount,
+        maxCandidates: graphExpansion.meta.maxCandidates,
+        edgeConfidence: graphExpansion.meta.edgeConfidence,
+        fallbackReasons: graphExpansion.meta.fallbackReasons,
+      },
       queryLanguage,
       queryModes: queryModeSummary,
       explain: explainData,

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -81,6 +81,20 @@ export interface SearchMeta {
   author?: string;
   /** Rerank candidate limit used */
   candidateLimit?: number;
+  /** Bounded graph expansion summary, when hybrid query evaluates graph neighbors */
+  graphExpansion?: {
+    enabled: boolean;
+    seedCount: number;
+    candidateCount: number;
+    maxCandidates: number;
+    edgeConfidence: {
+      explicit: number;
+      inferred: number;
+      ambiguous: number;
+      similarity: number;
+    };
+    fallbackReasons: string[];
+  };
   /** Explicit exclusion terms applied */
   exclude?: string[];
   /** Explain data (when --explain is used) */
@@ -160,6 +174,8 @@ export type HybridSearchOptions = SearchOptions & {
   candidateLimit?: number;
   /** Enable explain output */
   explain?: boolean;
+  /** Disable bounded one-hop graph candidate expansion */
+  noGraph?: boolean;
   /** Language hint for prompt selection (does NOT filter retrieval, only affects expansion prompts) */
   queryLanguageHint?: string;
 };
@@ -225,7 +241,8 @@ export type FusionSource =
   | "vector"
   | "bm25_variant"
   | "vector_variant"
-  | "hyde";
+  | "hyde"
+  | "graph";
 
 /** Fusion candidate with ranks from different sources */
 export interface FusionCandidate {

--- a/src/serve/public/pages/GraphView.tsx
+++ b/src/serve/public/pages/GraphView.tsx
@@ -67,6 +67,17 @@ interface GraphLink {
   target: string;
   type: "wiki" | "markdown" | "similar";
   weight: number;
+  confidence: "explicit" | "inferred" | "ambiguous" | "similarity";
+  audit: {
+    resolution:
+      | "exact-title"
+      | "exact-path"
+      | "path-fallback"
+      | "ambiguous-fallback"
+      | "similarity";
+    matchCount?: number;
+    score?: number;
+  };
 }
 
 interface GraphMeta {
@@ -106,6 +117,17 @@ interface GraphReport {
     markdown: number;
     similar: number;
   };
+  edgeConfidence: {
+    explicit: number;
+    inferred: number;
+    ambiguous: number;
+    similarity: number;
+  };
+  audit: {
+    inferredEdges: number;
+    ambiguousEdges: number;
+    similarityEdges: number;
+  };
 }
 
 interface GraphResponse {
@@ -142,6 +164,8 @@ const COLORS = {
   edgeWiki: "rgba(77, 184, 168, 0.4)", // Teal threads
   edgeMarkdown: "rgba(77, 184, 168, 0.25)", // Fainter teal
   edgeSimilar: "rgba(212, 160, 83, 0.3)", // Gold similarity
+  edgeInferred: "rgba(124, 158, 178, 0.35)",
+  edgeAmbiguous: "rgba(245, 215, 142, 0.55)",
 
   // Background
   canvas: "#050505", // Deep black - observatory darkness
@@ -410,11 +434,15 @@ export default function GraphView({ navigate }: PageProps) {
       links: graphData.links.map((l) => ({
         ...l,
         color:
-          l.type === "similar"
-            ? COLORS.edgeSimilar
-            : l.type === "wiki"
-              ? COLORS.edgeWiki
-              : COLORS.edgeMarkdown,
+          l.confidence === "ambiguous"
+            ? COLORS.edgeAmbiguous
+            : l.confidence === "inferred"
+              ? COLORS.edgeInferred
+              : l.type === "similar"
+                ? COLORS.edgeSimilar
+                : l.type === "wiki"
+                  ? COLORS.edgeWiki
+                  : COLORS.edgeMarkdown,
       })),
     };
   }, [graphData]);
@@ -624,6 +652,16 @@ export default function GraphView({ navigate }: PageProps) {
                 {graphData.report.isolated.total.toLocaleString()}
               </span>{" "}
               isolated
+              <span className="text-border">•</span>
+              <span className="text-[#7c9eb2]">
+                {graphData.report.audit.inferredEdges.toLocaleString()}
+              </span>{" "}
+              inferred
+              <span className="text-border">•</span>
+              <span className="text-[#f5d78e]">
+                {graphData.report.audit.ambiguousEdges.toLocaleString()}
+              </span>{" "}
+              ambiguous
             </div>
           )}
 
@@ -764,6 +802,20 @@ export default function GraphView({ navigate }: PageProps) {
               <span className="text-muted-foreground">Similarity</span>
             </div>
           )}
+          <div className="flex items-center gap-2">
+            <span
+              className="size-2 rounded-full"
+              style={{ backgroundColor: COLORS.edgeInferred }}
+            />
+            <span className="text-muted-foreground">Inferred</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="size-2 rounded-full"
+              style={{ backgroundColor: COLORS.edgeAmbiguous }}
+            />
+            <span className="text-muted-foreground">Ambiguous</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/serve/public/pages/GraphView.tsx
+++ b/src/serve/public/pages/GraphView.tsx
@@ -53,6 +53,15 @@ interface GraphNode {
   degree: number;
 }
 
+interface GraphReportNode {
+  id: string;
+  uri: string;
+  title: string | null;
+  collection: string;
+  relPath: string;
+  degree: number;
+}
+
 interface GraphLink {
   source: string;
   target: string;
@@ -78,9 +87,31 @@ interface GraphMeta {
   warnings: string[];
 }
 
+interface GraphReport {
+  hubs: GraphReportNode[];
+  bridgeCandidates: GraphReportNode[];
+  isolated: {
+    total: number;
+    examples: GraphReportNode[];
+  };
+  unresolvedLinks: {
+    total: number;
+    byType: {
+      wiki: number;
+      markdown: number;
+    };
+  };
+  edgeTypes: {
+    wiki: number;
+    markdown: number;
+    similar: number;
+  };
+}
+
 interface GraphResponse {
   nodes: GraphNode[];
   links: GraphLink[];
+  report: GraphReport;
   meta: GraphMeta;
 }
 
@@ -578,6 +609,21 @@ export default function GraphView({ navigate }: PageProps) {
                 {graphData.links.length.toLocaleString()}
               </span>{" "}
               edges
+              <span className="text-border">•</span>
+              <span className="text-[#f5d78e]">
+                {graphData.report.hubs[0]?.degree ?? 0}
+              </span>{" "}
+              top degree
+              <span className="text-border">•</span>
+              <span className="text-[#d4a053]">
+                {graphData.report.unresolvedLinks.total.toLocaleString()}
+              </span>{" "}
+              unresolved
+              <span className="text-border">•</span>
+              <span className="text-[#4db8a8]">
+                {graphData.report.isolated.total.toLocaleString()}
+              </span>{" "}
+              isolated
             </div>
           )}
 

--- a/src/serve/public/pages/GraphView.tsx
+++ b/src/serve/public/pages/GraphView.tsx
@@ -51,6 +51,7 @@ interface GraphNode {
   collection: string;
   relPath: string;
   degree: number;
+  communityId?: string;
 }
 
 interface GraphReportNode {
@@ -60,6 +61,16 @@ interface GraphReportNode {
   collection: string;
   relPath: string;
   degree: number;
+  communityId?: string;
+}
+
+interface GraphCommunity {
+  id: string;
+  label: string;
+  size: number;
+  edgeCount: number;
+  density: number;
+  topNodes: GraphReportNode[];
 }
 
 interface GraphLink {
@@ -128,6 +139,13 @@ interface GraphReport {
     ambiguousEdges: number;
     similarityEdges: number;
   };
+  communities: {
+    total: number;
+    algorithm: "deterministic-label-propagation";
+    skipped: boolean;
+    assignments: Record<string, string>;
+    top: GraphCommunity[];
+  };
 }
 
 interface GraphResponse {
@@ -189,6 +207,22 @@ function getCollectionColor(collection: string): string {
     hash = ((hash << 5) - hash + collection.charCodeAt(i)) | 0;
   }
   return palette[Math.abs(hash) % palette.length]!;
+}
+
+function getCommunityColor(communityId: string | undefined): string | null {
+  if (!communityId) return null;
+  const palette = [
+    "#4db8a8",
+    "#d4a053",
+    "#6ba3d6",
+    "#a8c686",
+    "#c9a7c7",
+    "#e2a76f",
+    "#f5d78e",
+    "#7c9eb2",
+  ];
+  const index = Math.max(0, Number.parseInt(communityId.slice(1), 10) - 1);
+  return palette[index % palette.length] ?? null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -295,6 +329,7 @@ export default function GraphView({ navigate }: PageProps) {
   // Filter state
   const [selectedCollection, setSelectedCollection] = useState<string>("_all");
   const [includeSimilar, setIncludeSimilar] = useState(false);
+  const [selectedCommunity, setSelectedCommunity] = useState<string>("_all");
 
   // UI state
   const [showTruncationBanner, setShowTruncationBanner] = useState(true);
@@ -344,6 +379,7 @@ export default function GraphView({ navigate }: PageProps) {
     setLoading(true);
     setError(null);
     setShowTruncationBanner(true);
+    setSelectedCommunity("_all");
     clearZoomTimeouts();
 
     const params = new URLSearchParams();
@@ -424,28 +460,47 @@ export default function GraphView({ navigate }: PageProps) {
   const forceGraphData = useMemo(() => {
     if (!graphData) return { nodes: [], links: [] };
 
+    const visibleNodeIds = new Set(
+      graphData.nodes
+        .filter(
+          (node) =>
+            selectedCommunity === "_all" ||
+            node.communityId === selectedCommunity
+        )
+        .map((node) => node.id)
+    );
+
     return {
-      nodes: graphData.nodes.map((n) => ({
-        ...n,
-        // Add computed properties for rendering
-        color: getCollectionColor(n.collection),
-        size: Math.max(4, Math.min(20, 4 + Math.sqrt(n.degree) * 2)),
-      })),
-      links: graphData.links.map((l) => ({
-        ...l,
-        color:
-          l.confidence === "ambiguous"
-            ? COLORS.edgeAmbiguous
-            : l.confidence === "inferred"
-              ? COLORS.edgeInferred
-              : l.type === "similar"
-                ? COLORS.edgeSimilar
-                : l.type === "wiki"
-                  ? COLORS.edgeWiki
-                  : COLORS.edgeMarkdown,
-      })),
+      nodes: graphData.nodes
+        .filter((node) => visibleNodeIds.has(node.id))
+        .map((n) => ({
+          ...n,
+          // Add computed properties for rendering
+          color:
+            getCommunityColor(n.communityId) ??
+            getCollectionColor(n.collection),
+          size: Math.max(4, Math.min(20, 4 + Math.sqrt(n.degree) * 2)),
+        })),
+      links: graphData.links
+        .filter(
+          (link) =>
+            visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target)
+        )
+        .map((l) => ({
+          ...l,
+          color:
+            l.confidence === "ambiguous"
+              ? COLORS.edgeAmbiguous
+              : l.confidence === "inferred"
+                ? COLORS.edgeInferred
+                : l.type === "similar"
+                  ? COLORS.edgeSimilar
+                  : l.type === "wiki"
+                    ? COLORS.edgeWiki
+                    : COLORS.edgeMarkdown,
+        })),
     };
-  }, [graphData]);
+  }, [graphData, selectedCommunity]);
 
   // Node canvas rendering for custom aesthetics
   // biome-ignore lint: dynamic import typing
@@ -552,6 +607,27 @@ export default function GraphView({ navigate }: PageProps) {
             <HomeIcon className="size-4" />
             <span className="hidden sm:inline">Dashboard</span>
           </Button>
+
+          {graphData &&
+            !graphData.report.communities.skipped &&
+            graphData.report.communities.top.length > 0 && (
+              <Select
+                onValueChange={setSelectedCommunity}
+                value={selectedCommunity}
+              >
+                <SelectTrigger className="h-8 w-[170px] border-border/50 bg-background/50 text-xs">
+                  <SelectValue placeholder="All communities" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="_all">All communities</SelectItem>
+                  {graphData.report.communities.top.map((community) => (
+                    <SelectItem key={community.id} value={community.id}>
+                      {community.id} · {community.size} docs
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
 
           <div className="h-4 w-px bg-border/50" />
 
@@ -662,6 +738,11 @@ export default function GraphView({ navigate }: PageProps) {
                 {graphData.report.audit.ambiguousEdges.toLocaleString()}
               </span>{" "}
               ambiguous
+              <span className="text-border">•</span>
+              <span className="text-[#6ba3d6]">
+                {graphData.report.communities.total.toLocaleString()}
+              </span>{" "}
+              communities
             </div>
           )}
 
@@ -694,6 +775,48 @@ export default function GraphView({ navigate }: PageProps) {
           onDismiss={() => setShowTruncationBanner(false)}
         />
       )}
+
+      {graphData &&
+        !loading &&
+        !graphData.report.communities.skipped &&
+        graphData.report.communities.top.length > 0 && (
+          <div className="absolute right-4 bottom-4 z-20 hidden max-w-xs rounded-lg border border-border/30 bg-[#0f1115]/85 p-3 shadow-lg backdrop-blur-md md:block">
+            <p className="mb-2 font-mono text-[#4db8a8] text-[10px] uppercase tracking-[0.12em]">
+              Communities
+            </p>
+            <div className="space-y-1.5">
+              {graphData.report.communities.top.slice(0, 6).map((community) => (
+                <button
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-xs transition-colors hover:bg-white/5",
+                    selectedCommunity === community.id && "bg-white/10"
+                  )}
+                  key={community.id}
+                  onClick={() =>
+                    setSelectedCommunity((current) =>
+                      current === community.id ? "_all" : community.id
+                    )
+                  }
+                  type="button"
+                >
+                  <span
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor:
+                        getCommunityColor(community.id) ?? COLORS.nodeDefault,
+                    }}
+                  />
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                    {community.label}
+                  </span>
+                  <span className="font-mono text-[#d4a053]">
+                    {community.size}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
       {/* Graph canvas */}
       <div className="h-full pt-12">

--- a/src/serve/public/pages/Search.tsx
+++ b/src/serve/public/pages/Search.tsx
@@ -388,6 +388,7 @@ export default function Search({ navigate }: PageProps) {
       if (!useBm25) {
         body.noExpand = depthPolicy.noExpand;
         body.noRerank = depthPolicy.noRerank;
+        body.noGraph = thoroughness === "fast";
         if (queryModes.length > 0) {
           body.queryModes = queryModes;
         }

--- a/src/serve/routes/api.ts
+++ b/src/serve/routes/api.ts
@@ -172,6 +172,7 @@ export interface QueryRequestBody {
   queryModes?: QueryModeInput[];
   noExpand?: boolean;
   noRerank?: boolean;
+  noGraph?: boolean;
   /** Comma-separated tags - filter to docs having ALL (AND) */
   tagsAll?: string;
   /** Comma-separated tags - filter to docs having ANY (OR) */
@@ -3310,6 +3311,7 @@ export async function handleQuery(
       queryModes: normalizedQueryModes,
       noExpand: body.noExpand,
       noRerank: body.noRerank,
+      noGraph: body.noGraph,
       tagsAll,
       tagsAny,
       since: body.since,

--- a/src/store/sqlite/adapter.ts
+++ b/src/store/sqlite/adapter.ts
@@ -49,6 +49,7 @@ import type {
 import type { SqliteDbProvider } from "./types";
 
 import { buildUri, deriveDocid, stripUriIndex } from "../../app/constants";
+import { analyzeGraphCommunities } from "../../core/graph-analysis";
 import { normalizeWikiName, stripWikiMdExt } from "../../core/links";
 import { migrations, runMigrations } from "../migrations";
 import { err, ok } from "../types";
@@ -2905,6 +2906,16 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
         edgeConfidence[edge.confidence] += 1;
       }
 
+      const communityAnalysis = analyzeGraphCommunities(nodes, allEdges);
+      warnings.push(...communityAnalysis.warnings);
+      const nodesWithCommunities = nodes.map((node) => {
+        const communityId = communityAnalysis.assignments[node.id];
+        return communityId ? { ...node, communityId } : node;
+      });
+      const communityByNodeId = new Map(
+        Object.entries(communityAnalysis.assignments)
+      );
+
       const truncatedEdges = allEdges.length > limitEdges;
       const links = allEdges.slice(0, limitEdges);
 
@@ -2917,10 +2928,13 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       }
 
       return ok({
-        nodes,
+        nodes: nodesWithCommunities,
         links,
         report: {
-          hubs: connectedNodes.slice(0, 10).map(toReportNode),
+          hubs: connectedNodes.slice(0, 10).map((node) => ({
+            ...toReportNode(node),
+            communityId: communityByNodeId.get(node.docid),
+          })),
           bridgeCandidates: connectedNodes
             .filter(
               (row) =>
@@ -2928,10 +2942,16 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
                 (outNeighbors.get(row.id)?.size ?? 0) > 0
             )
             .slice(0, 10)
-            .map(toReportNode),
+            .map((node) => ({
+              ...toReportNode(node),
+              communityId: communityByNodeId.get(node.docid),
+            })),
           isolated: {
             total: isolatedTotal,
-            examples: isolatedExampleRows.map(toReportNode),
+            examples: isolatedExampleRows.map((node) => ({
+              ...toReportNode(node),
+              communityId: communityByNodeId.get(node.docid),
+            })),
           },
           unresolvedLinks: {
             total: totalEdgesUnresolved,
@@ -2944,6 +2964,13 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
             ambiguousEdges: edgeConfidence.ambiguous,
             similarityEdges: edgeConfidence.similarity,
           },
+          communities: {
+            total: communityAnalysis.total,
+            algorithm: communityAnalysis.algorithm,
+            skipped: communityAnalysis.skipped,
+            assignments: communityAnalysis.assignments,
+            top: communityAnalysis.communities,
+          },
         },
         meta: {
           collection,
@@ -2953,7 +2980,7 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           // totalEdges = collapsed edge count within selected nodes (matches allEdges)
           totalEdges: allEdges.length,
           totalEdgesUnresolved,
-          returnedNodes: nodes.length,
+          returnedNodes: nodesWithCommunities.length,
           returnedEdges: links.length,
           truncated: truncatedNodes || truncatedEdges,
           linkedOnly,

--- a/src/store/sqlite/adapter.ts
+++ b/src/store/sqlite/adapter.ts
@@ -812,6 +812,59 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
     }
   }
 
+  async getDocumentsByDocids(
+    docids: string[],
+    options: {
+      collection?: string;
+      activeOnly?: boolean;
+    } = {}
+  ): Promise<StoreResult<DocumentRow[]>> {
+    try {
+      if (docids.length === 0) {
+        return ok([]);
+      }
+
+      const uniqueDocids = [
+        ...new Set(docids.filter((docid) => docid.trim().length > 0)),
+      ];
+      if (uniqueDocids.length === 0) {
+        return ok([]);
+      }
+
+      const db = this.ensureOpen();
+      const rows: DbDocumentRow[] = [];
+      const SQL_PARAM_LIMIT = options.collection ? 899 : 900;
+
+      for (let i = 0; i < uniqueDocids.length; i += SQL_PARAM_LIMIT) {
+        const batch = uniqueDocids.slice(i, i + SQL_PARAM_LIMIT);
+        const placeholders = batch.map(() => "?").join(",");
+        const clauses = [`docid IN (${placeholders})`];
+        const params: string[] = [...batch];
+
+        if (options.activeOnly ?? true) {
+          clauses.push("active = 1");
+        }
+        if (options.collection) {
+          clauses.push("collection = ?");
+          params.push(options.collection);
+        }
+
+        const sql = `SELECT * FROM documents WHERE ${clauses.join(" AND ")} ORDER BY id`;
+        rows.push(...db.query<DbDocumentRow, string[]>(sql).all(...params));
+      }
+
+      return ok(rows.map(mapDocumentRow));
+    } catch (cause) {
+      return err(
+        "QUERY_FAILED",
+        cause instanceof Error
+          ? cause.message
+          : "Failed to get documents by docids",
+        cause
+      );
+    }
+  }
+
   async listDocumentsPaginated(options: {
     collection?: string;
     limit: number;
@@ -2695,10 +2748,16 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
         nextAudit: GraphEdgeAudit
       ): void => {
         if (
-          confidenceRank[nextConfidence] > confidenceRank[current.confidence]
+          confidenceRank[nextConfidence] < confidenceRank[current.confidence]
         ) {
           current.confidence = nextConfidence;
-          current.audit = nextAudit;
+          current.audit = {
+            ...nextAudit,
+            matchCount: Math.max(
+              current.audit.matchCount ?? 0,
+              nextAudit.matchCount ?? 0
+            ),
+          };
           return;
         }
         if (

--- a/src/store/sqlite/adapter.ts
+++ b/src/store/sqlite/adapter.ts
@@ -30,6 +30,8 @@ import type {
   FtsResult,
   FtsSearchOptions,
   GetGraphOptions,
+  GraphLinkType,
+  GraphReportNode,
   GraphResult,
   IndexStatus,
   IngestErrorInput,
@@ -2342,8 +2344,9 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
         weight: number;
       }
 
-      interface UnresolvedCountRow {
-        unresolved: number | null;
+      interface UnresolvedByTypeRow {
+        link_type: "wiki" | "markdown";
+        unresolved: number;
       }
 
       interface NodeMetaRow {
@@ -2403,9 +2406,11 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       }
       const unresolvedQuery = `
         SELECT
-          SUM(CASE WHEN target_id IS NULL THEN 1 ELSE 0 END) as unresolved
+          link_type,
+          COUNT(*) as unresolved
         FROM (
           SELECT
+            dl.link_type,
             CASE dl.link_type
               WHEN 'wiki' THEN (
                 ${wikiBestMatch(
@@ -2426,11 +2431,21 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           WHERE src.active = 1
             ${unresolvedCollectionClause}
         )
+        WHERE target_id IS NULL
+        GROUP BY link_type
       `;
-      const unresolvedRow = db
-        .query<UnresolvedCountRow, string[]>(unresolvedQuery)
-        .get(...unresolvedParams);
-      const totalEdgesUnresolved = unresolvedRow?.unresolved ?? 0;
+      const unresolvedRows = db
+        .query<UnresolvedByTypeRow, string[]>(unresolvedQuery)
+        .all(...unresolvedParams);
+      const unresolvedByType: Record<"wiki" | "markdown", number> = {
+        wiki: 0,
+        markdown: 0,
+      };
+      for (const row of unresolvedRows) {
+        unresolvedByType[row.link_type] = row.unresolved;
+      }
+      const totalEdgesUnresolved =
+        unresolvedByType.wiki + unresolvedByType.markdown;
 
       const outNeighbors = new Map<number, Set<number>>();
       const inNeighbors = new Map<number, Set<number>>();
@@ -2480,6 +2495,46 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
         })
         .filter((row): row is NodeMetaRow & { degree: number } => row !== null)
         .sort((a, b) => b.degree - a.degree || a.id - b.id);
+
+      const toReportNode = (
+        row: NodeMetaRow & { degree: number }
+      ): GraphReportNode => ({
+        id: row.docid,
+        uri: row.uri,
+        title: row.title,
+        collection: row.collection,
+        relPath: row.rel_path,
+        degree: row.degree,
+      });
+
+      const isolatedBaseParams: (string | number)[] = [];
+      const isolatedBaseConditions = ["active = 1"];
+      if (collection) {
+        isolatedBaseConditions.push("collection = ?");
+        isolatedBaseParams.push(collection);
+      }
+      if (connectedIdList.length > 0) {
+        const placeholders = connectedIdList.map(() => "?").join(",");
+        isolatedBaseConditions.push(`id NOT IN (${placeholders})`);
+        isolatedBaseParams.push(...connectedIdList);
+      }
+      const isolatedWhereClause = isolatedBaseConditions.join(" AND ");
+      const isolatedCountRow = db
+        .query<{ cnt: number }, (string | number)[]>(
+          `SELECT COUNT(*) as cnt FROM documents WHERE ${isolatedWhereClause}`
+        )
+        .get(...isolatedBaseParams);
+      const isolatedTotal = isolatedCountRow?.cnt ?? 0;
+      const isolatedExampleRows = db
+        .query<NodeMetaRow, (string | number)[]>(
+          `SELECT id, docid, uri, title, collection, rel_path
+           FROM documents
+           WHERE ${isolatedWhereClause}
+           ORDER BY id ASC
+           LIMIT 10`
+        )
+        .all(...isolatedBaseParams)
+        .map((row) => ({ ...row, degree: 0 }));
 
       let totalNodes = linkedOnly ? connectedNodes.length : 0;
       if (!linkedOnly) {
@@ -2690,6 +2745,15 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
         };
       });
 
+      const edgeTypes: Record<GraphLinkType, number> = {
+        wiki: 0,
+        markdown: 0,
+        similar: 0,
+      };
+      for (const edge of allEdges) {
+        edgeTypes[edge.type] += 1;
+      }
+
       const truncatedEdges = allEdges.length > limitEdges;
       const links = allEdges.slice(0, limitEdges);
 
@@ -2704,6 +2768,26 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       return ok({
         nodes,
         links,
+        report: {
+          hubs: connectedNodes.slice(0, 10).map(toReportNode),
+          bridgeCandidates: connectedNodes
+            .filter(
+              (row) =>
+                (inNeighbors.get(row.id)?.size ?? 0) > 0 &&
+                (outNeighbors.get(row.id)?.size ?? 0) > 0
+            )
+            .slice(0, 10)
+            .map(toReportNode),
+          isolated: {
+            total: isolatedTotal,
+            examples: isolatedExampleRows.map(toReportNode),
+          },
+          unresolvedLinks: {
+            total: totalEdgesUnresolved,
+            byType: unresolvedByType,
+          },
+          edgeTypes,
+        },
         meta: {
           collection,
           nodeLimit: limitNodes,

--- a/src/store/sqlite/adapter.ts
+++ b/src/store/sqlite/adapter.ts
@@ -30,6 +30,8 @@ import type {
   FtsResult,
   FtsSearchOptions,
   GetGraphOptions,
+  GraphEdgeConfidence,
+  GraphEdgeAudit,
   GraphLinkType,
   GraphReportNode,
   GraphResult,
@@ -2335,13 +2337,38 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           )
         ORDER BY t.id LIMIT 1
       `;
+
+      const wikiBestRank = (
+        collectionExpr: string,
+        targetRefExpr: string
+      ): string => `
+        SELECT MIN(${wikiOrder("t", targetRefExpr)}) FROM documents t
+        WHERE t.active = 1
+          AND t.collection = ${collectionExpr}
+          AND ${wikiMatch("t", targetRefExpr)}
+      `;
+
+      const wikiBestRankMatchCount = (
+        collectionExpr: string,
+        targetRefExpr: string
+      ): string => `
+        SELECT COUNT(*) FROM documents t
+        WHERE t.active = 1
+          AND t.collection = ${collectionExpr}
+          AND ${wikiMatch("t", targetRefExpr)}
+          AND ${wikiOrder("t", targetRefExpr)} = (${wikiBestRank(
+            collectionExpr,
+            targetRefExpr
+          )})
+      `;
       interface ResolvedEdgeRow {
         source_id: number;
         source_docid: string;
         target_id: number;
         target_docid: string;
         link_type: "wiki" | "markdown";
-        weight: number;
+        match_rank: number | null;
+        match_count: number | null;
       }
 
       interface UnresolvedByTypeRow {
@@ -2372,7 +2399,20 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           tgt.id as target_id,
           tgt.docid as target_docid,
           dl.link_type,
-          COUNT(*) as weight
+          CASE dl.link_type
+            WHEN 'wiki' THEN (${wikiBestRank(
+              "COALESCE(dl.target_collection, src.collection)",
+              "dl.target_ref_norm"
+            )})
+            WHEN 'markdown' THEN 5
+          END as match_rank,
+          CASE dl.link_type
+            WHEN 'wiki' THEN (${wikiBestRankMatchCount(
+              "COALESCE(dl.target_collection, src.collection)",
+              "dl.target_ref_norm"
+            )})
+            WHEN 'markdown' THEN 1
+          END as match_count
         FROM documents src
         JOIN doc_links dl ON dl.source_doc_id = src.id
         JOIN documents tgt ON tgt.id = CASE dl.link_type
@@ -2390,8 +2430,7 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
         END
         WHERE src.active = 1 AND tgt.active = 1
           ${edgeCollectionClause}
-        GROUP BY src.id, src.docid, tgt.id, tgt.docid, dl.link_type
-        ORDER BY weight DESC, src.id ASC, tgt.id ASC
+        ORDER BY src.id ASC, tgt.id ASC, dl.link_type ASC
       `;
 
       const resolvedEdgeRows = db
@@ -2597,9 +2636,89 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       const selectedDocids = new Set(nodes.map((node) => node.id));
       const nodeDocids = new Set(nodes.map((node) => node.id));
 
+      const confidenceRank: Record<GraphEdgeConfidence, number> = {
+        explicit: 1,
+        inferred: 2,
+        ambiguous: 3,
+        similarity: 4,
+      };
+      const classifyResolvedEdge = (
+        linkType: "wiki" | "markdown",
+        matchRank: number | null,
+        matchCount: number | null
+      ): { confidence: GraphEdgeConfidence; audit: GraphEdgeAudit } => {
+        if (linkType === "markdown") {
+          return {
+            confidence: "explicit",
+            audit: { resolution: "exact-path", matchCount: 1 },
+          };
+        }
+
+        const count = matchCount ?? 0;
+        if (count > 1) {
+          return {
+            confidence: "ambiguous",
+            audit: {
+              resolution: "ambiguous-fallback",
+              matchCount: count,
+            },
+          };
+        }
+
+        if (matchRank === 1 || matchRank === 2) {
+          return {
+            confidence: "explicit",
+            audit: { resolution: "exact-title", matchCount: count || 1 },
+          };
+        }
+        if (matchRank === 5 || matchRank === 6) {
+          return {
+            confidence: "explicit",
+            audit: { resolution: "exact-path", matchCount: count || 1 },
+          };
+        }
+
+        return {
+          confidence: "inferred",
+          audit: { resolution: "path-fallback", matchCount: count || 1 },
+        };
+      };
+      const mergeAudit = (
+        current: {
+          type: GraphLinkType;
+          weight: number;
+          confidence: GraphEdgeConfidence;
+          audit: GraphEdgeAudit;
+        },
+        nextConfidence: GraphEdgeConfidence,
+        nextAudit: GraphEdgeAudit
+      ): void => {
+        if (
+          confidenceRank[nextConfidence] > confidenceRank[current.confidence]
+        ) {
+          current.confidence = nextConfidence;
+          current.audit = nextAudit;
+          return;
+        }
+        if (
+          nextAudit.matchCount !== undefined &&
+          (current.audit.matchCount ?? 0) < nextAudit.matchCount
+        ) {
+          current.audit = {
+            ...current.audit,
+            matchCount: nextAudit.matchCount,
+          };
+        }
+      };
+
       const edgeMap = new Map<
         string,
-        { type: "wiki" | "markdown" | "similar"; weight: number }
+        {
+          type: GraphLinkType;
+          weight: number;
+          confidence: GraphEdgeConfidence;
+          audit: GraphEdgeAudit;
+        }
       >();
       for (const row of resolvedEdgeRows) {
         if (
@@ -2609,7 +2728,23 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           continue;
         }
         const key = `${row.source_docid}:${row.target_docid}:${row.link_type}`;
-        edgeMap.set(key, { type: row.link_type, weight: row.weight });
+        const { confidence, audit } = classifyResolvedEdge(
+          row.link_type,
+          row.match_rank,
+          row.match_count
+        );
+        const existing = edgeMap.get(key);
+        if (existing) {
+          existing.weight += 1;
+          mergeAudit(existing, confidence, audit);
+        } else {
+          edgeMap.set(key, {
+            type: row.link_type,
+            weight: 1,
+            confidence,
+            audit,
+          });
+        }
       }
 
       // Phase 3: Similarity edges (if requested)
@@ -2716,7 +2851,12 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
               // Keep max score
               const existing = edgeMap.get(key);
               if (!existing || clampedScore > existing.weight) {
-                edgeMap.set(key, { type: "similar", weight: clampedScore });
+                edgeMap.set(key, {
+                  type: "similar",
+                  weight: clampedScore,
+                  confidence: "similarity",
+                  audit: { resolution: "similarity", score: clampedScore },
+                });
               }
             }
           } catch {
@@ -2742,6 +2882,8 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           target: parts[1] ?? "",
           type: val.type,
           weight: val.weight,
+          confidence: val.confidence,
+          audit: val.audit,
         };
       });
 
@@ -2752,6 +2894,15 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       };
       for (const edge of allEdges) {
         edgeTypes[edge.type] += 1;
+      }
+      const edgeConfidence: Record<GraphEdgeConfidence, number> = {
+        explicit: 0,
+        inferred: 0,
+        ambiguous: 0,
+        similarity: 0,
+      };
+      for (const edge of allEdges) {
+        edgeConfidence[edge.confidence] += 1;
       }
 
       const truncatedEdges = allEdges.length > limitEdges;
@@ -2787,6 +2938,12 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
             byType: unresolvedByType,
           },
           edgeTypes,
+          edgeConfidence,
+          audit: {
+            inferredEdges: edgeConfidence.inferred,
+            ambiguousEdges: edgeConfidence.ambiguous,
+            similarityEdges: edgeConfidence.similarity,
+          },
         },
         meta: {
           collection,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -750,6 +750,18 @@ export interface StorePort {
   ): Promise<StoreResult<DocumentRow[]>>;
 
   /**
+   * Fetch documents by docids in batch.
+   * Useful for graph traversal pipelines to avoid per-node document lookups.
+   */
+  getDocumentsByDocids(
+    docids: string[],
+    options?: {
+      collection?: string;
+      activeOnly?: boolean;
+    }
+  ): Promise<StoreResult<DocumentRow[]>>;
+
+  /**
    * List documents with pagination support.
    * Returns documents and total count for efficient browsing.
    */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -454,6 +454,8 @@ export interface GraphNode {
   relPath: string;
   /** Total degree (in + out unique neighbors) */
   degree: number;
+  /** Optional deterministic community id from graph analysis */
+  communityId?: string;
 }
 
 /** Compact graph report node summary */
@@ -470,6 +472,24 @@ export interface GraphReportNode {
   relPath: string;
   /** Total degree (in + out unique neighbors) */
   degree: number;
+  /** Optional deterministic community id from graph analysis */
+  communityId?: string;
+}
+
+/** Deterministic graph community summary */
+export interface GraphCommunity {
+  /** Stable community id within this graph response */
+  id: string;
+  /** Human-readable label derived from the highest-degree member */
+  label: string;
+  /** Number of returned nodes assigned to this community */
+  size: number;
+  /** Internal edge count before edge-limit truncation */
+  edgeCount: number;
+  /** Internal density, 0-1 */
+  density: number;
+  /** Highest-degree example nodes in the community */
+  topNodes: GraphReportNode[];
 }
 
 /** Graph link (edge) between two nodes */
@@ -517,6 +537,19 @@ export interface GraphReport {
     inferredEdges: number;
     ambiguousEdges: number;
     similarityEdges: number;
+  };
+  /** Optional deterministic community/cluster analysis over returned nodes */
+  communities: {
+    /** Number of detected communities */
+    total: number;
+    /** Algorithm used for deterministic cluster labels */
+    algorithm: "deterministic-label-propagation";
+    /** Whether community detection was skipped for graph size */
+    skipped: boolean;
+    /** Node docid to community id map */
+    assignments: Record<string, string>;
+    /** Top communities by size */
+    top: GraphCommunity[];
   };
 }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -418,6 +418,28 @@ export interface EmbeddingCleanupStats {
 /** Graph link type (wiki, markdown, or similarity) */
 export type GraphLinkType = "wiki" | "markdown" | "similar";
 
+/** Trust classification for graph edges */
+export type GraphEdgeConfidence =
+  | "explicit"
+  | "inferred"
+  | "ambiguous"
+  | "similarity";
+
+/** Audit metadata explaining how an edge was derived */
+export interface GraphEdgeAudit {
+  /** Resolution path used to create the edge */
+  resolution:
+    | "exact-title"
+    | "exact-path"
+    | "path-fallback"
+    | "ambiguous-fallback"
+    | "similarity";
+  /** Number of equally ranked target candidates, when applicable */
+  matchCount?: number;
+  /** Similarity score copied from weight for similarity edges */
+  score?: number;
+}
+
 /** Graph node representing a document */
 export interface GraphNode {
   /** Document ID (#hex) - primary identifier */
@@ -460,6 +482,10 @@ export interface GraphLink {
   type: GraphLinkType;
   /** Edge weight (link count for wiki/md, similarity score for similar) */
   weight: number;
+  /** Trust classification for retrieval and agent audit */
+  confidence: GraphEdgeConfidence;
+  /** Audit metadata for how this edge was resolved */
+  audit: GraphEdgeAudit;
 }
 
 /** Graph report summary over the current graph result */
@@ -484,6 +510,14 @@ export interface GraphReport {
   };
   /** Edge breakdown by type before edge-limit truncation */
   edgeTypes: Record<GraphLinkType, number>;
+  /** Edge confidence breakdown before edge-limit truncation */
+  edgeConfidence: Record<GraphEdgeConfidence, number>;
+  /** Explicit links resolved through fallback or ambiguous matching */
+  audit: {
+    inferredEdges: number;
+    ambiguousEdges: number;
+    similarityEdges: number;
+  };
 }
 
 /** Graph metadata with truncation info */

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -434,6 +434,22 @@ export interface GraphNode {
   degree: number;
 }
 
+/** Compact graph report node summary */
+export interface GraphReportNode {
+  /** Document ID (#hex) */
+  id: string;
+  /** Document URI (gno://collection/path) */
+  uri: string;
+  /** Document title */
+  title: string | null;
+  /** Collection name */
+  collection: string;
+  /** Relative path within collection */
+  relPath: string;
+  /** Total degree (in + out unique neighbors) */
+  degree: number;
+}
+
 /** Graph link (edge) between two nodes */
 export interface GraphLink {
   /** Source node ID (docid) */
@@ -444,6 +460,30 @@ export interface GraphLink {
   type: GraphLinkType;
   /** Edge weight (link count for wiki/md, similarity score for similar) */
   weight: number;
+}
+
+/** Graph report summary over the current graph result */
+export interface GraphReport {
+  /** Highest-degree documents */
+  hubs: GraphReportNode[];
+  /** Bridge-like documents with both incoming and outgoing links */
+  bridgeCandidates: GraphReportNode[];
+  /** Isolated documents with no resolved explicit graph links */
+  isolated: {
+    /** Total isolated active documents in scope */
+    total: number;
+    /** First isolated documents by stable document id order */
+    examples: GraphReportNode[];
+  };
+  /** Unresolved explicit links */
+  unresolvedLinks: {
+    /** Total unresolved wiki/markdown links in scope */
+    total: number;
+    /** Unresolved links by type */
+    byType: Record<Exclude<GraphLinkType, "similar">, number>;
+  };
+  /** Edge breakdown by type before edge-limit truncation */
+  edgeTypes: Record<GraphLinkType, number>;
 }
 
 /** Graph metadata with truncation info */
@@ -484,6 +524,7 @@ export interface GraphMeta {
 export interface GraphResult {
   nodes: GraphNode[];
   links: GraphLink[];
+  report: GraphReport;
   meta: GraphMeta;
 }
 

--- a/test/cli/commands/links.test.ts
+++ b/test/cli/commands/links.test.ts
@@ -446,3 +446,53 @@ describe("gno similar", () => {
     expect(stderr).toContain("threshold");
   });
 });
+
+describe("gno graph traversal", () => {
+  test("returns neighbors for a graph ref", async () => {
+    const { code, stdout } = await cli(
+      "graph",
+      "--neighbors",
+      "gno://notes/source.md",
+      "--direction",
+      "out",
+      "--json"
+    );
+
+    expect(code).toBe(0);
+    const data = JSON.parse(stdout) as {
+      neighbors: Array<{ node: { uri: string }; direction: string }>;
+      meta: { mode: string; direction: string; totalNeighbors: number };
+    };
+    expect(data.meta).toMatchObject({
+      mode: "neighbors",
+      direction: "out",
+    });
+    expect(data.meta.totalNeighbors).toBeGreaterThan(0);
+    expect(
+      data.neighbors.some((item) => item.node.uri.includes("target"))
+    ).toBe(true);
+  });
+
+  test("returns a graph path payload", async () => {
+    const { code, stdout } = await cli(
+      "graph",
+      "--from",
+      "gno://notes/source.md",
+      "--to",
+      "gno://notes/source.md",
+      "--json"
+    );
+
+    expect(code).toBe(0);
+    const data = JSON.parse(stdout) as {
+      path: { nodes: Array<{ uri: string }>; edges: unknown[] };
+      meta: { mode: string; found: boolean; hops: number };
+    };
+    expect(data.meta).toMatchObject({
+      mode: "path",
+      found: true,
+      hops: 0,
+    });
+    expect(data.path.nodes[0]?.uri).toBe("gno://notes/source.md");
+  });
+});

--- a/test/core/graph-analysis.test.ts
+++ b/test/core/graph-analysis.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import type { GraphLink, GraphNode } from "../../src/store/types";
+
+import { analyzeGraphCommunities } from "../../src/core/graph-analysis";
+
+const node = (id: string, degree = 1): GraphNode => ({
+  id,
+  uri: `gno://notes/${id.slice(1)}.md`,
+  title: id,
+  collection: "notes",
+  relPath: `${id.slice(1)}.md`,
+  degree,
+});
+
+const link = (
+  source: string,
+  target: string,
+  weight = 1,
+  confidence: GraphLink["confidence"] = "explicit"
+): GraphLink => ({
+  source,
+  target,
+  type: "wiki",
+  weight,
+  confidence,
+  audit: { resolution: "exact-title", matchCount: 1 },
+});
+
+describe("analyzeGraphCommunities", () => {
+  test("detects two dense communities with a weak bridge deterministically", () => {
+    const nodes = ["#a1", "#a2", "#a3", "#b1", "#b2", "#b3"].map((id) =>
+      node(id, 3)
+    );
+    const links: GraphLink[] = [
+      link("#a1", "#a2"),
+      link("#a2", "#a3"),
+      link("#a1", "#a3"),
+      link("#b1", "#b2"),
+      link("#b2", "#b3"),
+      link("#b1", "#b3"),
+      link("#a3", "#b1", 0.1, "similarity"),
+    ];
+
+    const first = analyzeGraphCommunities(nodes, links);
+    const second = analyzeGraphCommunities(nodes, links);
+
+    expect(first.skipped).toBe(false);
+    expect(first.total).toBe(2);
+    expect(first.communities.map((community) => community.size)).toEqual([
+      3, 3,
+    ]);
+    expect(first.assignments).toEqual(second.assignments);
+    expect(first.communities.map((community) => community.id)).toEqual([
+      "c1",
+      "c2",
+    ]);
+  });
+
+  test("keeps isolates as singleton communities", () => {
+    const result = analyzeGraphCommunities(
+      [node("#a1", 1), node("#a2", 1), node("#z", 0)],
+      [link("#a1", "#a2")]
+    );
+
+    expect(result.total).toBe(2);
+    expect(result.assignments["#z"]).toBeDefined();
+    expect(
+      result.communities.some(
+        (community) => community.size === 1 && community.edgeCount === 0
+      )
+    ).toBe(true);
+  });
+
+  test("handles sparse graphs", () => {
+    const result = analyzeGraphCommunities(
+      [node("#a", 1), node("#b", 1), node("#c", 0)],
+      [link("#a", "#b")]
+    );
+
+    expect(result.skipped).toBe(false);
+    expect(result.total).toBe(2);
+    expect(result.communities[0]?.edgeCount).toBe(1);
+  });
+
+  test("skips large graphs with a warning", () => {
+    const nodes = Array.from({ length: 6 }, (_, index) => node(`#n${index}`));
+    const result = analyzeGraphCommunities(nodes, [], { nodeCap: 5 });
+
+    expect(result.skipped).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.warnings[0]).toContain("Community detection skipped");
+  });
+});

--- a/test/mcp/links-integration.test.ts
+++ b/test/mcp/links-integration.test.ts
@@ -443,6 +443,9 @@ describe("MCP link tools integration", () => {
       // Should have at least 1 edge (edges may be deduplicated/collapsed)
       expect(links.length).toBeGreaterThanOrEqual(1);
       expect(links.every((l) => l.type === "markdown")).toBe(true);
+      expect(result.value.report.hubs).toHaveLength(2);
+      expect(result.value.report.edgeTypes.markdown).toBeGreaterThanOrEqual(1);
+      expect(result.value.report.unresolvedLinks.total).toBe(0);
 
       // Both docs should have degree >= 1 (connected to each other)
       expect(nodes.every((n) => n.degree >= 1)).toBe(true);

--- a/test/mcp/links-integration.test.ts
+++ b/test/mcp/links-integration.test.ts
@@ -11,8 +11,13 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { ToolContext } from "../../src/mcp/server";
 import type { DocLinkInput, DocumentInput } from "../../src/store/types";
 
+import {
+  handleGraphNeighbors,
+  handleGraphPath,
+} from "../../src/mcp/tools/links";
 import { SqliteAdapter } from "../../src/store/sqlite/adapter";
 import { safeRm } from "../helpers/cleanup";
 
@@ -82,6 +87,43 @@ describe("MCP link tools integration", () => {
     expect(contentResult.ok).toBe(true);
 
     return result.value.id;
+  }
+
+  function toolContext(): ToolContext {
+    return {
+      store,
+      config: {
+        version: "1.0",
+        ftsTokenizer: "porter",
+        collections: [],
+        contexts: [],
+      },
+      collections: [
+        {
+          name: "notes",
+          path: tmpDir,
+          pattern: "**/*.md",
+          include: [],
+          exclude: [],
+        },
+        {
+          name: "docs",
+          path: tmpDir,
+          pattern: "**/*.md",
+          include: [],
+          exclude: [],
+        },
+      ],
+      actualConfigPath: join(tmpDir, "config.yml"),
+      toolMutex: {
+        acquire: async () => () => {},
+      } as ToolContext["toolMutex"],
+      jobManager: {} as ToolContext["jobManager"],
+      serverInstanceId: "test",
+      writeLockPath: join(tmpDir, ".lock"),
+      enableWrite: false,
+      isShuttingDown: () => false,
+    };
   }
 
   describe("gno_links integration", () => {
@@ -555,6 +597,69 @@ describe("MCP link tools integration", () => {
       expect(getChunks.value).toHaveLength(2);
       expect(getChunks.value[0]?.text).toBe("# Header");
       expect(getChunks.value[1]?.text).toBe("Long content for chunking...");
+    });
+
+    test("graph neighbors tool returns formatted relationship output", async () => {
+      const docAId = await createTestDoc(
+        "notes",
+        "doc-a.md",
+        "Document A",
+        "Links to doc-b.md"
+      );
+      await createTestDoc("notes", "doc-b.md", "Document B", "Target");
+      await store.setDocLinks(
+        docAId,
+        [
+          {
+            targetRef: "doc-b.md",
+            targetRefNorm: "doc-b.md",
+            linkType: "markdown",
+            startLine: 1,
+            startCol: 10,
+            endLine: 1,
+            endCol: 25,
+          },
+        ],
+        "parsed"
+      );
+
+      const result = await handleGraphNeighbors(
+        {
+          ref: "gno://notes/doc-a.md",
+          collection: "notes",
+          direction: "out",
+        },
+        toolContext()
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]?.text).toContain("graph neighbors");
+      expect(result.content[0]?.text).toContain("gno://notes/doc-b.md");
+      expect(result.structuredContent?.meta).toMatchObject({
+        direction: "out",
+        totalNeighbors: 1,
+      });
+    });
+
+    test("graph path tool returns formatted path output", async () => {
+      await createTestDoc("notes", "doc-a.md", "Document A", "A");
+
+      const result = await handleGraphPath(
+        {
+          from: "gno://notes/doc-a.md",
+          to: "gno://notes/doc-a.md",
+          collection: "notes",
+          linkedOnly: false,
+        },
+        toolContext()
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]?.text).toContain("Graph path (0 hops)");
+      expect(result.structuredContent?.meta).toMatchObject({
+        found: true,
+        hops: 0,
+      });
     });
   });
 });

--- a/test/mcp/tools/links.test.ts
+++ b/test/mcp/tools/links.test.ts
@@ -418,6 +418,17 @@ const graphInputSchema = z.object({
   similarTopK: z.number().int().min(1).max(20).default(5),
 });
 
+const graphNeighborsInputSchema = graphInputSchema.extend({
+  ref: z.string().min(1),
+  direction: z.enum(["both", "out", "in"]).default("both"),
+});
+
+const graphPathInputSchema = graphInputSchema.extend({
+  from: z.string().min(1),
+  to: z.string().min(1),
+  maxDepth: z.number().int().min(1).max(12).default(6),
+});
+
 const graphOutputSchema = z.object({
   nodes: z.array(
     z.object({
@@ -614,5 +625,61 @@ describe("gno_graph schema", () => {
     };
     const result = graphOutputSchema.safeParse(validOutput);
     expect(result.success).toBe(true);
+  });
+});
+
+describe("gno_graph_neighbors schema", () => {
+  test("neighbors input requires non-empty ref", () => {
+    const result = graphNeighborsInputSchema.safeParse({ ref: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("neighbors input defaults direction and graph limits", () => {
+    const result = graphNeighborsInputSchema.safeParse({
+      ref: "notes/readme.md",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.direction).toBe("both");
+      expect(result.data.limit).toBe(2000);
+    }
+  });
+
+  test("neighbors input rejects invalid direction", () => {
+    const result = graphNeighborsInputSchema.safeParse({
+      ref: "notes/readme.md",
+      direction: "sideways",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("gno_graph_path schema", () => {
+  test("path input requires from and to refs", () => {
+    const result = graphPathInputSchema.safeParse({
+      from: "notes/a.md",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("path input accepts max depth", () => {
+    const result = graphPathInputSchema.safeParse({
+      from: "notes/a.md",
+      to: "notes/b.md",
+      maxDepth: 4,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxDepth).toBe(4);
+    }
+  });
+
+  test("path input rejects excessive max depth", () => {
+    const result = graphPathInputSchema.safeParse({
+      from: "notes/a.md",
+      to: "notes/b.md",
+      maxDepth: 13,
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/test/pipeline/hybrid-doc-lookup.test.ts
+++ b/test/pipeline/hybrid-doc-lookup.test.ts
@@ -484,11 +484,81 @@ describe("searchHybrid targeted document lookup", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(requestedDocids).toHaveLength(2);
+    expect(requestedDocids).toHaveLength(4);
     if (result.ok) {
       expect(result.value.meta.graphExpansion?.candidateCount).toBe(2);
       expect(result.value.meta.graphExpansion?.maxCandidates).toBe(2);
     }
+  });
+
+  test("graph expansion caps candidates after active filters", async () => {
+    const store = createGraphStore(
+      [
+        {
+          source: "#seed",
+          target: "#dropone",
+          type: "wiki",
+          weight: 4,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+        {
+          source: "#seed",
+          target: "#droptwo",
+          type: "wiki",
+          weight: 3,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+        {
+          source: "#seed",
+          target: "#valid",
+          type: "wiki",
+          weight: 1,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+      ],
+      {
+        docs: ["seed", "dropone", "droptwo", "valid"],
+        docMetadata: {
+          seed: { tags: ["keep"], sourceMtime: NOW, language: "en" },
+          dropone: { tags: ["drop"], sourceMtime: NOW, language: "en" },
+          droptwo: { tags: ["drop"], sourceMtime: NOW, language: "en" },
+          valid: { tags: ["keep"], sourceMtime: NOW, language: "en" },
+        },
+      }
+    );
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort: null,
+      },
+      "seed query",
+      {
+        noExpand: true,
+        noRerank: true,
+        candidateLimit: 1,
+        limit: 5,
+        tagsAll: ["keep"],
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.results.map((r) => r.source.relPath)).toContain(
+      "valid.md"
+    );
+    expect(result.value.meta.graphExpansion?.candidateCount).toBe(1);
+    expect(result.value.meta.graphExpansion?.maxCandidates).toBe(1);
   });
 
   test("graph expansion keeps candidates within active filters", async () => {

--- a/test/pipeline/hybrid-doc-lookup.test.ts
+++ b/test/pipeline/hybrid-doc-lookup.test.ts
@@ -6,11 +6,13 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Config } from "../../src/config/types";
+import type { RerankPort } from "../../src/llm/types";
 import type {
   ChunkRow,
   CollectionRow,
   DocumentRow,
   FtsResult,
+  GraphResult,
   StorePort,
 } from "../../src/store/types";
 
@@ -65,6 +67,94 @@ const makeFtsResult = (mirrorHash: string, seq: number): FtsResult => ({
   seq,
   score: -1.0,
 });
+
+const makeGraph = (
+  links: GraphResult["links"],
+  nodes: GraphResult["nodes"]
+): GraphResult => ({
+  nodes,
+  links,
+  report: {
+    hubs: [],
+    bridgeCandidates: [],
+    isolated: { total: 0, examples: [] },
+    unresolvedLinks: { total: 0, byType: { wiki: 0, markdown: 0 } },
+    edgeTypes: { wiki: 0, markdown: 0, similar: 0 },
+    edgeConfidence: { explicit: 0, inferred: 0, ambiguous: 0, similarity: 0 },
+    audit: { inferredEdges: 0, ambiguousEdges: 0, similarityEdges: 0 },
+  },
+  meta: {
+    collection: "notes",
+    nodeLimit: 2000,
+    edgeLimit: 10000,
+    totalNodes: nodes.length,
+    totalEdges: links.length,
+    totalEdgesUnresolved: 0,
+    returnedNodes: nodes.length,
+    returnedEdges: links.length,
+    truncated: false,
+    linkedOnly: true,
+    includedSimilar: false,
+    similarAvailable: false,
+    similarTopK: 5,
+    similarTruncatedByComputeBudget: false,
+    warnings: [],
+  },
+});
+
+const graphNode = (mirrorHash: string): GraphResult["nodes"][number] => ({
+  id: `#${mirrorHash}`,
+  uri: `gno://notes/${mirrorHash}.md`,
+  title: `Doc ${mirrorHash}`,
+  collection: "notes",
+  relPath: `${mirrorHash}.md`,
+  degree: 1,
+});
+
+const createGraphStore = (
+  links: GraphResult["links"],
+  options: {
+    docs?: string[];
+    fts?: string[];
+    onGetDocumentByDocid?: (docid: string) => void;
+  } = {}
+): Partial<StorePort> => {
+  const hashes = options.docs ?? ["seed", "explicit", "inferred", "ambiguous"];
+  const docs = new Map(
+    hashes.map((hash, index) => [`#${hash}`, makeDoc(index + 1, hash)])
+  );
+  return {
+    searchFts: async () => ({
+      ok: true as const,
+      value: (options.fts ?? ["seed"]).map((hash) => makeFtsResult(hash, 0)),
+    }),
+    getGraph: async () => ({
+      ok: true as const,
+      value: makeGraph(links, hashes.map(graphNode)),
+    }),
+    getDocumentByDocid: async (docid) => {
+      options.onGetDocumentByDocid?.(docid);
+      return { ok: true as const, value: docs.get(docid) ?? null };
+    },
+    getDocumentsByMirrorHashes: async (requestedHashes) => ({
+      ok: true as const,
+      value: requestedHashes
+        .map((hash) => docs.get(`#${hash}`))
+        .filter((doc): doc is DocumentRow => Boolean(doc)),
+    }),
+    getCollections: async () => ({
+      ok: true as const,
+      value: TEST_COLLECTIONS,
+    }),
+    getChunksBatch: async (requestedHashes) => {
+      const map = new Map<string, ChunkRow[]>();
+      for (const hash of requestedHashes) {
+        map.set(hash, [makeChunk(hash, 0)]);
+      }
+      return { ok: true as const, value: map };
+    },
+  };
+};
 
 const TEST_COLLECTIONS: CollectionRow[] = [
   {
@@ -213,5 +303,245 @@ describe("searchHybrid targeted document lookup", () => {
     expect(result.value.results).toHaveLength(2);
     expect(result.value.results[0]?.source.relPath).toBe("hash_b.md");
     expect(result.value.results[1]?.source.relPath).toBe("hash_a.md");
+  });
+
+  test("expands one-hop graph neighbors when embeddings are unavailable", async () => {
+    const store = createGraphStore([
+      {
+        source: "#seed",
+        target: "#explicit",
+        type: "wiki",
+        weight: 1,
+        confidence: "explicit",
+        audit: { resolution: "exact-title", matchCount: 1 },
+      },
+    ]);
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort: null,
+      },
+      "seed query",
+      { noExpand: true, noRerank: true, limit: 2, explain: true }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.results.map((r) => r.source.relPath)).toContain(
+      "explicit.md"
+    );
+    expect(result.value.meta.mode).toBe("bm25_only");
+    expect(result.value.meta.graphExpansion?.enabled).toBe(true);
+    expect(result.value.meta.graphExpansion?.candidateCount).toBe(1);
+    expect(
+      result.value.meta.explain?.lines.some((l) => l.stage === "graph")
+    ).toBe(true);
+  });
+
+  test("graph expansion fallback preserves current retrieval output", async () => {
+    const baseStore: Partial<StorePort> = {
+      searchFts: async () => ({
+        ok: true as const,
+        value: [makeFtsResult("seed", 0)],
+      }),
+      getDocumentsByMirrorHashes: async () => ({
+        ok: true as const,
+        value: [makeDoc(1, "seed")],
+      }),
+      getCollections: async () => ({
+        ok: true as const,
+        value: TEST_COLLECTIONS,
+      }),
+      getChunksBatch: async () => ({
+        ok: true as const,
+        value: new Map([["seed", [makeChunk("seed", 0)]]]),
+      }),
+    };
+    const graphStore: Partial<StorePort> = {
+      ...baseStore,
+      getGraph: async () => ({
+        ok: true as const,
+        value: makeGraph([], [graphNode("seed")]),
+      }),
+    };
+
+    const deps = {
+      config: {} as Config,
+      vectorIndex: null,
+      embedPort: null,
+      expandPort: null,
+      rerankPort: null,
+    };
+    const withoutGraph = await searchHybrid(
+      { ...deps, store: baseStore as StorePort },
+      "seed query",
+      { noExpand: true, noRerank: true, limit: 2 }
+    );
+    const emptyGraph = await searchHybrid(
+      { ...deps, store: graphStore as StorePort },
+      "seed query",
+      { noExpand: true, noRerank: true, limit: 2 }
+    );
+
+    expect(withoutGraph.ok).toBe(true);
+    expect(emptyGraph.ok).toBe(true);
+    if (!withoutGraph.ok || !emptyGraph.ok) {
+      return;
+    }
+    expect(emptyGraph.value.results).toEqual(withoutGraph.value.results);
+    expect(emptyGraph.value.meta.graphExpansion?.enabled).toBe(false);
+  });
+
+  test("graph expansion enforces candidate cap", async () => {
+    const requestedDocids: string[] = [];
+    const store = createGraphStore(
+      ["one", "two", "three", "four"].map((hash) => ({
+        source: "#seed",
+        target: `#${hash}`,
+        type: "wiki" as const,
+        weight: 1,
+        confidence: "explicit" as const,
+        audit: { resolution: "exact-title" as const, matchCount: 1 },
+      })),
+      {
+        docs: ["seed", "one", "two", "three", "four"],
+        onGetDocumentByDocid: (docid) => requestedDocids.push(docid),
+      }
+    );
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort: null,
+      },
+      "seed query",
+      { noExpand: true, noRerank: true, candidateLimit: 2, limit: 5 }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(requestedDocids).toHaveLength(2);
+    if (result.ok) {
+      expect(result.value.meta.graphExpansion?.candidateCount).toBe(2);
+      expect(result.value.meta.graphExpansion?.maxCandidates).toBe(2);
+    }
+  });
+
+  test("explicit graph neighbors outrank inferred and ambiguous neighbors", async () => {
+    const store = createGraphStore([
+      {
+        source: "#seed",
+        target: "#inferred",
+        type: "wiki",
+        weight: 1,
+        confidence: "inferred",
+        audit: { resolution: "path-fallback", matchCount: 1 },
+      },
+      {
+        source: "#seed",
+        target: "#ambiguous",
+        type: "wiki",
+        weight: 1,
+        confidence: "ambiguous",
+        audit: { resolution: "ambiguous-fallback", matchCount: 2 },
+      },
+      {
+        source: "#seed",
+        target: "#explicit",
+        type: "markdown",
+        weight: 1,
+        confidence: "explicit",
+        audit: { resolution: "exact-path", matchCount: 1 },
+      },
+    ]);
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort: null,
+      },
+      "seed query",
+      { noExpand: true, noRerank: true, limit: 4 }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const paths = result.value.results.map((r) => r.source.relPath);
+    expect(paths.indexOf("explicit.md")).toBeLessThan(
+      paths.indexOf("inferred.md")
+    );
+    expect(paths.indexOf("explicit.md")).toBeLessThan(
+      paths.indexOf("ambiguous.md")
+    );
+  });
+
+  test("graph candidates participate in reranking", async () => {
+    const store = createGraphStore([
+      {
+        source: "#seed",
+        target: "#explicit",
+        type: "wiki",
+        weight: 1,
+        confidence: "explicit",
+        audit: { resolution: "exact-title", matchCount: 1 },
+      },
+    ]);
+    const rerankedDocs: string[] = [];
+    const rerankPort: RerankPort = {
+      modelUri: "test:rerank",
+      rerank: async (_query, documents) => ({
+        ok: true as const,
+        value: documents.map((doc, index) => {
+          rerankedDocs.push(doc);
+          return {
+            index,
+            score: doc.includes("explicit") ? 10 : 1,
+            rank: doc.includes("explicit") ? 1 : 2,
+          };
+        }),
+      }),
+      dispose: async () => {},
+    };
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort,
+      },
+      "seed query",
+      { noExpand: true, limit: 2 }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(rerankedDocs.some((doc) => doc.includes("explicit"))).toBe(true);
+    expect(result.value.results.map((r) => r.source.relPath)).toContain(
+      "explicit.md"
+    );
+    expect(result.value.meta.reranked).toBe(true);
   });
 });

--- a/test/pipeline/hybrid-doc-lookup.test.ts
+++ b/test/pipeline/hybrid-doc-lookup.test.ts
@@ -23,7 +23,12 @@ const NOW = "2026-02-22T00:00:00.000Z";
 const makeDoc = (
   id: number,
   mirrorHash: string,
-  metadata?: { sourceMtime?: string; frontmatterDate?: string | null }
+  metadata?: {
+    sourceMtime?: string;
+    frontmatterDate?: string | null;
+    categories?: string[];
+    author?: string;
+  }
 ): DocumentRow => ({
   id,
   collection: "notes",
@@ -48,16 +53,22 @@ const makeDoc = (
   createdAt: NOW,
   updatedAt: NOW,
   frontmatterDate: metadata?.frontmatterDate ?? null,
+  categories: metadata?.categories ?? null,
+  author: metadata?.author ?? null,
 });
 
-const makeChunk = (mirrorHash: string, seq: number): ChunkRow => ({
+const makeChunk = (
+  mirrorHash: string,
+  seq: number,
+  language = "en"
+): ChunkRow => ({
   mirrorHash,
   seq,
   pos: seq * 100,
   text: `Chunk ${mirrorHash}:${seq}`,
   startLine: seq + 1,
   endLine: seq + 1,
-  language: "en",
+  language,
   tokenCount: 20,
   createdAt: NOW,
 });
@@ -123,12 +134,20 @@ const createGraphStore = (
   options: {
     docs?: string[];
     fts?: string[];
-    onGetDocumentByDocid?: (docid: string) => void;
+    docMetadata?: Record<
+      string,
+      Parameters<typeof makeDoc>[2] & { tags?: string[]; language?: string }
+    >;
+    chunkSeqs?: Record<string, number[]>;
+    onGetDocumentsByDocids?: (docids: string[]) => void;
   } = {}
 ): Partial<StorePort> => {
   const hashes = options.docs ?? ["seed", "explicit", "inferred", "ambiguous"];
   const docs = new Map(
-    hashes.map((hash, index) => [`#${hash}`, makeDoc(index + 1, hash)])
+    hashes.map((hash, index) => [
+      `#${hash}`,
+      makeDoc(index + 1, hash, options.docMetadata?.[hash]),
+    ])
   );
   return {
     searchFts: async () => ({
@@ -140,8 +159,16 @@ const createGraphStore = (
       value: makeGraph(links, hashes.map(graphNode)),
     }),
     getDocumentByDocid: async (docid) => {
-      options.onGetDocumentByDocid?.(docid);
       return { ok: true as const, value: docs.get(docid) ?? null };
+    },
+    getDocumentsByDocids: async (docids) => {
+      options.onGetDocumentsByDocids?.(docids);
+      return {
+        ok: true as const,
+        value: docids
+          .map((docid) => docs.get(docid))
+          .filter((doc): doc is DocumentRow => Boolean(doc)),
+      };
     },
     getDocumentsByMirrorHashes: async (requestedHashes) => ({
       ok: true as const,
@@ -156,9 +183,28 @@ const createGraphStore = (
     getChunksBatch: async (requestedHashes) => {
       const map = new Map<string, ChunkRow[]>();
       for (const hash of requestedHashes) {
-        map.set(hash, [makeChunk(hash, 0)]);
+        const seqs = options.chunkSeqs?.[hash] ?? [0];
+        const language = options.docMetadata?.[hash]?.language ?? "en";
+        map.set(
+          hash,
+          seqs.map((seq) => makeChunk(hash, seq, language))
+        );
       }
       return { ok: true as const, value: map };
+    },
+    getTagsBatch: async (documentIds) => {
+      const values = new Map();
+      for (const doc of docs.values()) {
+        if (!documentIds.includes(doc.id)) {
+          continue;
+        }
+        const tags = options.docMetadata?.[doc.mirrorHash ?? ""]?.tags ?? [];
+        values.set(
+          doc.id,
+          tags.map((tag) => ({ tag, source: "frontmatter" as const }))
+        );
+      }
+      return { ok: true as const, value: values };
     },
   };
 };
@@ -420,7 +466,7 @@ describe("searchHybrid targeted document lookup", () => {
       })),
       {
         docs: ["seed", "one", "two", "three", "four"],
-        onGetDocumentByDocid: (docid) => requestedDocids.push(docid),
+        onGetDocumentsByDocids: (docids) => requestedDocids.push(...docids),
       }
     );
 
@@ -443,6 +489,145 @@ describe("searchHybrid targeted document lookup", () => {
       expect(result.value.meta.graphExpansion?.candidateCount).toBe(2);
       expect(result.value.meta.graphExpansion?.maxCandidates).toBe(2);
     }
+  });
+
+  test("graph expansion keeps candidates within active filters", async () => {
+    const store = createGraphStore(
+      [
+        {
+          source: "#seed",
+          target: "#valid",
+          type: "wiki",
+          weight: 1,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+        {
+          source: "#seed",
+          target: "#wrongtag",
+          type: "wiki",
+          weight: 1,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+        {
+          source: "#seed",
+          target: "#old",
+          type: "wiki",
+          weight: 1,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+        {
+          source: "#seed",
+          target: "#fr",
+          type: "wiki",
+          weight: 1,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+      ],
+      {
+        docs: ["seed", "valid", "wrongtag", "old", "fr"],
+        docMetadata: {
+          seed: { tags: ["keep"], sourceMtime: NOW, language: "en" },
+          valid: { tags: ["keep"], sourceMtime: NOW, language: "en" },
+          wrongtag: { tags: ["drop"], sourceMtime: NOW, language: "en" },
+          old: {
+            tags: ["keep"],
+            sourceMtime: "2025-01-01T00:00:00.000Z",
+            language: "en",
+          },
+          fr: { tags: ["keep"], sourceMtime: NOW, language: "fr" },
+        },
+      }
+    );
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort: null,
+      },
+      "seed query",
+      {
+        noExpand: true,
+        noRerank: true,
+        limit: 5,
+        tagsAll: ["keep"],
+        since: "2026-01-01",
+        lang: "en",
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.results.map((r) => r.source.relPath)).toContain(
+      "valid.md"
+    );
+    expect(result.value.results.map((r) => r.source.relPath)).not.toContain(
+      "wrongtag.md"
+    );
+    expect(result.value.results.map((r) => r.source.relPath)).not.toContain(
+      "old.md"
+    );
+    expect(result.value.results.map((r) => r.source.relPath)).not.toContain(
+      "fr.md"
+    );
+    expect(result.value.meta.graphExpansion?.candidateCount).toBe(1);
+  });
+
+  test("graph expansion reuses existing candidate seq for document-level boosts", async () => {
+    const store = createGraphStore(
+      [
+        {
+          source: "#seed",
+          target: "#related",
+          type: "wiki",
+          weight: 1,
+          confidence: "explicit",
+          audit: { resolution: "exact-title", matchCount: 1 },
+        },
+      ],
+      {
+        docs: ["seed", "related"],
+        fts: ["seed", "related"],
+        chunkSeqs: { seed: [0], related: [2] },
+      }
+    );
+
+    const result = await searchHybrid(
+      {
+        store: store as StorePort,
+        config: {} as Config,
+        vectorIndex: null,
+        embedPort: null,
+        expandPort: null,
+        rerankPort: null,
+      },
+      "seed query",
+      { noExpand: true, noRerank: true, limit: 5, explain: true }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const related = result.value.results.find(
+      (entry) => entry.source.relPath === "related.md"
+    );
+    expect(related?.snippet).toBe("Chunk related:2");
+    const timingLine = result.value.meta.explain?.lines.find(
+      (line) => line.stage === "timing"
+    );
+    expect(timingLine?.message).toContain("graph=");
   });
 
   test("explicit graph neighbors outrank inferred and ambiguous neighbors", async () => {

--- a/test/pipeline/hybrid-doc-lookup.test.ts
+++ b/test/pipeline/hybrid-doc-lookup.test.ts
@@ -82,6 +82,13 @@ const makeGraph = (
     edgeTypes: { wiki: 0, markdown: 0, similar: 0 },
     edgeConfidence: { explicit: 0, inferred: 0, ambiguous: 0, similarity: 0 },
     audit: { inferredEdges: 0, ambiguousEdges: 0, similarityEdges: 0 },
+    communities: {
+      total: 0,
+      algorithm: "deterministic-label-propagation",
+      skipped: false,
+      assignments: {},
+      top: [],
+    },
   },
   meta: {
     collection: "notes",

--- a/test/spec/schemas/api-graph.test.ts
+++ b/test/spec/schemas/api-graph.test.ts
@@ -22,6 +22,13 @@ describe("graph schema", () => {
       edgeTypes: { wiki: 0, markdown: 0, similar: 0 },
       edgeConfidence: { explicit: 0, inferred: 0, ambiguous: 0, similarity: 0 },
       audit: { inferredEdges: 0, ambiguousEdges: 0, similarityEdges: 0 },
+      communities: {
+        total: 0,
+        algorithm: "deterministic-label-propagation",
+        skipped: false,
+        assignments: {},
+        top: [],
+      },
       ...overrides,
     };
   }
@@ -63,6 +70,7 @@ describe("graph schema", () => {
             collection: "notes",
             relPath: "doc1.md",
             degree: 3,
+            communityId: "c1",
           },
           {
             id: "#def456",
@@ -92,6 +100,7 @@ describe("graph schema", () => {
               collection: "notes",
               relPath: "doc1.md",
               degree: 3,
+              communityId: "c1",
             },
           ],
           bridgeCandidates: [
@@ -102,9 +111,36 @@ describe("graph schema", () => {
               collection: "notes",
               relPath: "doc1.md",
               degree: 3,
+              communityId: "c1",
             },
           ],
           edgeTypes: { wiki: 1, markdown: 0, similar: 0 },
+          communities: {
+            total: 1,
+            algorithm: "deterministic-label-propagation",
+            skipped: false,
+            assignments: { "#abc123": "c1" },
+            top: [
+              {
+                id: "c1",
+                label: "Document 1",
+                size: 2,
+                edgeCount: 1,
+                density: 1,
+                topNodes: [
+                  {
+                    id: "#abc123",
+                    uri: "gno://notes/doc1.md",
+                    title: "Document 1",
+                    collection: "notes",
+                    relPath: "doc1.md",
+                    degree: 3,
+                    communityId: "c1",
+                  },
+                ],
+              },
+            ],
+          },
         }),
         meta: {
           collection: "notes",

--- a/test/spec/schemas/api-graph.test.ts
+++ b/test/spec/schemas/api-graph.test.ts
@@ -20,6 +20,8 @@ describe("graph schema", () => {
       isolated: { total: 0, examples: [] },
       unresolvedLinks: { total: 0, byType: { wiki: 0, markdown: 0 } },
       edgeTypes: { wiki: 0, markdown: 0, similar: 0 },
+      edgeConfidence: { explicit: 0, inferred: 0, ambiguous: 0, similarity: 0 },
+      audit: { inferredEdges: 0, ambiguousEdges: 0, similarityEdges: 0 },
       ...overrides,
     };
   }
@@ -77,6 +79,8 @@ describe("graph schema", () => {
             target: "#def456",
             type: "wiki",
             weight: 2,
+            confidence: "explicit",
+            audit: { resolution: "exact-title", matchCount: 1 },
           },
         ],
         report: report({
@@ -144,16 +148,32 @@ describe("graph schema", () => {
           },
         ],
         links: [
-          { source: "#abc123", target: "#def456", type: "markdown", weight: 1 },
+          {
+            source: "#abc123",
+            target: "#def456",
+            type: "markdown",
+            weight: 1,
+            confidence: "explicit",
+            audit: { resolution: "exact-path", matchCount: 1 },
+          },
           {
             source: "#abc123",
             target: "#def456",
             type: "similar",
             weight: 0.85,
+            confidence: "similarity",
+            audit: { resolution: "similarity", score: 0.85 },
           },
         ],
         report: report({
           edgeTypes: { wiki: 0, markdown: 1, similar: 1 },
+          edgeConfidence: {
+            explicit: 1,
+            inferred: 0,
+            ambiguous: 0,
+            similarity: 1,
+          },
+          audit: { inferredEdges: 0, ambiguousEdges: 0, similarityEdges: 1 },
         }),
         meta: {
           collection: null,

--- a/test/spec/schemas/api-graph.test.ts
+++ b/test/spec/schemas/api-graph.test.ts
@@ -13,11 +13,23 @@ describe("graph schema", () => {
     schema = await loadSchema("graph");
   });
 
+  function report(overrides: Record<string, unknown> = {}) {
+    return {
+      hubs: [],
+      bridgeCandidates: [],
+      isolated: { total: 0, examples: [] },
+      unresolvedLinks: { total: 0, byType: { wiki: 0, markdown: 0 } },
+      edgeTypes: { wiki: 0, markdown: 0, similar: 0 },
+      ...overrides,
+    };
+  }
+
   describe("valid inputs", () => {
     test("validates minimal response", () => {
       const response = {
         nodes: [],
         links: [],
+        report: report(),
         meta: {
           collection: null,
           nodeLimit: 2000,
@@ -67,6 +79,29 @@ describe("graph schema", () => {
             weight: 2,
           },
         ],
+        report: report({
+          hubs: [
+            {
+              id: "#abc123",
+              uri: "gno://notes/doc1.md",
+              title: "Document 1",
+              collection: "notes",
+              relPath: "doc1.md",
+              degree: 3,
+            },
+          ],
+          bridgeCandidates: [
+            {
+              id: "#abc123",
+              uri: "gno://notes/doc1.md",
+              title: "Document 1",
+              collection: "notes",
+              relPath: "doc1.md",
+              degree: 3,
+            },
+          ],
+          edgeTypes: { wiki: 1, markdown: 0, similar: 0 },
+        }),
         meta: {
           collection: "notes",
           nodeLimit: 2000,
@@ -117,6 +152,9 @@ describe("graph schema", () => {
             weight: 0.85,
           },
         ],
+        report: report({
+          edgeTypes: { wiki: 0, markdown: 1, similar: 1 },
+        }),
         meta: {
           collection: null,
           nodeLimit: 2000,
@@ -151,6 +189,25 @@ describe("graph schema", () => {
           },
         ],
         links: [],
+        report: report({
+          isolated: {
+            total: 400,
+            examples: [
+              {
+                id: "#def456",
+                uri: "gno://notes/isolated.md",
+                title: "Isolated",
+                collection: "notes",
+                relPath: "isolated.md",
+                degree: 0,
+              },
+            ],
+          },
+          unresolvedLinks: {
+            total: 10,
+            byType: { wiki: 7, markdown: 3 },
+          },
+        }),
         meta: {
           collection: null,
           nodeLimit: 100,

--- a/test/store/links.test.ts
+++ b/test/store/links.test.ts
@@ -798,6 +798,107 @@ describe("SqliteAdapter links", () => {
   });
 
   describe("getGraph", () => {
+    test("reports hubs, bridge candidates, isolates, unresolved links, and edge breakdown", async () => {
+      const hubId = await createTestDoc("notes", "hub.md", "Hub");
+      const spokeAId = await createTestDoc("notes", "spoke-a.md", "Spoke A");
+      const spokeBId = await createTestDoc("notes", "spoke-b.md", "Spoke B");
+      await createTestDoc("notes", "isolated.md", "Isolated");
+
+      const hubDoc = await adapter.getDocument("notes", "hub.md");
+      expect(hubDoc.ok).toBe(true);
+      if (!hubDoc.ok || !hubDoc.value) return;
+
+      await adapter.setDocLinks(
+        hubId,
+        [
+          {
+            targetRef: "Spoke A",
+            targetRefNorm: "spoke a",
+            linkType: "wiki",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 12,
+          },
+          {
+            targetRef: "spoke-b.md",
+            targetRefNorm: "spoke-b.md",
+            linkType: "markdown",
+            startLine: 2,
+            startCol: 1,
+            endLine: 2,
+            endCol: 20,
+          },
+        ],
+        "parsed"
+      );
+      await adapter.setDocLinks(
+        spokeAId,
+        [
+          {
+            targetRef: "hub.md",
+            targetRefNorm: "hub.md",
+            linkType: "markdown",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 15,
+          },
+        ],
+        "parsed"
+      );
+      await adapter.setDocLinks(
+        spokeBId,
+        [
+          {
+            targetRef: "missing",
+            targetRefNorm: "missing",
+            linkType: "wiki",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 11,
+          },
+        ],
+        "parsed"
+      );
+
+      const graph = await adapter.getGraph({
+        collection: "notes",
+        linkedOnly: false,
+        limitNodes: 10,
+        limitEdges: 1,
+        includeSimilar: true,
+      });
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      expect(graph.value.report.hubs[0]?.id).toBe(hubDoc.value.docid);
+      expect(graph.value.report.hubs[0]?.degree).toBe(3);
+      expect(
+        graph.value.report.bridgeCandidates.some(
+          (node) => node.id === hubDoc.value?.docid
+        )
+      ).toBe(true);
+      expect(graph.value.report.isolated.total).toBe(1);
+      expect(graph.value.report.isolated.examples[0]?.title).toBe("Isolated");
+      expect(graph.value.report.unresolvedLinks).toEqual({
+        total: 1,
+        byType: { wiki: 1, markdown: 0 },
+      });
+      expect(graph.value.report.edgeTypes).toEqual({
+        wiki: 1,
+        markdown: 2,
+        similar: 0,
+      });
+      expect(graph.value.links).toHaveLength(1);
+      expect(graph.value.meta.truncated).toBe(true);
+      expect(graph.value.meta.warnings).toContain("Edges truncated: 3 → 1");
+      expect(graph.value.meta.warnings).toContain(
+        "Similarity edges unavailable: sqlite-vec not loaded"
+      );
+    });
+
     test("resolves wiki links to subfolder rel_path by basename", async () => {
       const sourceId = await createTestDoc("notes", "source.md", "Source");
       await createTestDoc("notes", "projects/task.md", "Different Title");

--- a/test/store/links.test.ts
+++ b/test/store/links.test.ts
@@ -902,6 +902,9 @@ describe("SqliteAdapter links", () => {
         ambiguousEdges: 0,
         similarityEdges: 0,
       });
+      expect(graph.value.report.communities.total).toBeGreaterThanOrEqual(2);
+      expect(graph.value.report.communities.skipped).toBe(false);
+      expect(graph.value.nodes.every((node) => node.communityId)).toBe(true);
       expect(graph.value.links).toHaveLength(1);
       expect(graph.value.meta.truncated).toBe(true);
       expect(graph.value.meta.warnings).toContain("Edges truncated: 3 → 1");
@@ -1011,6 +1014,118 @@ describe("SqliteAdapter links", () => {
       expect(
         graph.value.links.some((link) => link.target === docBValue.docid)
       ).toBe(false);
+    });
+
+    test("detects stable communities across deterministic graph runs", async () => {
+      const a1 = await createTestDoc("notes", "a1.md", "Alpha 1");
+      const a2 = await createTestDoc("notes", "a2.md", "Alpha 2");
+      const b1 = await createTestDoc("notes", "b1.md", "Beta 1");
+      const b2 = await createTestDoc("notes", "b2.md", "Beta 2");
+
+      await adapter.setDocLinks(
+        a1,
+        [
+          {
+            targetRef: "a2.md",
+            targetRefNorm: "a2.md",
+            linkType: "markdown",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 8,
+          },
+        ],
+        "parsed"
+      );
+      await adapter.setDocLinks(
+        a2,
+        [
+          {
+            targetRef: "a1.md",
+            targetRefNorm: "a1.md",
+            linkType: "markdown",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 8,
+          },
+        ],
+        "parsed"
+      );
+      await adapter.setDocLinks(
+        b1,
+        [
+          {
+            targetRef: "b2.md",
+            targetRefNorm: "b2.md",
+            linkType: "markdown",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 8,
+          },
+        ],
+        "parsed"
+      );
+      await adapter.setDocLinks(
+        b2,
+        [
+          {
+            targetRef: "b1.md",
+            targetRefNorm: "b1.md",
+            linkType: "markdown",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 8,
+          },
+        ],
+        "parsed"
+      );
+
+      const first = await adapter.getGraph({
+        collection: "notes",
+        limitNodes: 10,
+        limitEdges: 10,
+      });
+      const second = await adapter.getGraph({
+        collection: "notes",
+        limitNodes: 10,
+        limitEdges: 10,
+      });
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      if (!first.ok || !second.ok) return;
+
+      expect(first.value.report.communities.total).toBe(2);
+      expect(first.value.report.communities.assignments).toEqual(
+        second.value.report.communities.assignments
+      );
+      expect(first.value.report.communities.top.map((c) => c.id)).toEqual([
+        "c1",
+        "c2",
+      ]);
+    });
+
+    test("skips community detection for large returned graphs", async () => {
+      for (let i = 0; i < 2001; i++) {
+        await createTestDoc("notes", `large-${i}.md`, `Large ${i}`);
+      }
+
+      const graph = await adapter.getGraph({
+        collection: "notes",
+        linkedOnly: false,
+        limitNodes: 2001,
+        limitEdges: 10,
+      });
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      expect(graph.value.report.communities.skipped).toBe(true);
+      expect(graph.value.report.communities.top).toEqual([]);
+      expect(graph.value.meta.warnings).toContain(
+        "Community detection skipped: graph has 2001 nodes (cap 2000)"
+      );
     });
   });
 });

--- a/test/store/links.test.ts
+++ b/test/store/links.test.ts
@@ -1016,6 +1016,59 @@ describe("SqliteAdapter links", () => {
       ).toBe(false);
     });
 
+    test("merged graph edges keep best available confidence", async () => {
+      const sourceId = await createTestDoc("notes", "source.md", "Source");
+      await createTestDoc("notes", "projects/task.md", "Target Task");
+      await createTestDoc("notes", "archive/task.md", "Archive Task");
+
+      const target = await adapter.getDocument("notes", "projects/task.md");
+      expect(target.ok).toBe(true);
+      if (!target.ok || !target.value) return;
+      const targetValue = target.value;
+
+      await adapter.setDocLinks(
+        sourceId,
+        [
+          {
+            targetRef: "task.md",
+            targetRefNorm: "task.md",
+            linkType: "wiki",
+            startLine: 1,
+            startCol: 1,
+            endLine: 1,
+            endCol: 12,
+          },
+          {
+            targetRef: "projects/task.md",
+            targetRefNorm: "projects/task.md",
+            linkType: "wiki",
+            startLine: 2,
+            startCol: 1,
+            endLine: 2,
+            endCol: 19,
+          },
+        ],
+        "parsed"
+      );
+
+      const graph = await adapter.getGraph({
+        collection: "notes",
+        linkedOnly: false,
+        limitNodes: 100,
+        limitEdges: 100,
+      });
+      expect(graph.ok).toBe(true);
+      if (!graph.ok) return;
+
+      const edge = graph.value.links.find(
+        (link) => link.target === targetValue.docid
+      );
+      expect(edge).toBeDefined();
+      expect(edge?.weight).toBe(2);
+      expect(edge?.confidence).toBe("explicit");
+      expect(edge?.audit.matchCount).toBe(2);
+    });
+
     test("detects stable communities across deterministic graph runs", async () => {
       const a1 = await createTestDoc("notes", "a1.md", "Alpha 1");
       const a2 = await createTestDoc("notes", "a2.md", "Alpha 2");

--- a/test/store/links.test.ts
+++ b/test/store/links.test.ts
@@ -891,6 +891,17 @@ describe("SqliteAdapter links", () => {
         markdown: 2,
         similar: 0,
       });
+      expect(graph.value.report.edgeConfidence).toEqual({
+        explicit: 3,
+        inferred: 0,
+        ambiguous: 0,
+        similarity: 0,
+      });
+      expect(graph.value.report.audit).toEqual({
+        inferredEdges: 0,
+        ambiguousEdges: 0,
+        similarityEdges: 0,
+      });
       expect(graph.value.links).toHaveLength(1);
       expect(graph.value.meta.truncated).toBe(true);
       expect(graph.value.meta.warnings).toContain("Edges truncated: 3 → 1");
@@ -944,6 +955,11 @@ describe("SqliteAdapter links", () => {
           link.source === sourceValue.docid && link.target === targetValue.docid
       );
       expect(edge).toBeDefined();
+      expect(edge?.confidence).toBe("inferred");
+      expect(edge?.audit).toEqual({
+        resolution: "path-fallback",
+        matchCount: 1,
+      });
     });
 
     test("resolves ambiguous basename deterministically by id", async () => {
@@ -985,6 +1001,13 @@ describe("SqliteAdapter links", () => {
         (link) => link.target === docAValue.docid
       );
       expect(edge).toBeDefined();
+      expect(edge?.confidence).toBe("ambiguous");
+      expect(edge?.audit).toEqual({
+        resolution: "ambiguous-fallback",
+        matchCount: 2,
+      });
+      expect(graph.value.report.edgeConfidence.ambiguous).toBe(1);
+      expect(graph.value.report.audit.ambiguousEdges).toBe(1);
       expect(
         graph.value.links.some((link) => link.target === docBValue.docid)
       ).toBe(false);

--- a/website/_data/features.yml
+++ b/website/_data/features.yml
@@ -154,10 +154,10 @@
 - slug: mcp-integration
   title: MCP Integration
   headline: Give Your AI Assistant Memory
-  description: Connect GNO to Claude Desktop, Cursor, Zed, Windsurf, Amp, Raycast, LM Studio, LibreChat, and more via MCP. 19 tools for search, retrieval, indexing, and graph exploration. Your AI assistant can search and cite your local documents.
+  description: Connect GNO to Claude Desktop, Cursor, Zed, Windsurf, Amp, Raycast, LM Studio, LibreChat, and more via MCP. 21 tools for search, retrieval, indexing, and graph exploration. Your AI assistant can search and cite your local documents.
   icon: mcp-integration
   benefits:
-    - 19 MCP tools (search, query, get, graph, capture, and more)
+    - 21 MCP tools (search, query, get, graph, graph path, capture, and more)
     - Works with Claude Desktop, Cursor, Zed, Windsurf, Amp
     - Also supports Raycast, LM Studio, LibreChat
     - Resource URIs for direct document access

--- a/website/_data/features.yml
+++ b/website/_data/features.yml
@@ -104,6 +104,7 @@
     - Collection management (add, remove, re-index)
     - Collection-level model editor with per-role overrides
     - Visual search with BM25, vector, and hybrid modes
+    - Graph-aware query expansion from linked notes
     - AI answers with citations
     - Interactive knowledge graph visualization
     - Instant refresh after edits with external-change awareness

--- a/website/_data/features.yml
+++ b/website/_data/features.yml
@@ -267,6 +267,7 @@
   benefits:
     - Interactive force-directed visualization
     - Wiki links, markdown links, and golden similarity edges
+    - Graph health report with hubs, unresolved links, and isolates
     - Filter by collection
     - Click nodes to navigate to documents
     - Zoom, pan, and explore

--- a/website/features/graph-view.md
+++ b/website/features/graph-view.md
@@ -148,7 +148,9 @@ curl "http://localhost:3000/api/graph?collection=notes&includeSimilar=true&limit
       "source": "doc-123",
       "target": "doc-456",
       "type": "wiki",
-      "weight": 1
+      "weight": 1,
+      "confidence": "explicit",
+      "audit": { "resolution": "exact-title", "matchCount": 1 }
     }
   ],
   "report": {
@@ -159,7 +161,14 @@ curl "http://localhost:3000/api/graph?collection=notes&includeSimilar=true&limit
       "total": 0,
       "byType": { "wiki": 0, "markdown": 0 }
     },
-    "edgeTypes": { "wiki": 1, "markdown": 0, "similar": 0 }
+    "edgeTypes": { "wiki": 1, "markdown": 0, "similar": 0 },
+    "edgeConfidence": {
+      "explicit": 1,
+      "inferred": 0,
+      "ambiguous": 0,
+      "similarity": 0
+    },
+    "audit": { "inferredEdges": 0, "ambiguousEdges": 0, "similarityEdges": 0 }
   },
   "meta": {
     "totalNodes": 150,

--- a/website/features/graph-view.md
+++ b/website/features/graph-view.md
@@ -74,6 +74,12 @@ gno graph
 # Filter by collection
 gno graph --collection notes
 
+# Expand around one document
+gno graph --neighbors gno://notes/auth.md
+
+# Explain how two docs connect
+gno graph --from gno://notes/a.md --to gno://notes/b.md
+
 # JSON output
 gno graph --json
 
@@ -86,15 +92,18 @@ gno graph --limit 500 --edge-limit 2000
 
 ### Options
 
-| Flag            | Description                 | Default |
-| --------------- | --------------------------- | ------- |
-| `--collection`  | Filter to single collection | all     |
-| `--limit`       | Max nodes to return         | 2000    |
-| `--edge-limit`  | Max edges to return         | 10000   |
-| `--similar`     | Include similarity edges    | false   |
-| `--threshold`   | Similarity threshold (0-1)  | 0.7     |
-| `--linked-only` | Exclude isolated nodes      | true    |
-| `--json`        | JSON output                 | false   |
+| Flag             | Description                 | Default |
+| ---------------- | --------------------------- | ------- |
+| `--collection`   | Filter to single collection | all     |
+| `--limit`        | Max nodes to return         | 2000    |
+| `--edge-limit`   | Max edges to return         | 10000   |
+| `--similar`      | Include similarity edges    | false   |
+| `--threshold`    | Similarity threshold (0-1)  | 0.7     |
+| `--linked-only`  | Exclude isolated nodes      | true    |
+| `--neighbors`    | Show graph neighbors        | -       |
+| `--from`, `--to` | Find shortest graph path    | -       |
+| `--max-depth`    | Max path hops               | 6       |
+| `--json`         | JSON output                 | false   |
 
 ## REST API
 

--- a/website/features/graph-view.md
+++ b/website/features/graph-view.md
@@ -32,6 +32,7 @@ See your document connections at a glance. The Knowledge Graph renders your note
 - **Wiki links**: `[[Document Name]]` connections shown as teal edges
 - **Markdown links**: `[text](path.md)` shown as lighter edges
 - **Similar documents**: Optional gold edges for semantically related notes (requires vector index)
+- **Graph health**: Header stats expose top-degree hubs, unresolved links, and isolated documents
 
 ## Web UI
 
@@ -141,6 +142,16 @@ curl "http://localhost:3000/api/graph?collection=notes&includeSimilar=true&limit
       "weight": 1
     }
   ],
+  "report": {
+    "hubs": [],
+    "bridgeCandidates": [],
+    "isolated": { "total": 0, "examples": [] },
+    "unresolvedLinks": {
+      "total": 0,
+      "byType": { "wiki": 0, "markdown": 0 }
+    },
+    "edgeTypes": { "wiki": 1, "markdown": 0, "similar": 0 }
+  },
   "meta": {
     "totalNodes": 150,
     "totalEdges": 320,

--- a/website/features/graph-view.md
+++ b/website/features/graph-view.md
@@ -53,6 +53,7 @@ gno serve
 ### Filtering
 
 - **Collection filter**: Focus on a single collection
+- **Community filter**: Focus on one detected cluster
 - **Similar toggle**: Show/hide semantic similarity edges (golden lines)
 
 ### Legend
@@ -62,6 +63,7 @@ The bottom-right legend shows edge types:
 - Teal: Wiki links (`[[...]]`)
 - Light teal: Markdown links (`[...](...)`)
 - Gold: Similarity connections (when enabled)
+- Community swatches: deterministic clusters for returned nodes
 
 ## CLI Access
 
@@ -140,7 +142,8 @@ curl "http://localhost:3000/api/graph?collection=notes&includeSimilar=true&limit
       "title": "My Note",
       "collection": "notes",
       "relPath": "my-note.md",
-      "degree": 5
+      "degree": 5,
+      "communityId": "c1"
     }
   ],
   "links": [
@@ -168,7 +171,14 @@ curl "http://localhost:3000/api/graph?collection=notes&includeSimilar=true&limit
       "ambiguous": 0,
       "similarity": 0
     },
-    "audit": { "inferredEdges": 0, "ambiguousEdges": 0, "similarityEdges": 0 }
+    "audit": { "inferredEdges": 0, "ambiguousEdges": 0, "similarityEdges": 0 },
+    "communities": {
+      "total": 3,
+      "algorithm": "deterministic-label-propagation",
+      "skipped": false,
+      "assignments": { "doc-123": "c1" },
+      "top": []
+    }
   },
   "meta": {
     "totalNodes": 150,

--- a/website/features/hybrid-search.md
+++ b/website/features/hybrid-search.md
@@ -55,6 +55,8 @@ The `query` command combines both methods using RRF, a proven algorithm that mer
 gno query "authentication best practices"
 ```
 
+`gno query` also uses the document graph as a bounded retrieval signal. It starts from the top BM25/vector seeds, adds capped one-hop neighbors, and weights explicit wiki/markdown links above inferred, ambiguous, or similarity edges before reranking.
+
 When stdout is a TTY, GNO can also wrap the visible `gno://...` result URI in a clickable terminal hyperlink that resolves to the source file path, with best-effort line hints when available.
 
 For teams tuning retrieval quality over time, GNO now also ships dedicated benchmark workflows for hybrid retrieval and code embeddings. See [Benchmarks](/features/benchmarks/).

--- a/website/features/mcp-integration.md
+++ b/website/features/mcp-integration.md
@@ -9,7 +9,7 @@ slug: mcp-integration
 permalink: /features/mcp-integration/
 og_image: /assets/images/og/og-mcp-integration.png
 benefits:
-  - 19 MCP tools for search, retrieval, graph, and indexing
+  - 21 MCP tools for search, retrieval, graph traversal, and indexing
   - Works with Claude Desktop, Cursor, Zed, Windsurf, Amp
   - Also supports Raycast, LM Studio, LibreChat
   - One-command install for 10+ clients
@@ -94,19 +94,21 @@ Once connected, your AI assistant can use:
 
 **Read Tools:**
 
-| Tool            | Description                    |
-| --------------- | ------------------------------ |
-| `gno_search`    | BM25 keyword search            |
-| `gno_vsearch`   | Vector similarity search       |
-| `gno_query`     | Hybrid search with reranking   |
-| `gno_get`       | Retrieve document content      |
-| `gno_multi_get` | Batch document retrieval       |
-| `gno_status`    | Check index status             |
-| `gno_list_tags` | List all tags                  |
-| `gno_links`     | Get outgoing links             |
-| `gno_backlinks` | Get incoming backlinks         |
-| `gno_similar`   | Find semantically similar docs |
-| `gno_graph`     | Knowledge graph data           |
+| Tool                  | Description                    |
+| --------------------- | ------------------------------ |
+| `gno_search`          | BM25 keyword search            |
+| `gno_vsearch`         | Vector similarity search       |
+| `gno_query`           | Hybrid search with reranking   |
+| `gno_get`             | Retrieve document content      |
+| `gno_multi_get`       | Batch document retrieval       |
+| `gno_status`          | Check index status             |
+| `gno_list_tags`       | List all tags                  |
+| `gno_links`           | Get outgoing links             |
+| `gno_backlinks`       | Get incoming backlinks         |
+| `gno_similar`         | Find semantically similar docs |
+| `gno_graph`           | Knowledge graph data           |
+| `gno_graph_neighbors` | Nearby graph relationships     |
+| `gno_graph_path`      | Shortest path between docs     |
 
 **Write Tools (opt-in with `--enable-write`):**
 


### PR DESCRIPTION
# Graph-Aware Retrieval and Agent Navigation

GNO now uses its existing document graph as a retrieval signal without replacing BM25/vector/rerank. Graph structure is exposed through reports, traversal tools, agent guidance, bounded query expansion, and community analysis.

> **Spec:** [fn-79-graph-aware-retrieval-and-agent](.flow/specs/fn-79-graph-aware-retrieval-and-agent.md)
> **Branch:** `feat/fn-79-graph-aware-retrieval-and-agent` -> `origin/main`
> **Tasks:** 6 completed
> **R-ID coverage:** 9/9 satisfied

## TL;DR

- Adds graph health reporting for hubs, bridge candidates, isolates, unresolved links, edge types, confidence, audit, and community structure.
- Exposes graph neighbor and shortest-path traversal through MCP and `gno graph`, with skill guidance for relationship-oriented agent workflows.
- Adds bounded graph-aware expansion inside `gno_query`, including confidence-weighted one-hop candidates, explain metadata, and `noGraph` controls.
- Keeps code-symbol graph work deferred behind ADR-006 and the existing fn-76 future symbol retrieval epic.

## R-ID coverage

| R-ID | Acceptance criterion | Task | Evidence |
|------|----------------------|------|----------|
| R1 | GNO can produce a graph report/stats summary over the current document graph, including hubs, isolated documents, unresolved links, and edge-type breakdown. | [fn-79-graph-aware-retrieval-and-agent.1](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md) | [`f22b0e9`](../../commit/f22b0e90d8424da30bab5c3e2c4ac388478529f6), `gno.sh:54b0380` |
| R2 | MCP exposes graph navigation tools for neighbors, paths, and graph stats/report, with tool descriptions that tell agents when to use them. | [fn-79-graph-aware-retrieval-and-agent.2](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md) | [`88a6a6d`](../../commit/88a6a6d2beda15e9ab343a7a49864187390ae6f3), [`50b2c30`](../../commit/50b2c308a18c0355acc185d78c3ccea6fe6673a7) |
| R3 | GNO records or derives graph edge confidence/audit metadata so explicit links, inferred fallbacks, and similarity edges are distinguishable. | [fn-79-graph-aware-retrieval-and-agent.3](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.3.md) | [`db0a84a`](../../commit/db0a84aa7437d305d884a088eb2443cb3fc3542b), `gno.sh:2902239` |
| R4 | `gno_query` can use bounded graph expansion as a retrieval adjunct, with tests showing fallback to current behavior when graph expansion is unavailable. | [fn-79-graph-aware-retrieval-and-agent.4](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.4.md) | [`b5e5aef`](../../commit/b5e5aef3c2638abdb589e5ec61a4d4acb1b4b2b6), `gno.sh:034fd99` |
| R5 | Community/cluster analysis is available for graph report/UI/agent navigation after the lower-level graph contracts are stable. | [fn-79-graph-aware-retrieval-and-agent.5](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.5.md) | [`d6035eb`](../../commit/d6035eb39271b8caf02221fb29252d784142cb7f), `gno.sh:2fb94d3` |
| R6 | Scoped code-symbol graph work is planned behind clear boundaries and does not block document-graph retrieval improvements. | [fn-79-graph-aware-retrieval-and-agent.6](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.6.md) | [`2a1068d`](../../commit/2a1068d90dafba29c544f6d35588c362f31f481b) |
| R7 | GNO skill instructions are updated so agents know the retrieval order: status when needed, query first, graph/link expansion for relationship context, then targeted document reads. | [fn-79-graph-aware-retrieval-and-agent.2](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.2.md) | [`88a6a6d`](../../commit/88a6a6d2beda15e9ab343a7a49864187390ae6f3), [`50b2c30`](../../commit/50b2c308a18c0355acc185d78c3ccea6fe6673a7) |
| R8 | User-facing docs, MCP docs, CLI/API docs, Web UI surfaces when affected, and hosted website content are updated in the same task that changes behavior. | [fn-79-graph-aware-retrieval-and-agent.1](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md) | [`f22b0e9`](../../commit/f22b0e90d8424da30bab5c3e2c4ac388478529f6), `gno.sh:54b0380` |
| R9 | Detailed automated tests cover store/API behavior, MCP schemas/tool output, retrieval ranking/expansion behavior, and docs verification. | [fn-79-graph-aware-retrieval-and-agent.1](.flow/tasks/fn-79-graph-aware-retrieval-and-agent.1.md) | [`f22b0e9`](../../commit/f22b0e90d8424da30bab5c3e2c4ac388478529f6), `gno.sh:54b0380` |

## Critical changes

- **High-churn:** [`test/pipeline/hybrid-doc-lookup.test.ts`](test/pipeline/hybrid-doc-lookup.test.ts) (+337/-0 lines)
- **High-churn:** [`src/mcp/tools/links.ts`](src/mcp/tools/links.ts) (+304/-7 lines)
- **High-churn:** [`src/store/sqlite/adapter.ts`](src/store/sqlite/adapter.ts) (+284/-16 lines)
- **High-churn:** [`src/serve/public/pages/GraphView.tsx`](src/serve/public/pages/GraphView.tsx) (+237/-16 lines)
- **High-churn:** [`src/cli/commands/graph.ts`](src/cli/commands/graph.ts) (+237/-4 lines)
- **Cross-module:** test/core imports src/core (new)
- **Cross-module:** test/mcp imports src/mcp (new)

## Structural changes

Graph analysis now sits below store/API/MCP/CLI/UI consumers and feeds both report output and retrieval explain metadata. The retrieval addition is isolated in [`src/pipeline/graph-retrieval.ts`](src/pipeline/graph-retrieval.ts), while graph topology analysis lives in [`src/core/graph-analysis.ts`](src/core/graph-analysis.ts). MCP and CLI traversal reuse the same graph contracts instead of creating a parallel graph schema.

```mermaid
flowchart TD
  Store["SQLite graph store"]
  Analysis["Graph analysis"]
  Report["Graph report/meta"]
  Traversal["CLI + MCP traversal"]
  Retrieval["Graph retrieval expansion"]
  UI["Graph + Search UI"]

  Store --> Analysis
  Analysis --> Report
  Report --> Traversal
  Report --> UI
  Store --> Retrieval
  Retrieval --> UI
```

## Where to look

- [`src/store/sqlite/adapter.ts`](src/store/sqlite/adapter.ts) and [`src/store/types.ts`](src/store/types.ts) for the graph contract, confidence/audit metadata, and report fields.
- [`src/pipeline/graph-retrieval.ts`](src/pipeline/graph-retrieval.ts), [`src/pipeline/hybrid.ts`](src/pipeline/hybrid.ts), and [`src/pipeline/fusion.ts`](src/pipeline/fusion.ts) for bounded graph expansion in hybrid query.
- [`src/mcp/tools/links.ts`](src/mcp/tools/links.ts), [`src/cli/commands/graph.ts`](src/cli/commands/graph.ts), and [`src/cli/program.ts`](src/cli/program.ts) for traversal surfaces.
- [`src/serve/public/pages/GraphView.tsx`](src/serve/public/pages/GraphView.tsx) and [`src/serve/public/pages/Search.tsx`](src/serve/public/pages/Search.tsx) for user-facing graph and retrieval controls.
- [`docs/adr/006-code-symbol-graph-foundation.md`](docs/adr/006-code-symbol-graph-foundation.md) for the code-symbol graph decision.

## Verification

- `bun run lint:check`
- `bun run typecheck`
- `bun test` - 1870 pass, 1 skip
- `bun run docs:verify`
- `cd website && mise exec -- make build`
- Hosted site repo `~/work/gno.sh`: workers ran `bun run check`, `bun run typecheck`, `bun test` where available, and `bun run build` across the docs updates.

Generated by /flow-next:make-pr from fn-79-graph-aware-retrieval-and-agent against origin/main on 2026-05-09.
