### PR TITLE
perf: improve CPU embedding defaults

### DIFF
--- a/.flow/epics/fn-80-cpu-embedding-autoresearch-and.json
+++ b/.flow/epics/fn-80-cpu-embedding-autoresearch-and.json
@@ -1,0 +1,13 @@
+{
+  "branch_name": "fn-80-cpu-embedding-autoresearch-and",
+  "created_at": "2026-05-25T16:05:49.517156Z",
+  "depends_on_epics": [],
+  "id": "fn-80-cpu-embedding-autoresearch-and",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-80-cpu-embedding-autoresearch-and.md",
+  "status": "open",
+  "title": "CPU embedding autoresearch and optimization",
+  "updated_at": "2026-05-25T16:06:00.647196Z"
+}

--- a/.flow/specs/fn-80-cpu-embedding-autoresearch-and.md
+++ b/.flow/specs/fn-80-cpu-embedding-autoresearch-and.md
@@ -1,0 +1,32 @@
+# CPU Embedding Autoresearch and Optimization
+
+## Goal & Context
+
+Investigate and optimize GNO's CPU embedding path after issue #115 showed CPU-only embedding can be unusably slow on Windows-era Ryzen hardware. Build a repeatable local autoresearch script that benchmarks the embedding pipeline and use it to validate changes.
+
+## Architecture & Data Models
+
+The work targets the shared embedding batch pipeline and CLI embedding command. The benchmark should isolate pipeline overhead and concurrency behavior without requiring real GPU hardware. Changes should preserve embedding recovery semantics, vector storage behavior, and existing CLI/API/MCP contracts.
+
+## API Contracts
+
+No public output schema changes unless required. Existing `gno embed` flags stay compatible. Any new env/options must be documented.
+
+## Edge Cases & Constraints
+
+Do not regress batch fallback, disposed-context recovery, low-memory Windows safety, or vector index syncing. CPU improvements must not force high RAM use by default. Benchmarks must be deterministic enough for local comparison.
+
+## Acceptance Criteria
+
+- [ ] Add a repeatable autoresearch/benchmark script for CPU embedding pipeline variants.
+- [ ] Identify at least one measurable CPU-path improvement or document why none is safe.
+- [ ] Add regression tests around changed embedding behavior.
+- [ ] Run focused tests, full tests, lint/typecheck, and docs verification.
+
+## Boundaries
+
+Do not add new third-party dependencies. Do not require actual CUDA/Vulkan hardware for the benchmark. Do not replace the default embedding model in this task unless evidence strongly supports it.
+
+## Decision Context
+
+A GPU remains the real solution for large transformer embeddings, but GNO should avoid avoidable CPU-side overhead and provide evidence-backed defaults.

--- a/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.json
+++ b/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-05-25T16:06:05.651188Z",
+  "depends_on": [],
+  "epic": "fn-80-cpu-embedding-autoresearch-and",
+  "id": "fn-80-cpu-embedding-autoresearch-and.1",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.md",
+  "status": "todo",
+  "title": "Benchmark and optimize CPU embedding path",
+  "updated_at": "2026-05-25T16:06:05.651311Z"
+}

--- a/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.md
+++ b/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.md
@@ -9,13 +9,16 @@ TBD
 - [ ] TBD
 
 ## Done summary
+
 Implemented CPU embedding autoresearch harness and adjusted Windows CPU context defaults.
 
 - Added `bun run bench:cpu-embeddings` synthetic native-async context benchmark.
 - Changed Windows CPU context heuristic: <16GB -> 1, 16GB-<24GB -> 2, >=24GB -> adaptive up to 4.
 - Updated docs/changelog and regression tests.
 - Benchmark evidence: 2 contexts ~1.98x, 4 contexts ~3.98x vs one context in synthetic native-async scheduling model.
+
 ## Evidence
+
 - Commits:
 - Tests:
 - PRs:

--- a/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.md
+++ b/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.1.md
@@ -1,0 +1,21 @@
+# fn-80-cpu-embedding-autoresearch-and.1 Benchmark and optimize CPU embedding path
+
+## Description
+
+TBD
+
+## Acceptance
+
+- [ ] TBD
+
+## Done summary
+Implemented CPU embedding autoresearch harness and adjusted Windows CPU context defaults.
+
+- Added `bun run bench:cpu-embeddings` synthetic native-async context benchmark.
+- Changed Windows CPU context heuristic: <16GB -> 1, 16GB-<24GB -> 2, >=24GB -> adaptive up to 4.
+- Updated docs/changelog and regression tests.
+- Benchmark evidence: 2 contexts ~1.98x, 4 contexts ~3.98x vs one context in synthetic native-async scheduling model.
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.json
+++ b/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-05-25T16:52:12.963649Z",
+  "depends_on": [],
+  "epic": "fn-80-cpu-embedding-autoresearch-and",
+  "id": "fn-80-cpu-embedding-autoresearch-and.2",
+  "priority": null,
+  "spec_path": ".flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.md",
+  "status": "todo",
+  "title": "Add real CPU embedding benchmark path",
+  "updated_at": "2026-05-25T16:52:12.963796Z"
+}

--- a/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.md
+++ b/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.md
@@ -1,0 +1,33 @@
+# fn-80-cpu-embedding-autoresearch-and.2 Add real CPU embedding benchmark path
+
+## Description
+
+Add a real-model mode to the CPU embedding autoresearch benchmark so context
+pool variants can be measured through production model/cache/embedding code.
+
+## Acceptance
+
+- [x] Script can still run synthetic scheduler benchmark without a cached model.
+- [x] Script can benchmark a real cached or downloaded GGUF embedding model.
+- [x] Output separates init/load time from timed embedding throughput.
+- [x] Docs/changelog mention the real-path benchmark mode.
+
+## Done summary
+
+Added --real mode to the CPU embedding autoresearch script so benchmark variants can run through LlmAdapter, ModelCache, NodeLlamaCppEmbedding, and node-llama-cpp with cached/downloaded GGUF models. Updated AGENTS and changelog.
+
+- Real-path local evidence: 1 context 66.4 chunks/s, 2 contexts 67.6 chunks/s,
+  4 contexts 68.7 chunks/s on the cached default GGUF model. On this machine,
+  extra contexts were effectively flat, so real-path data should drive future
+  tuning decisions over synthetic scheduler data.
+
+## Evidence
+
+- Commits:
+- Tests:
+  - `bun run bench:cpu-embeddings -- --chunks 32 --delay-ms 5 --dimensions 16`
+  - `bun run bench:cpu-embeddings -- --real --chunks 32 --warmup 4 --contexts 1,2,4`
+  - `bun test test/llm/embedding.test.ts test/embed/batch.test.ts test/embed/backlog.test.ts`
+  - `bun run lint:check`
+  - `bun run typecheck`
+- PRs:

--- a/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.md
+++ b/.flow/tasks/fn-80-cpu-embedding-autoresearch-and.2.md
@@ -20,6 +20,12 @@ Added --real mode to the CPU embedding autoresearch script so benchmark variants
   4 contexts 68.7 chunks/s on the cached default GGUF model. On this machine,
   extra contexts were effectively flat, so real-path data should drive future
   tuning decisions over synthetic scheduler data.
+- Follow-up iteration: production now pre-tokenizes embedding inputs to avoid
+  duplicate tokenization, avoids a duplicate vector array copy, caps automatic
+  CPU contexts at two while preserving `GNO_EMBED_CONTEXTS=4` as an explicit
+  override, and exposes real benchmark knobs for context size and threads.
+  512-chunk evidence after the cap: 1 context 71.7 chunks/s, 2 contexts 72.3
+  chunks/s, explicit 4 contexts 71.3 chunks/s.
 
 ## Evidence
 
@@ -30,4 +36,6 @@ Added --real mode to the CPU embedding autoresearch script so benchmark variants
   - `bun test test/llm/embedding.test.ts test/embed/batch.test.ts test/embed/backlog.test.ts`
   - `bun run lint:check`
   - `bun run typecheck`
+  - `bun run docs:verify`
+  - `bun test`
 - PRs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,17 +106,18 @@ bun run eval:watch    # Watch mode for development
 
 **scripts/** - Development and testing utilities (not published)
 
-| Script                      | Purpose                                                                                                                                                                            |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `perf-test.ts`              | Performance testing for search pipeline. Tests different configurations (expand/rerank combinations) and measures timing.                                                          |
-| `test-rerank-size.ts`       | Tests reranker performance at different document sizes (1K-128K chars). Used to identify optimal chunk size for reranking.                                                         |
-| `docs-verify.ts`            | Verifies documentation is up-to-date with implementation.                                                                                                                          |
-| `hybrid-benchmark.ts`       | Runs hybrid benchmark and writes baseline artifacts to `evals/fixtures/hybrid-baseline/`.                                                                                          |
-| `ast-chunking-benchmark.ts` | Compares heuristic code chunking with experimental tree-sitter AST chunking and writes evidence artifacts.                                                                         |
-| `cpu-embed-autoresearch.ts` | Benchmarks CPU embedding context-count variants with synthetic scheduling or real GGUF embedding paths, and prints the Windows memory heuristic used by the native embedding path. |
-| `generate-test-fixtures.ts` | Generates test fixtures for unit tests.                                                                                                                                            |
-| `og-screenshots.ts`         | Generates PNG screenshots from OG image HTML templates using Playwright.                                                                                                           |
-| `sync-assets.ts`            | Syncs all website assets: OG images, screenshots, README hero. Run before release.                                                                                                 |
+| Script                            | Purpose                                                                                                                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `perf-test.ts`                    | Performance testing for search pipeline. Tests different configurations (expand/rerank combinations) and measures timing.                                                          |
+| `test-rerank-size.ts`             | Tests reranker performance at different document sizes (1K-128K chars). Used to identify optimal chunk size for reranking.                                                         |
+| `docs-verify.ts`                  | Verifies documentation is up-to-date with implementation.                                                                                                                          |
+| `hybrid-benchmark.ts`             | Runs hybrid benchmark and writes baseline artifacts to `evals/fixtures/hybrid-baseline/`.                                                                                          |
+| `ast-chunking-benchmark.ts`       | Compares heuristic code chunking with experimental tree-sitter AST chunking and writes evidence artifacts.                                                                         |
+| `cpu-embed-autoresearch.ts`       | Benchmarks CPU embedding context-count variants with synthetic scheduling or real GGUF embedding paths, and prints the Windows memory heuristic used by the native embedding path. |
+| `native-embedding-batch-probe.ts` | Probes whether the installed node-llama-cpp binding can retrieve distinct embeddings from a multi-sequence native batch.                                                           |
+| `generate-test-fixtures.ts`       | Generates test fixtures for unit tests.                                                                                                                                            |
+| `og-screenshots.ts`               | Generates PNG screenshots from OG image HTML templates using Playwright.                                                                                                           |
+| `sync-assets.ts`                  | Syncs all website assets: OG images, screenshots, README hero. Run before release.                                                                                                 |
 
 **Usage:**
 
@@ -125,6 +126,7 @@ bun scripts/perf-test.ts           # Run full performance test suite
 bun scripts/test-rerank-size.ts    # Test rerank scaling with doc size
 bun run bench:cpu-embeddings       # Compare CPU embedding context scheduling variants
 bun run bench:cpu-embeddings -- --real --contexts 1,2,4 --chunks 128
+bun run bench:cpu-embeddings:native-batch-probe
 bun run bench:ast-chunking -- --fixture canonical --write
 bun run website:sync-assets        # Sync all website assets (OG, screenshots, hero)
 bun run website:sync-assets --og   # OG images only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,17 +106,17 @@ bun run eval:watch    # Watch mode for development
 
 **scripts/** - Development and testing utilities (not published)
 
-| Script                      | Purpose                                                                                                                    |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `perf-test.ts`              | Performance testing for search pipeline. Tests different configurations (expand/rerank combinations) and measures timing.  |
-| `test-rerank-size.ts`       | Tests reranker performance at different document sizes (1K-128K chars). Used to identify optimal chunk size for reranking. |
-| `docs-verify.ts`            | Verifies documentation is up-to-date with implementation.                                                                  |
-| `hybrid-benchmark.ts`       | Runs hybrid benchmark and writes baseline artifacts to `evals/fixtures/hybrid-baseline/`.                                  |
-| `ast-chunking-benchmark.ts` | Compares heuristic code chunking with experimental tree-sitter AST chunking and writes evidence artifacts.                 |
-| `cpu-embed-autoresearch.ts` | Benchmarks CPU embedding context-count variants and prints the Windows memory heuristic used by the native embedding path. |
-| `generate-test-fixtures.ts` | Generates test fixtures for unit tests.                                                                                    |
-| `og-screenshots.ts`         | Generates PNG screenshots from OG image HTML templates using Playwright.                                                   |
-| `sync-assets.ts`            | Syncs all website assets: OG images, screenshots, README hero. Run before release.                                         |
+| Script                      | Purpose                                                                                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `perf-test.ts`              | Performance testing for search pipeline. Tests different configurations (expand/rerank combinations) and measures timing.                                                          |
+| `test-rerank-size.ts`       | Tests reranker performance at different document sizes (1K-128K chars). Used to identify optimal chunk size for reranking.                                                         |
+| `docs-verify.ts`            | Verifies documentation is up-to-date with implementation.                                                                                                                          |
+| `hybrid-benchmark.ts`       | Runs hybrid benchmark and writes baseline artifacts to `evals/fixtures/hybrid-baseline/`.                                                                                          |
+| `ast-chunking-benchmark.ts` | Compares heuristic code chunking with experimental tree-sitter AST chunking and writes evidence artifacts.                                                                         |
+| `cpu-embed-autoresearch.ts` | Benchmarks CPU embedding context-count variants with synthetic scheduling or real GGUF embedding paths, and prints the Windows memory heuristic used by the native embedding path. |
+| `generate-test-fixtures.ts` | Generates test fixtures for unit tests.                                                                                                                                            |
+| `og-screenshots.ts`         | Generates PNG screenshots from OG image HTML templates using Playwright.                                                                                                           |
+| `sync-assets.ts`            | Syncs all website assets: OG images, screenshots, README hero. Run before release.                                                                                                 |
 
 **Usage:**
 
@@ -124,6 +124,7 @@ bun run eval:watch    # Watch mode for development
 bun scripts/perf-test.ts           # Run full performance test suite
 bun scripts/test-rerank-size.ts    # Test rerank scaling with doc size
 bun run bench:cpu-embeddings       # Compare CPU embedding context scheduling variants
+bun run bench:cpu-embeddings -- --real --contexts 1,2,4 --chunks 128
 bun run bench:ast-chunking -- --fixture canonical --write
 bun run website:sync-assets        # Sync all website assets (OG, screenshots, hero)
 bun run website:sync-assets --og   # OG images only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ bun run eval:watch    # Watch mode for development
 | `docs-verify.ts`            | Verifies documentation is up-to-date with implementation.                                                                  |
 | `hybrid-benchmark.ts`       | Runs hybrid benchmark and writes baseline artifacts to `evals/fixtures/hybrid-baseline/`.                                  |
 | `ast-chunking-benchmark.ts` | Compares heuristic code chunking with experimental tree-sitter AST chunking and writes evidence artifacts.                 |
+| `cpu-embed-autoresearch.ts` | Benchmarks CPU embedding context-count variants and prints the Windows memory heuristic used by the native embedding path. |
 | `generate-test-fixtures.ts` | Generates test fixtures for unit tests.                                                                                    |
 | `og-screenshots.ts`         | Generates PNG screenshots from OG image HTML templates using Playwright.                                                   |
 | `sync-assets.ts`            | Syncs all website assets: OG images, screenshots, README hero. Run before release.                                         |
@@ -122,6 +123,7 @@ bun run eval:watch    # Watch mode for development
 ```bash
 bun scripts/perf-test.ts           # Run full performance test suite
 bun scripts/test-rerank-size.ts    # Test rerank scaling with doc size
+bun run bench:cpu-embeddings       # Compare CPU embedding context scheduling variants
 bun run bench:ast-chunking -- --fixture canonical --write
 bun run website:sync-assets        # Sync all website assets (OG, screenshots, hero)
 bun run website:sync-assets --og   # OG images only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved Windows CPU embedding throughput defaults by using two native
+  embedding contexts on 16GB+ machines while keeping 8-12GB systems on a single
+  context.
+
+### Added
+
+- Added a CPU embedding autoresearch benchmark script for comparing context pool
+  variants and validating the Windows memory heuristic.
+
 ## [1.5.2] - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a CPU embedding autoresearch benchmark script for comparing context pool
   variants with synthetic scheduler checks or real cached/downloaded GGUF
   embedding runs, and validating the Windows memory heuristic.
+- Added a native embedding batch probe that verifies whether node-llama-cpp can
+  retrieve distinct embeddings from multi-sequence native batches.
 
 ## [1.5.2] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a CPU embedding autoresearch benchmark script for comparing context pool
-  variants and validating the Windows memory heuristic.
+  variants with synthetic scheduler checks or real cached/downloaded GGUF
+  embedding runs, and validating the Windows memory heuristic.
 
 ## [1.5.2] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improved Windows CPU embedding throughput defaults by using two native
-  embedding contexts on 16GB+ machines while keeping 8-12GB systems on a single
-  context.
+- Improved CPU embedding throughput defaults by using at most two native
+  embedding contexts automatically, keeping low-memory Windows systems on a
+  single context, and preserving `GNO_EMBED_CONTEXTS=4` as an explicit
+  benchmark-driven override.
 
 ### Added
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -468,6 +468,10 @@ Runtime/model env vars:
 | `GNO_EMBED_CONTEXTS`        | Override CPU embedding context count, clamped to `1`-`4`           |
 | `GNO_NO_AUTO_DOWNLOAD`      | Disable automatic model downloads; explicit `models pull` allowed  |
 
+On Windows CPU-only runs, GNO defaults to one embedding context below 16GB RAM,
+two contexts from 16GB, and the CPU-core heuristic from 24GB. Increase
+`GNO_EMBED_CONTEXTS` only when memory headroom is clear.
+
 ## File Locations
 
 **Linux** (XDG):

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -466,11 +466,13 @@ Runtime/model env vars:
 | `GNO_LLAMA_BUILD`           | Backend build mode: default `never`; set `autoAttempt` to opt in   |
 | `GNO_LLAMA_INIT_TIMEOUT_MS` | Backend initialization timeout; default `30000` ms                 |
 | `GNO_EMBED_CONTEXTS`        | Override CPU embedding context count, clamped to `1`-`4`           |
+| `GNO_EMBED_CONTEXT_SIZE`    | Override native embedding context size; minimum `128`              |
+| `GNO_EMBED_THREADS`         | Override CPU threads per embedding context                         |
 | `GNO_NO_AUTO_DOWNLOAD`      | Disable automatic model downloads; explicit `models pull` allowed  |
 
 On Windows CPU-only runs, GNO defaults to one embedding context below 16GB RAM,
-two contexts from 16GB, and the CPU-core heuristic from 24GB. Increase
-`GNO_EMBED_CONTEXTS` only when memory headroom is clear.
+and at most two contexts from 16GB upward. Increase `GNO_EMBED_CONTEXTS` only
+when memory headroom is clear and a real benchmark shows a gain.
 
 ## File Locations
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -532,9 +532,9 @@ debugging:
 GNO_LLAMA_INIT_TIMEOUT_MS=60000 gno doctor
 ```
 
-CPU embedding uses a small adaptive context pool. On low-memory Windows
-machines, GNO caps this to one context by default. Override only if you have
-headroom:
+CPU embedding uses a small adaptive context pool. On Windows, GNO keeps one
+context below 16GB RAM, uses two contexts from 16GB, and returns to the adaptive
+CPU-core heuristic from 24GB. Override only if you have headroom:
 
 ```bash
 GNO_EMBED_CONTEXTS=2 gno embed --yes

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -533,8 +533,8 @@ GNO_LLAMA_INIT_TIMEOUT_MS=60000 gno doctor
 ```
 
 CPU embedding uses a small adaptive context pool. On Windows, GNO keeps one
-context below 16GB RAM, uses two contexts from 16GB, and returns to the adaptive
-CPU-core heuristic from 24GB. Override only if you have headroom:
+context below 16GB RAM and uses at most two contexts from 16GB upward. Override
+only if you have headroom and `bench:cpu-embeddings -- --real` shows a gain:
 
 ```bash
 GNO_EMBED_CONTEXTS=2 gno embed --yes

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "bench:code-embeddings:write": "bun scripts/code-embedding-benchmark.ts --write",
     "bench:general-embeddings": "bun scripts/general-embedding-benchmark.ts",
     "bench:general-embeddings:write": "bun scripts/general-embedding-benchmark.ts --write",
+    "bench:cpu-embeddings": "bun scripts/cpu-embed-autoresearch.ts",
     "eval:retrieval-candidates": "bun scripts/retrieval-candidate-benchmark.ts",
     "eval:retrieval-candidates:write": "bun scripts/retrieval-candidate-benchmark.ts --write",
     "eval:watch": "bun --bun evalite watch",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "bench:general-embeddings": "bun scripts/general-embedding-benchmark.ts",
     "bench:general-embeddings:write": "bun scripts/general-embedding-benchmark.ts --write",
     "bench:cpu-embeddings": "bun scripts/cpu-embed-autoresearch.ts",
+    "bench:cpu-embeddings:native-batch-probe": "bun scripts/native-embedding-batch-probe.ts",
     "eval:retrieval-candidates": "bun scripts/retrieval-candidate-benchmark.ts",
     "eval:retrieval-candidates:write": "bun scripts/retrieval-candidate-benchmark.ts --write",
     "eval:watch": "bun --bun evalite watch",

--- a/scripts/cpu-embed-autoresearch.ts
+++ b/scripts/cpu-embed-autoresearch.ts
@@ -22,12 +22,14 @@ interface Args {
   allowDownload: boolean;
   chunks: number;
   configPath?: string;
+  contextSize?: number;
   delayMs: number;
   dimensions: number;
   contexts: number[];
   cpuCores: number;
   model?: string;
   real: boolean;
+  threads?: number;
   warmup: number;
 }
 
@@ -66,12 +68,14 @@ function parseArgs(argv: string[]): Args {
     allowDownload: false,
     chunks: 256,
     configPath: undefined,
+    contextSize: undefined,
     delayMs: 40,
     dimensions: 1024,
     contexts: DEFAULT_CONTEXTS,
     cpuCores: navigator.hardwareConcurrency || 8,
     model: undefined,
     real: false,
+    threads: undefined,
     warmup: 8,
   };
 
@@ -84,6 +88,9 @@ function parseArgs(argv: string[]): Args {
       case "--config":
         args.configPath = argv[(i += 1)];
         break;
+      case "--context-size":
+        args.contextSize = parsePositiveInt(argv[(i += 1)], 2_048);
+        break;
       case "--delay-ms":
         args.delayMs = parsePositiveInt(argv[(i += 1)], args.delayMs);
         break;
@@ -95,6 +102,9 @@ function parseArgs(argv: string[]): Args {
         break;
       case "--cpu-cores":
         args.cpuCores = parsePositiveInt(argv[(i += 1)], args.cpuCores);
+        break;
+      case "--threads":
+        args.threads = parsePositiveInt(argv[(i += 1)], args.cpuCores);
         break;
       case "--contexts":
         args.contexts = (argv[(i += 1)] ?? "")
@@ -136,11 +146,13 @@ Options:
   --model <uri>      Model URI/path for --real (default: active/default embed model)
   --allow-download   Allow --real to download the model if not cached
   --config <path>    Config path for --real model preset resolution
+  --context-size <n> GNO_EMBED_CONTEXT_SIZE override for --real
   --warmup <n>       Warmup chunks before timing --real (default: 8)
   --delay-ms <n>     Per-chunk mock native latency (default: 40)
   --dimensions <n>   Mock vector dimensions (default: 1024)
   --contexts <csv>   Context counts to compare (default: 1,2,4)
   --cpu-cores <n>    CPU core count for heuristic display
+  --threads <n>      GNO_EMBED_THREADS override for --real
 `);
 }
 
@@ -261,7 +273,15 @@ async function runRealVariant(
   texts: string[]
 ): Promise<BenchmarkResult> {
   const previousOverride = process.env.GNO_EMBED_CONTEXTS;
+  const previousThreads = process.env.GNO_EMBED_THREADS;
+  const previousContextSize = process.env.GNO_EMBED_CONTEXT_SIZE;
   process.env.GNO_EMBED_CONTEXTS = String(contexts);
+  if (args.threads !== undefined) {
+    process.env.GNO_EMBED_THREADS = String(args.threads);
+  }
+  if (args.contextSize !== undefined) {
+    process.env.GNO_EMBED_CONTEXT_SIZE = String(args.contextSize);
+  }
   const { adapter, port } = await createRealEmbeddingPort(args);
 
   try {
@@ -302,6 +322,16 @@ async function runRealVariant(
     } else {
       process.env.GNO_EMBED_CONTEXTS = previousOverride;
     }
+    if (previousThreads === undefined) {
+      delete process.env.GNO_EMBED_THREADS;
+    } else {
+      process.env.GNO_EMBED_THREADS = previousThreads;
+    }
+    if (previousContextSize === undefined) {
+      delete process.env.GNO_EMBED_CONTEXT_SIZE;
+    } else {
+      process.env.GNO_EMBED_CONTEXT_SIZE = previousContextSize;
+    }
   }
 }
 
@@ -326,6 +356,12 @@ function printHeuristic(args: Args): void {
     console.log(
       `Model: ${args.model ?? "active/default embed model"}; warmup: ${args.warmup} chunk(s)`
     );
+    if (args.threads !== undefined) {
+      console.log(`Threads per context override: ${args.threads}`);
+    }
+    if (args.contextSize !== undefined) {
+      console.log(`Context size override: ${args.contextSize}`);
+    }
   }
   const memoryCases = [12, 16, 24, Math.round(totalmem() / BYTES_PER_GIB)];
   console.log("Windows CPU context heuristic:");

--- a/scripts/cpu-embed-autoresearch.ts
+++ b/scripts/cpu-embed-autoresearch.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env bun
+/**
+ * CPU embedding autoresearch harness.
+ *
+ * This script benchmarks the scheduling behavior of GNO's native embedding
+ * context pool without requiring a local GGUF model. It uses delayed mock
+ * embedding contexts to measure the throughput impact of context-count choices
+ * and prints the same Windows memory heuristic that production uses.
+ */
+
+// Bun does not expose total system memory; node:os is the narrow runtime API.
+import { totalmem } from "node:os";
+
+import {
+  NodeLlamaCppEmbedding,
+  resolveEmbeddingContextPoolSize,
+} from "../src/llm/nodeLlamaCpp/embedding";
+
+interface Args {
+  chunks: number;
+  delayMs: number;
+  dimensions: number;
+  contexts: number[];
+  cpuCores: number;
+}
+
+interface BenchmarkResult {
+  contexts: number;
+  durationMs: number;
+  chunksPerSecond: number;
+  speedup: number;
+}
+
+const DEFAULT_CONTEXTS = [1, 2, 4];
+const BYTES_PER_GIB = 1024 * 1024 * 1024;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    chunks: 256,
+    delayMs: 40,
+    dimensions: 1024,
+    contexts: DEFAULT_CONTEXTS,
+    cpuCores: navigator.hardwareConcurrency || 8,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--chunks":
+        args.chunks = parsePositiveInt(argv[(i += 1)], args.chunks);
+        break;
+      case "--delay-ms":
+        args.delayMs = parsePositiveInt(argv[(i += 1)], args.delayMs);
+        break;
+      case "--dimensions":
+        args.dimensions = parsePositiveInt(argv[(i += 1)], args.dimensions);
+        break;
+      case "--cpu-cores":
+        args.cpuCores = parsePositiveInt(argv[(i += 1)], args.cpuCores);
+        break;
+      case "--contexts":
+        args.contexts = (argv[(i += 1)] ?? "")
+          .split(",")
+          .map((value) => Number.parseInt(value.trim(), 10))
+          .filter((value) => Number.isFinite(value) && value > 0);
+        if (args.contexts.length === 0) {
+          args.contexts = DEFAULT_CONTEXTS;
+        }
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+    }
+  }
+
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`CPU embedding autoresearch
+
+Usage:
+  bun scripts/cpu-embed-autoresearch.ts [options]
+
+Options:
+  --chunks <n>       Synthetic chunks to embed (default: 256)
+  --delay-ms <n>     Per-chunk mock native latency (default: 40)
+  --dimensions <n>   Mock vector dimensions (default: 1024)
+  --contexts <csv>   Context counts to compare (default: 1,2,4)
+  --cpu-cores <n>    CPU core count for heuristic display
+`);
+}
+
+function createManager(options: {
+  contexts: number;
+  cpuCores: number;
+  delayMs: number;
+  dimensions: number;
+}) {
+  let created = 0;
+  const vector = Array.from({ length: options.dimensions }, (_, index) =>
+    index % 2 === 0 ? 0.1 : -0.1
+  );
+
+  return {
+    getLlama: async () => ({
+      cpuMathCores: options.cpuCores,
+      gpu: false,
+    }),
+    loadModel: async () => ({
+      ok: true as const,
+      value: {
+        model: {
+          embeddingVectorSize: options.dimensions,
+          trainContextSize: 2_048,
+          tokenize: (text: string) => text.split(""),
+          detokenize: (tokens: readonly string[]) => tokens.join(""),
+          createEmbeddingContext: async () => {
+            created += 1;
+            if (created > options.contexts) {
+              throw new Error("context limit reached");
+            }
+            return {
+              dispose: async () => undefined,
+              getEmbeddingFor: async () => {
+                await Bun.sleep(options.delayMs);
+                return { vector };
+              },
+            };
+          },
+        },
+      },
+    }),
+  };
+}
+
+async function runVariant(
+  args: Args,
+  contexts: number
+): Promise<BenchmarkResult> {
+  const previousOverride = process.env.GNO_EMBED_CONTEXTS;
+  process.env.GNO_EMBED_CONTEXTS = String(contexts);
+  const manager = createManager({
+    contexts,
+    cpuCores: args.cpuCores,
+    delayMs: args.delayMs,
+    dimensions: args.dimensions,
+  });
+  const embedding = new NodeLlamaCppEmbedding(
+    manager as never,
+    "synthetic-cpu-embed",
+    "/tmp/synthetic.gguf"
+  );
+  const texts = Array.from({ length: args.chunks }, (_, index) => {
+    const suffix = index.toString().padStart(4, "0");
+    return `title: synthetic-${suffix} | text: ${"token ".repeat(96)}`;
+  });
+
+  const started = performance.now();
+  const result = await embedding.embedBatch(texts);
+  const durationMs = performance.now() - started;
+  await embedding.dispose();
+  if (previousOverride === undefined) {
+    delete process.env.GNO_EMBED_CONTEXTS;
+  } else {
+    process.env.GNO_EMBED_CONTEXTS = previousOverride;
+  }
+
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+
+  return {
+    contexts,
+    durationMs,
+    chunksPerSecond: args.chunks / (durationMs / 1000),
+    speedup: 1,
+  };
+}
+
+function printHeuristic(args: Args): void {
+  const memoryCases = [12, 16, 24, Math.round(totalmem() / BYTES_PER_GIB)];
+  console.log("Windows CPU context heuristic:");
+  for (const gib of [...new Set(memoryCases)].sort((a, b) => a - b)) {
+    const pool = resolveEmbeddingContextPoolSize({
+      gpu: false,
+      cpuMathCores: args.cpuCores,
+      platformName: "win32",
+      totalMemoryBytes: gib * BYTES_PER_GIB,
+    });
+    console.log(`  ${gib} GiB, ${args.cpuCores} cores -> ${pool} context(s)`);
+  }
+  console.log("");
+}
+
+function printResults(results: BenchmarkResult[]): void {
+  const baseline = results[0]?.chunksPerSecond ?? 1;
+  console.log("| contexts | duration | chunks/s | speedup |");
+  console.log("| ---: | ---: | ---: | ---: |");
+  for (const result of results) {
+    result.speedup = result.chunksPerSecond / baseline;
+    console.log(
+      `| ${result.contexts} | ${(result.durationMs / 1000).toFixed(2)}s | ${result.chunksPerSecond.toFixed(1)} | ${result.speedup.toFixed(2)}x |`
+    );
+  }
+}
+
+const args = parseArgs(Bun.argv.slice(2));
+printHeuristic(args);
+
+const results: BenchmarkResult[] = [];
+for (const contexts of args.contexts) {
+  results.push(await runVariant(args, contexts));
+}
+
+printResults(results);

--- a/scripts/cpu-embed-autoresearch.ts
+++ b/scripts/cpu-embed-autoresearch.ts
@@ -2,31 +2,39 @@
 /**
  * CPU embedding autoresearch harness.
  *
- * This script benchmarks the scheduling behavior of GNO's native embedding
- * context pool without requiring a local GGUF model. It uses delayed mock
- * embedding contexts to measure the throughput impact of context-count choices
- * and prints the same Windows memory heuristic that production uses.
+ * By default this script benchmarks GNO's embedding context-pool scheduler
+ * without requiring a local GGUF model. Use --real to run the same benchmark
+ * through the production LlmAdapter, ModelCache, NodeLlamaCppEmbedding, and
+ * node-llama-cpp code path with a cached or downloadable GGUF model.
  */
 
 // Bun does not expose total system memory; node:os is the narrow runtime API.
 import { totalmem } from "node:os";
 
+import { createDefaultConfig, loadConfig } from "../src/config";
+import { LlmAdapter } from "../src/llm/nodeLlamaCpp/adapter";
 import {
   NodeLlamaCppEmbedding,
   resolveEmbeddingContextPoolSize,
 } from "../src/llm/nodeLlamaCpp/embedding";
 
 interface Args {
+  allowDownload: boolean;
   chunks: number;
+  configPath?: string;
   delayMs: number;
   dimensions: number;
   contexts: number[];
   cpuCores: number;
+  model?: string;
+  real: boolean;
+  warmup: number;
 }
 
 interface BenchmarkResult {
   contexts: number;
   durationMs: number;
+  initMs?: number;
   chunksPerSecond: number;
   speedup: number;
 }
@@ -42,13 +50,29 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parseNonNegativeInt(
+  value: string | undefined,
+  fallback: number
+): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 function parseArgs(argv: string[]): Args {
   const args: Args = {
+    allowDownload: false,
     chunks: 256,
+    configPath: undefined,
     delayMs: 40,
     dimensions: 1024,
     contexts: DEFAULT_CONTEXTS,
     cpuCores: navigator.hardwareConcurrency || 8,
+    model: undefined,
+    real: false,
+    warmup: 8,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -57,11 +81,17 @@ function parseArgs(argv: string[]): Args {
       case "--chunks":
         args.chunks = parsePositiveInt(argv[(i += 1)], args.chunks);
         break;
+      case "--config":
+        args.configPath = argv[(i += 1)];
+        break;
       case "--delay-ms":
         args.delayMs = parsePositiveInt(argv[(i += 1)], args.delayMs);
         break;
       case "--dimensions":
         args.dimensions = parsePositiveInt(argv[(i += 1)], args.dimensions);
+        break;
+      case "--model":
+        args.model = argv[(i += 1)];
         break;
       case "--cpu-cores":
         args.cpuCores = parsePositiveInt(argv[(i += 1)], args.cpuCores);
@@ -74,6 +104,15 @@ function parseArgs(argv: string[]): Args {
         if (args.contexts.length === 0) {
           args.contexts = DEFAULT_CONTEXTS;
         }
+        break;
+      case "--allow-download":
+        args.allowDownload = true;
+        break;
+      case "--real":
+        args.real = true;
+        break;
+      case "--warmup":
+        args.warmup = parseNonNegativeInt(argv[(i += 1)], args.warmup);
         break;
       case "--help":
       case "-h":
@@ -93,6 +132,11 @@ Usage:
 
 Options:
   --chunks <n>       Synthetic chunks to embed (default: 256)
+  --real             Use production GGUF embedding path instead of synthetic mocks
+  --model <uri>      Model URI/path for --real (default: active/default embed model)
+  --allow-download   Allow --real to download the model if not cached
+  --config <path>    Config path for --real model preset resolution
+  --warmup <n>       Warmup chunks before timing --real (default: 8)
   --delay-ms <n>     Per-chunk mock native latency (default: 40)
   --dimensions <n>   Mock vector dimensions (default: 1024)
   --contexts <csv>   Context counts to compare (default: 1,2,4)
@@ -187,7 +231,102 @@ async function runVariant(
   };
 }
 
+async function createRealEmbeddingPort(args: Args) {
+  const config =
+    args.configPath === undefined
+      ? createDefaultConfig()
+      : await loadConfig(args.configPath).then((result) => {
+          if (!result.ok) {
+            throw new Error(result.error.message);
+          }
+          return result.value;
+        });
+  const adapter = new LlmAdapter(config);
+  const portResult = await adapter.createEmbeddingPort(args.model, {
+    policy: {
+      allowDownload: args.allowDownload,
+      offline: !args.allowDownload,
+    },
+  });
+  if (!portResult.ok) {
+    await adapter.dispose();
+    throw new Error(portResult.error.message);
+  }
+  return { adapter, port: portResult.value };
+}
+
+async function runRealVariant(
+  args: Args,
+  contexts: number,
+  texts: string[]
+): Promise<BenchmarkResult> {
+  const previousOverride = process.env.GNO_EMBED_CONTEXTS;
+  process.env.GNO_EMBED_CONTEXTS = String(contexts);
+  const { adapter, port } = await createRealEmbeddingPort(args);
+
+  try {
+    const initStarted = performance.now();
+    const initResult = await port.init();
+    const initMs = performance.now() - initStarted;
+    if (!initResult.ok) {
+      throw new Error(initResult.error.message);
+    }
+
+    if (args.warmup > 0) {
+      const warmupTexts = texts.slice(0, Math.min(args.warmup, texts.length));
+      const warmupResult = await port.embedBatch(warmupTexts);
+      if (!warmupResult.ok) {
+        throw new Error(warmupResult.error.message);
+      }
+    }
+
+    const started = performance.now();
+    const result = await port.embedBatch(texts);
+    const durationMs = performance.now() - started;
+    if (!result.ok) {
+      throw new Error(result.error.message);
+    }
+
+    return {
+      contexts,
+      durationMs,
+      initMs,
+      chunksPerSecond: args.chunks / (durationMs / 1000),
+      speedup: 1,
+    };
+  } finally {
+    await port.dispose();
+    await adapter.dispose();
+    if (previousOverride === undefined) {
+      delete process.env.GNO_EMBED_CONTEXTS;
+    } else {
+      process.env.GNO_EMBED_CONTEXTS = previousOverride;
+    }
+  }
+}
+
+function createBenchmarkTexts(chunks: number): string[] {
+  return Array.from({ length: chunks }, (_, index) => {
+    const suffix = index.toString().padStart(4, "0");
+    const body = [
+      "CPU embedding benchmark chunk",
+      suffix,
+      "with mixed prose, code identifiers, filenames, and repeated project terms.",
+      "The benchmark intentionally resembles indexed note chunks rather than one-word inputs.",
+      "query embedding retrieval sqlite vector llama context scheduling windows cpu throughput",
+    ].join(" ");
+    return `title: cpu-embed-${suffix}\ntext: ${body}`;
+  });
+}
+
 function printHeuristic(args: Args): void {
+  const mode = args.real ? "real GGUF path" : "synthetic scheduler path";
+  console.log(`Mode: ${mode}`);
+  if (args.real) {
+    console.log(
+      `Model: ${args.model ?? "active/default embed model"}; warmup: ${args.warmup} chunk(s)`
+    );
+  }
   const memoryCases = [12, 16, 24, Math.round(totalmem() / BYTES_PER_GIB)];
   console.log("Windows CPU context heuristic:");
   for (const gib of [...new Set(memoryCases)].sort((a, b) => a - b)) {
@@ -204,13 +343,25 @@ function printHeuristic(args: Args): void {
 
 function printResults(results: BenchmarkResult[]): void {
   const baseline = results[0]?.chunksPerSecond ?? 1;
-  console.log("| contexts | duration | chunks/s | speedup |");
-  console.log("| ---: | ---: | ---: | ---: |");
+  const hasInit = results.some((result) => result.initMs !== undefined);
+  if (hasInit) {
+    console.log("| contexts | init | embed duration | chunks/s | speedup |");
+    console.log("| ---: | ---: | ---: | ---: | ---: |");
+  } else {
+    console.log("| contexts | duration | chunks/s | speedup |");
+    console.log("| ---: | ---: | ---: | ---: |");
+  }
   for (const result of results) {
     result.speedup = result.chunksPerSecond / baseline;
-    console.log(
-      `| ${result.contexts} | ${(result.durationMs / 1000).toFixed(2)}s | ${result.chunksPerSecond.toFixed(1)} | ${result.speedup.toFixed(2)}x |`
-    );
+    if (hasInit) {
+      console.log(
+        `| ${result.contexts} | ${((result.initMs ?? 0) / 1000).toFixed(2)}s | ${(result.durationMs / 1000).toFixed(2)}s | ${result.chunksPerSecond.toFixed(1)} | ${result.speedup.toFixed(2)}x |`
+      );
+    } else {
+      console.log(
+        `| ${result.contexts} | ${(result.durationMs / 1000).toFixed(2)}s | ${result.chunksPerSecond.toFixed(1)} | ${result.speedup.toFixed(2)}x |`
+      );
+    }
   }
 }
 
@@ -218,8 +369,13 @@ const args = parseArgs(Bun.argv.slice(2));
 printHeuristic(args);
 
 const results: BenchmarkResult[] = [];
+const texts = createBenchmarkTexts(args.chunks);
 for (const contexts of args.contexts) {
-  results.push(await runVariant(args, contexts));
+  if (args.real) {
+    results.push(await runRealVariant(args, contexts, texts));
+  } else {
+    results.push(await runVariant(args, contexts));
+  }
 }
 
 printResults(results);

--- a/scripts/native-embedding-batch-probe.ts
+++ b/scripts/native-embedding-batch-probe.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env bun
+/**
+ * Probe node-llama-cpp internals for true native multi-sequence embedding.
+ *
+ * This is intentionally a development-only probe. It verifies whether the
+ * installed node-llama-cpp binding can evaluate multiple embedding sequences in
+ * one native batch and then retrieve a distinct embedding vector for each
+ * sequence.
+ */
+
+import { createDefaultConfig } from "../src/config";
+import { LlmAdapter } from "../src/llm/nodeLlamaCpp/adapter";
+
+interface ProbeArgs {
+  allowDownload: boolean;
+  model?: string;
+  sequences: number;
+}
+
+interface InternalModel {
+  createContext(options: Record<string, unknown>): Promise<InternalContext>;
+  tokenize(text: string): number[];
+}
+
+interface InternalContext {
+  readonly batchSize: number;
+  readonly totalSequences: number;
+  _ctx: {
+    getEmbedding(
+      inputTokensLength: number,
+      maxVectorSize?: number
+    ): Float64Array;
+  };
+  dispose(): Promise<void>;
+  getSequence(): InternalSequence;
+}
+
+interface InternalSequence {
+  readonly _sequenceId: number;
+  readonly nextTokenIndex: number;
+  dispose(): void;
+  evaluateWithoutGeneratingNewTokens(
+    tokens: number[],
+    options?: Record<string, unknown>
+  ): Promise<void>;
+}
+
+interface InternalEmbeddingPort {
+  readonly modelUri: string;
+  dimensions(): number;
+  dispose(): Promise<void>;
+  init(): Promise<{ ok: true; value: void } | { ok: false; error: Error }>;
+  llamaModel?: InternalModel;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseArgs(argv: string[]): ProbeArgs {
+  const args: ProbeArgs = {
+    allowDownload: false,
+    model: undefined,
+    sequences: 4,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    switch (argv[i]) {
+      case "--allow-download":
+        args.allowDownload = true;
+        break;
+      case "--model":
+        args.model = argv[(i += 1)];
+        break;
+      case "--sequences":
+        args.sequences = parsePositiveInt(argv[(i += 1)], args.sequences);
+        break;
+      case "--help":
+      case "-h":
+        printHelp();
+        process.exit(0);
+    }
+  }
+
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`Native embedding batch probe
+
+Usage:
+  bun scripts/native-embedding-batch-probe.ts [options]
+
+Options:
+  --model <uri>      Model URI/path (default: active/default embed model)
+  --allow-download   Allow model download if not cached
+  --sequences <n>    Native context sequences to probe (default: 4)
+`);
+}
+
+function formatPrefix(values: Float64Array, length = 5): string {
+  return Array.from(values.slice(0, length))
+    .map((value) => value.toFixed(4))
+    .join(", ");
+}
+
+const args = parseArgs(Bun.argv.slice(2));
+const adapter = new LlmAdapter(createDefaultConfig());
+const portResult = await adapter.createEmbeddingPort(args.model, {
+  policy: {
+    allowDownload: args.allowDownload,
+    offline: !args.allowDownload,
+  },
+});
+
+if (!portResult.ok) {
+  throw new Error(portResult.error.message);
+}
+
+const port = portResult.value as unknown as InternalEmbeddingPort;
+try {
+  const initResult = await port.init();
+  if (!initResult.ok) {
+    throw new Error(initResult.error.message);
+  }
+
+  const model = port.llamaModel;
+  if (!model) {
+    throw new Error("Embedding model internals unavailable after init");
+  }
+
+  const context = await model.createContext({
+    _embeddings: true,
+    batchSize: 512,
+    contextSize: 256,
+    sequences: args.sequences,
+  });
+
+  try {
+    const texts = Array.from(
+      { length: args.sequences },
+      (_, index) =>
+        `native batch probe document ${index} ${"token ".repeat(16)}`
+    );
+    const sequences = texts.map(() => context.getSequence());
+    const started = performance.now();
+    await Promise.all(
+      sequences.map((sequence, index) =>
+        sequence.evaluateWithoutGeneratingNewTokens(
+          model.tokenize(texts[index] ?? "")
+        )
+      )
+    );
+    const durationMs = performance.now() - started;
+
+    console.log(`Model: ${port.modelUri}`);
+    console.log(`Context sequences: ${context.totalSequences}`);
+    console.log(`Native batch size: ${context.batchSize}`);
+    console.log(`Decode duration: ${(durationMs / 1000).toFixed(3)}s`);
+    console.log("");
+    console.log(
+      "| sequence | token length | getEmbedding(len) | getEmbedding(len, seqId) length |"
+    );
+    console.log("| ---: | ---: | --- | ---: |");
+
+    let distinctRetrievalSupported = true;
+    for (const sequence of sequences) {
+      const defaultVector = context._ctx.getEmbedding(sequence.nextTokenIndex);
+      const seqVector = context._ctx.getEmbedding(
+        sequence.nextTokenIndex,
+        sequence._sequenceId
+      );
+      if (seqVector.length !== port.dimensions()) {
+        distinctRetrievalSupported = false;
+      }
+      console.log(
+        `| ${sequence._sequenceId} | ${sequence.nextTokenIndex} | ${formatPrefix(defaultVector)} | ${seqVector.length} |`
+      );
+      sequence.dispose();
+    }
+
+    console.log("");
+    if (distinctRetrievalSupported) {
+      console.log(
+        "Result: native per-sequence embedding retrieval appears supported."
+      );
+    } else {
+      console.log(
+        "Result: blocked. The binding's second getEmbedding argument is maxVectorSize, not sequence id."
+      );
+    }
+  } finally {
+    await context.dispose();
+  }
+} finally {
+  await port.dispose();
+  await adapter.dispose();
+}

--- a/src/llm/nodeLlamaCpp/embedding.ts
+++ b/src/llm/nodeLlamaCpp/embedding.ts
@@ -39,6 +39,8 @@ interface TokenizingModel {
   detokenize(tokens: readonly number[]): string;
 }
 
+type EmbeddingInput = Parameters<LlamaEmbeddingContext["getEmbeddingFor"]>[0];
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
@@ -46,13 +48,18 @@ interface TokenizingModel {
 // Aim for a small pool so CPU-only runs can exploit parallel contexts without
 // multiplying RAM usage too aggressively. Additional contexts fall back
 // gracefully if memory is tight.
-const MAX_EMBEDDING_CONTEXTS = 4;
+const MAX_DEFAULT_EMBEDDING_CONTEXTS = 2;
+const MAX_EMBEDDING_CONTEXTS_OVERRIDE = 4;
 const TARGET_CORES_PER_EMBEDDING_CONTEXT = 4;
 const CONSTRAINED_WINDOWS_THRESHOLD_BYTES = 16 * 1024 * 1024 * 1024;
 const MID_MEMORY_WINDOWS_THRESHOLD_BYTES = 24 * 1024 * 1024 * 1024;
 const LOW_MEMORY_WINDOWS_CONTEXTS = 1;
 const MID_MEMORY_WINDOWS_CONTEXTS = 2;
 const DEFAULT_EMBEDDING_CONTEXT_SIZE = 2_048;
+
+function embeddingVectorToArray(vector: readonly number[]): number[] {
+  return Array.isArray(vector) ? (vector as number[]) : Array.from(vector);
+}
 
 function resolveEmbeddingContextPoolOverride(
   env: NodeJS.ProcessEnv = process.env
@@ -65,7 +72,35 @@ function resolveEmbeddingContextPoolOverride(
   if (!(Number.isFinite(parsed) && parsed > 0)) {
     return undefined;
   }
-  return Math.max(1, Math.min(MAX_EMBEDDING_CONTEXTS, parsed));
+  return Math.max(1, Math.min(MAX_EMBEDDING_CONTEXTS_OVERRIDE, parsed));
+}
+
+function resolveThreadsPerContextOverride(
+  env: NodeJS.ProcessEnv = process.env
+): number | undefined {
+  const raw = env.GNO_EMBED_THREADS;
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!(Number.isFinite(parsed) && parsed > 0)) {
+    return undefined;
+  }
+  return Math.max(1, parsed);
+}
+
+function resolveEmbeddingContextSizeOverride(
+  env: NodeJS.ProcessEnv = process.env
+): number | undefined {
+  const raw = env.GNO_EMBED_CONTEXT_SIZE;
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!(Number.isFinite(parsed) && parsed > 0)) {
+    return undefined;
+  }
+  return Math.max(128, parsed);
 }
 
 export function resolveEmbeddingContextPoolSize(options: {
@@ -97,7 +132,7 @@ export function resolveEmbeddingContextPoolSize(options: {
   const adaptivePoolSize = Math.max(
     1,
     Math.min(
-      MAX_EMBEDDING_CONTEXTS,
+      MAX_DEFAULT_EMBEDDING_CONTEXTS,
       Math.ceil(cpuMathCores / TARGET_CORES_PER_EMBEDDING_CONTEXT)
     )
   );
@@ -156,9 +191,9 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
         return { ok: false, error: prepared.error };
       }
       const embedding = await this.runOnWorker((worker) =>
-        worker.context.getEmbeddingFor(prepared.value.text)
+        worker.context.getEmbeddingFor(prepared.value.input)
       );
-      const vector = Array.from(embedding.vector) as number[];
+      const vector = embeddingVectorToArray(embedding.vector);
 
       // Cache dimensions on first call
       if (this.dims === null) {
@@ -182,13 +217,13 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
     }
 
     try {
-      const preparedTexts: string[] = [];
+      const preparedInputs: EmbeddingInput[] = [];
       for (const text of texts) {
         const prepared = this.truncateForEmbedding(text, "batch");
         if (!prepared.ok) {
           return { ok: false, error: prepared.error };
         }
-        preparedTexts.push(prepared.value.text);
+        preparedInputs.push(prepared.value.input);
       }
 
       const allResults = Array.from(
@@ -202,16 +237,19 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
           while (true) {
             const index = nextIndex;
             nextIndex += 1;
-            if (index >= preparedTexts.length) {
+            if (index >= preparedInputs.length) {
               return;
             }
 
+            const input = preparedInputs[index];
+            if (input === undefined) {
+              return;
+            }
             const embedding = await this.runOnSpecificWorker(
               worker,
-              (current) =>
-                current.context.getEmbeddingFor(preparedTexts[index] as string)
+              (current) => current.context.getEmbeddingFor(input)
             );
-            allResults[index] = Array.from(embedding.vector) as number[];
+            allResults[index] = embeddingVectorToArray(embedding.vector);
           }
         })
       );
@@ -327,6 +365,11 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
       return 0;
     }
 
+    const override = resolveThreadsPerContextOverride();
+    if (override !== undefined) {
+      return override;
+    }
+
     return Math.max(1, Math.floor(Math.max(1, llama.cpuMathCores) / poolSize));
   }
 
@@ -346,6 +389,8 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
       this.llamaModel = llamaModel as TokenizingModel;
       const llama = await this.manager.getLlama();
       const lifecycleVersion = this.lifecycleVersion;
+      this.embeddingContextSize =
+        resolveEmbeddingContextSizeOverride() ?? DEFAULT_EMBEDDING_CONTEXT_SIZE;
       const targetPoolSize = this.resolveTargetPoolSize(llama);
       const threadsPerContext = this.resolveThreadsPerContext(
         llama,
@@ -411,7 +456,7 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
   private truncateForEmbedding(
     text: string,
     mode: "single" | "batch"
-  ): LlmResult<{ text: string }> {
+  ): LlmResult<{ input: EmbeddingInput }> {
     const model = this.llamaModel;
     const modelLimit =
       typeof model?.trainContextSize === "number" &&
@@ -420,7 +465,7 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
         ? Math.floor(model.trainContextSize)
         : undefined;
     if (!model) {
-      return { ok: true, value: { text } };
+      return { ok: true, value: { input: text } };
     }
 
     const rawLimit =
@@ -431,10 +476,13 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
     try {
       const tokens = model.tokenize(text);
       if (tokens.length <= limit) {
-        return { ok: true, value: { text } };
+        return {
+          ok: true,
+          value: { input: tokens as EmbeddingInput },
+        };
       }
 
-      const truncatedText = model.detokenize(tokens.slice(0, limit));
+      const truncatedTokens = tokens.slice(0, limit);
       const shouldWarn =
         mode === "single"
           ? !this.warnedSingleTruncation
@@ -449,7 +497,10 @@ export class NodeLlamaCppEmbedding implements EmbeddingPort {
           `[llama] Truncated embedding input from ${tokens.length} to ${limit} tokens`
         );
       }
-      return { ok: true, value: { text: truncatedText } };
+      return {
+        ok: true,
+        value: { input: truncatedTokens as EmbeddingInput },
+      };
     } catch (error) {
       return { ok: false, error: inferenceFailedError(this.modelUri, error) };
     }

--- a/src/llm/nodeLlamaCpp/embedding.ts
+++ b/src/llm/nodeLlamaCpp/embedding.ts
@@ -48,8 +48,10 @@ interface TokenizingModel {
 // gracefully if memory is tight.
 const MAX_EMBEDDING_CONTEXTS = 4;
 const TARGET_CORES_PER_EMBEDDING_CONTEXT = 4;
-const LOW_MEMORY_WINDOWS_THRESHOLD_BYTES = 24 * 1024 * 1024 * 1024;
+const CONSTRAINED_WINDOWS_THRESHOLD_BYTES = 16 * 1024 * 1024 * 1024;
+const MID_MEMORY_WINDOWS_THRESHOLD_BYTES = 24 * 1024 * 1024 * 1024;
 const LOW_MEMORY_WINDOWS_CONTEXTS = 1;
+const MID_MEMORY_WINDOWS_CONTEXTS = 2;
 const DEFAULT_EMBEDDING_CONTEXT_SIZE = 2_048;
 
 function resolveEmbeddingContextPoolOverride(
@@ -86,19 +88,28 @@ export function resolveEmbeddingContextPoolSize(options: {
   const totalMemoryBytes = options.totalMemoryBytes ?? totalmem();
   if (
     platformName === "win32" &&
-    totalMemoryBytes <= LOW_MEMORY_WINDOWS_THRESHOLD_BYTES
+    totalMemoryBytes < CONSTRAINED_WINDOWS_THRESHOLD_BYTES
   ) {
     return LOW_MEMORY_WINDOWS_CONTEXTS;
   }
 
   const cpuMathCores = Math.max(1, options.cpuMathCores);
-  return Math.max(
+  const adaptivePoolSize = Math.max(
     1,
     Math.min(
       MAX_EMBEDDING_CONTEXTS,
       Math.ceil(cpuMathCores / TARGET_CORES_PER_EMBEDDING_CONTEXT)
     )
   );
+
+  if (
+    platformName === "win32" &&
+    totalMemoryBytes < MID_MEMORY_WINDOWS_THRESHOLD_BYTES
+  ) {
+    return Math.min(MID_MEMORY_WINDOWS_CONTEXTS, adaptivePoolSize);
+  }
+
+  return adaptivePoolSize;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/llm/embedding.test.ts
+++ b/test/llm/embedding.test.ts
@@ -8,20 +8,22 @@ import {
 interface MockEmbeddingContext {
   dispose: ReturnType<typeof mock<() => Promise<void>>>;
   getEmbeddingFor: ReturnType<
-    typeof mock<(text: string) => Promise<{ vector: number[] }>>
+    typeof mock<
+      (input: string | readonly number[]) => Promise<{ vector: number[] }>
+    >
   >;
 }
 
 function createContext(
   contextId: number,
-  calls: Array<{ contextId: number; text: string }>
+  calls: Array<{ contextId: number; input: string | readonly number[] }>
 ): MockEmbeddingContext {
   return {
     dispose: mock(() => Promise.resolve()),
-    getEmbeddingFor: mock(async (text: string) => {
-      calls.push({ contextId, text });
+    getEmbeddingFor: mock(async (input: string | readonly number[]) => {
+      calls.push({ contextId, input });
       await Promise.resolve();
-      return { vector: [contextId, text.length] };
+      return { vector: [contextId, input.length] };
     }),
   };
 }
@@ -33,7 +35,8 @@ function createManager(options?: {
   failAtContextIndex?: number;
   trainContextSize?: number;
 }) {
-  const calls: Array<{ contextId: number; text: string }> = [];
+  const calls: Array<{ contextId: number; input: string | readonly number[] }> =
+    [];
   let createContextCallCount = 0;
   const contexts = options?.contexts ?? [
     createContext(1, calls),
@@ -47,18 +50,23 @@ function createManager(options?: {
     options?.gpu === false || options?.gpu === undefined
       ? process.env.GNO_EMBED_CONTEXTS
         ? Number.parseInt(process.env.GNO_EMBED_CONTEXTS, 10)
-        : Math.max(1, Math.min(4, Math.ceil(resolvedCpuMathCores / 4)))
+        : Math.max(1, Math.min(2, Math.ceil(resolvedCpuMathCores / 4)))
       : 1;
   const expectedOptions =
     options?.gpu === false || options?.gpu === undefined
       ? {
-          contextSize: 2_048,
-          threads: Math.max(
-            1,
-            Math.floor(resolvedCpuMathCores / resolvedPoolSize)
-          ),
+          contextSize: process.env.GNO_EMBED_CONTEXT_SIZE
+            ? Number.parseInt(process.env.GNO_EMBED_CONTEXT_SIZE, 10)
+            : 2_048,
+          threads: process.env.GNO_EMBED_THREADS
+            ? Number.parseInt(process.env.GNO_EMBED_THREADS, 10)
+            : Math.max(1, Math.floor(resolvedCpuMathCores / resolvedPoolSize)),
         }
-      : { contextSize: 2_048 };
+      : {
+          contextSize: process.env.GNO_EMBED_CONTEXT_SIZE
+            ? Number.parseInt(process.env.GNO_EMBED_CONTEXT_SIZE, 10)
+            : 2_048,
+        };
 
   const createEmbeddingContext = mock(async (opts?: { threads?: number }) => {
     const currentIndex = createContextCallCount;
@@ -89,8 +97,10 @@ function createManager(options?: {
           createEmbeddingContext,
           embeddingVectorSize: 2,
           trainContextSize: options?.trainContextSize,
-          tokenize: (text: string) => text.split(""),
-          detokenize: (tokens: readonly string[]) => tokens.join(""),
+          tokenize: (text: string) =>
+            Array.from(text, (char) => char.charCodeAt(0)),
+          detokenize: (tokens: readonly number[]) =>
+            tokens.map((token) => String.fromCharCode(token)).join(""),
         },
       },
     })),
@@ -102,6 +112,8 @@ function createManager(options?: {
 describe("NodeLlamaCppEmbedding", () => {
   afterEach(() => {
     delete process.env.GNO_EMBED_CONTEXTS;
+    delete process.env.GNO_EMBED_CONTEXT_SIZE;
+    delete process.env.GNO_EMBED_THREADS;
   });
 
   test("keeps CPU context pool single on constrained Windows machines", () => {
@@ -126,7 +138,7 @@ describe("NodeLlamaCppEmbedding", () => {
     ).toBe(2);
   });
 
-  test("uses adaptive CPU context pool on 24GB Windows machines", () => {
+  test("caps default adaptive CPU context pool at two on 24GB Windows machines", () => {
     expect(
       resolveEmbeddingContextPoolSize({
         gpu: false,
@@ -134,10 +146,10 @@ describe("NodeLlamaCppEmbedding", () => {
         platformName: "win32",
         totalMemoryBytes: 24 * 1024 * 1024 * 1024,
       })
-    ).toBe(4);
+    ).toBe(2);
   });
 
-  test("keeps CPU context pool adaptive outside low-memory Windows", () => {
+  test("keeps CPU context pool adaptive outside low-memory Windows capped at two", () => {
     expect(
       resolveEmbeddingContextPoolSize({
         gpu: false,
@@ -145,7 +157,7 @@ describe("NodeLlamaCppEmbedding", () => {
         platformName: "darwin",
         totalMemoryBytes: 16 * 1024 * 1024 * 1024,
       })
-    ).toBe(4);
+    ).toBe(2);
   });
 
   test("allows explicit CPU context pool override", () => {
@@ -176,6 +188,48 @@ describe("NodeLlamaCppEmbedding", () => {
     expect(result.ok).toBe(true);
     expect(createEmbeddingContext).toHaveBeenCalledTimes(4);
     expect(embedding.dimensions()).toBe(2);
+  });
+
+  test("allows explicit CPU threads per embedding context override", async () => {
+    process.env.GNO_EMBED_CONTEXTS = "2";
+    process.env.GNO_EMBED_THREADS = "6";
+    const { createEmbeddingContext, manager } = createManager({
+      cpuMathCores: 16,
+    });
+    const embedding = new NodeLlamaCppEmbedding(
+      manager as never,
+      "test-model",
+      "/tmp/model.gguf"
+    );
+
+    const result = await embedding.init();
+
+    expect(result.ok).toBe(true);
+    expect(createEmbeddingContext).toHaveBeenCalledWith({
+      contextSize: 2_048,
+      threads: 6,
+    });
+  });
+
+  test("allows explicit embedding context size override", async () => {
+    process.env.GNO_EMBED_CONTEXTS = "1";
+    process.env.GNO_EMBED_CONTEXT_SIZE = "512";
+    const { createEmbeddingContext, manager } = createManager({
+      cpuMathCores: 16,
+    });
+    const embedding = new NodeLlamaCppEmbedding(
+      manager as never,
+      "test-model",
+      "/tmp/model.gguf"
+    );
+
+    const result = await embedding.init();
+
+    expect(result.ok).toBe(true);
+    expect(createEmbeddingContext).toHaveBeenCalledWith({
+      contextSize: 512,
+      threads: 16,
+    });
   });
 
   test("keeps a single context when GPU is enabled", async () => {
@@ -256,7 +310,7 @@ describe("NodeLlamaCppEmbedding", () => {
     const result = await embedding.embed("abcdefghijk");
 
     expect(result.ok).toBe(true);
-    expect(calls[0]?.text).toBe("abcd");
+    expect(calls[0]?.input).toEqual([97, 98, 99, 100]);
   });
 
   test("truncates oversized batch items before embedding", async () => {
@@ -273,7 +327,10 @@ describe("NodeLlamaCppEmbedding", () => {
     const result = await embedding.embedBatch(["abcdef", "xy"]);
 
     expect(result.ok).toBe(true);
-    expect(calls.map((call) => call.text)).toEqual(["abc", "xy"]);
+    expect(calls.map((call) => call.input)).toEqual([
+      [97, 98, 99],
+      [120, 121],
+    ]);
   });
 
   test("disposes contexts created after a concurrent dispose", async () => {

--- a/test/llm/embedding.test.ts
+++ b/test/llm/embedding.test.ts
@@ -104,7 +104,18 @@ describe("NodeLlamaCppEmbedding", () => {
     delete process.env.GNO_EMBED_CONTEXTS;
   });
 
-  test("caps CPU context pool on low-memory Windows machines", () => {
+  test("keeps CPU context pool single on constrained Windows machines", () => {
+    expect(
+      resolveEmbeddingContextPoolSize({
+        gpu: false,
+        cpuMathCores: 16,
+        platformName: "win32",
+        totalMemoryBytes: 12 * 1024 * 1024 * 1024,
+      })
+    ).toBe(1);
+  });
+
+  test("uses two CPU contexts on 16GB Windows machines", () => {
     expect(
       resolveEmbeddingContextPoolSize({
         gpu: false,
@@ -112,7 +123,18 @@ describe("NodeLlamaCppEmbedding", () => {
         platformName: "win32",
         totalMemoryBytes: 16 * 1024 * 1024 * 1024,
       })
-    ).toBe(1);
+    ).toBe(2);
+  });
+
+  test("uses adaptive CPU context pool on 24GB Windows machines", () => {
+    expect(
+      resolveEmbeddingContextPoolSize({
+        gpu: false,
+        cpuMathCores: 16,
+        platformName: "win32",
+        totalMemoryBytes: 24 * 1024 * 1024 * 1024,
+      })
+    ).toBe(4);
   });
 
   test("keeps CPU context pool adaptive outside low-memory Windows", () => {


### PR DESCRIPTION
## Summary
- improve CPU-only embedding defaults by capping automatic context pools at safer levels
- add GNO_EMBED_THREADS and GNO_EMBED_CONTEXT_SIZE overrides
- add CPU embedding autoresearch and native-batch probe scripts
- document the new CPU embedding behavior and troubleshooting guidance

## Verification
- bun run bench:cpu-embeddings -- --real --contexts 1,2,4 --chunks 512
- bun run bench:cpu-embeddings:native-batch-probe
- bun run lint:check
- bun run typecheck
- bun run docs:verify
- bun test