### PR TITLE
Embedding and package hardening

### DIFF
--- a/.flow/specs/fn-81-embedding-and-package-hardening.md
+++ b/.flow/specs/fn-81-embedding-and-package-hardening.md
@@ -1,14 +1,17 @@
 # Embedding and package hardening
 
 ## Overview
+
 GNO should make embedding freshness explicit, recover transient embedding failures in the same run, and prove the published package shape before release. The current system already has model-aware vector rows, shared embedding recovery, `gno doctor`, and a publish-workflow package smoke. This plan turns those pieces into durable release hardening.
 
 Stakeholders:
+
 - **End users:** clearer `gno doctor` guidance, hosted docs that match behavior, and fewer rerun-only embed failures.
 - **Developers:** a stricter vector freshness contract and package smoke command.
 - **Operations:** a local release gate plus hosted docs/deploy verification that mirrors packed install behavior instead of relying only on CI.
 
 ## Scope
+
 - Add per-vector embedding fingerprints to `content_vectors` freshness checks.
 - Make shared and CLI embedding loops retry transient failed chunks within the same command run.
 - Add a deterministic packed-package smoke script and wire it into release verification.
@@ -16,7 +19,9 @@ Stakeholders:
 - Update and deploy canonical hosted website docs in `/Users/gordon/work/gno.sh` for every user-facing change in this spec.
 
 ## Approach
+
 ### Vector freshness
+
 Extend the existing vector storage path rather than adding another store. The seam is `content_vectors` in `src/store/migrations/001-initial.ts:135`, `VectorRow` / `VectorStatsPort` in `src/store/vector/types.ts:14`, and backlog SQL in `src/store/vector/stats.ts:66`.
 
 Use a compact fingerprint helper with a signature like:
@@ -36,22 +41,27 @@ AND v.embedded_at >= c.created_at
 ```
 
 ### Retry behavior
+
 Reuse `embedTextsWithRecovery()` in `src/embed/batch.ts:56`. Add bounded retry state around existing cursor loops instead of putting failed rows back into the hot cursor path. The shared path starts at `src/embed/backlog.ts:54`; the CLI still has a separate embed loop around `src/cli/commands/embed.ts:596`, so both must align.
 
 Retry state should be in-memory, capped per chunk, and drained after later progress or at the end of fresh backlog processing. Non-transient failures should still surface as final errors with actionable verbose/debug guidance.
 
 ### Doctor and docs
+
 Extend `gno doctor` in `src/cli/commands/doctor.ts:314` with fingerprint diagnostics. Update the JSON contract in `spec/output-schemas/doctor.schema.json:1` and CLI contract in `spec/cli.md:1146`. Keep `gno status` lightweight.
 
 ### Package smoke
+
 Create `bun run test:package` as a local tarball-first smoke. Reuse the command-runner/isolation style from `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts:62`, but target the CLI package shape in `package.json:28` and current publish smoke in `.github/workflows/publish.yml:217`.
 
 Use packed installs, isolated `HOME`/`GNO_HOME`/cache dirs, and fatal `gno --version` + `gno doctor --json` checks. Optional model-heavy checks should skip clearly when no cache/runtime is present.
 
 ### Hosted website
+
 Hosted docs are a release blocker for this spec, not follow-up polish. Any shipped user-facing behavior, CLI output, troubleshooting flow, install guidance, release gate, or FAQ/product claim changed by this work must be reflected in `/Users/gordon/work/gno.sh` in the same delivery path.
 
 Rules:
+
 - Do not mark the spec complete, release/tag, or hand off as “done” while `/Users/gordon/work/gno.sh` is stale for shipped behavior.
 - Do not rely on this repo's legacy `website/` directory as production documentation.
 - The website task should compare in-repo docs/spec changes against `gno.sh` pages and update every affected public page, not just obvious reference docs.
@@ -59,6 +69,7 @@ Rules:
 - When deployed, verify live `https://gno.sh`, service health, and remote revision.
 
 ## Quick commands
+
 ```bash
 bun test test/store/vector/stats.test.ts test/store/vector/sqlite-vec.test.ts test/embed/backlog.test.ts
 bun test test/cli/smoke.test.ts test/spec/schemas/status.test.ts
@@ -72,6 +83,7 @@ ssh root@178.104.180.89 "systemctl is-active gno-sh && cd /srv/gno-sh/repo && gi
 ```
 
 ## Boundaries / non-goals
+
 - No default embedding model change.
 - No second vector database backend.
 - No full desktop packaging smoke in this spec.
@@ -80,9 +92,11 @@ ssh root@178.104.180.89 "systemctl is-active gno-sh && cd /srv/gno-sh/repo && gi
 - No stale installed skill-stub work in this spec.
 
 ## Decision context
+
 Fingerprinting per vector row is the smallest reliable way to distinguish “same model URI, different embedding semantics” from fresh vectors. Treating mismatches as pending avoids destructive migrations and keeps recovery observable. Retrying failed chunks outside the forward cursor preserves current seek-pagination safety while reducing rerun-only failures. A tarball-first package smoke closes the gap between repo-local tests and what users install. The hosted website task is explicit and blocking because GNO’s production docs live in `/Users/gordon/work/gno.sh`, not this repo's legacy website tree; stale hosted docs create user-visible drift immediately.
 
 Dependencies and overlaps:
+
 - Depends on completed `fn-70-embedding-compatibility-and-query-batching` for embedding profiles, formatter behavior, and batch recovery seams.
 - Depends on completed `fn-67-evaluate-qwen3-embedding-06b-gguf-for` for re-embed semantics and collection-scoped vector cleanup precedent.
 - Depends on completed `fn-73-gno-runtime-hardening` for doctor/runtime guidance and vector diagnostics precedent.
@@ -90,6 +104,7 @@ Dependencies and overlaps:
 - `fn-57-mac-and-linux-packaging-matrix-and` can consume `test:package` later for broader packaging proof.
 
 ## Acceptance
+
 - **R1:** `content_vectors` has an `embed_fingerprint` column, useful index coverage, migration coverage, and matching updates in `spec/db/schema.sql`.
 - **R2:** New vector writes, backlog count/get queries, and embedded-count/status paths use exact model+fingerprint freshness while keeping legacy empty-fingerprint rows readable and non-destructive.
 - **R3:** `gno doctor` terminal and JSON output report current fingerprint, stale/pending count, legacy empty-fingerprint count, and mixed fingerprint groups without making `gno status` probe native models.
@@ -99,20 +114,23 @@ Dependencies and overlaps:
 - **R7:** `/Users/gordon/work/gno.sh` hosted website docs are updated in the same delivery path for all user-facing changes, and the spec is not complete until the hosted site is deployed/verified or the exact blocker is documented in Flow evidence.
 
 ## Early proof point
+
 Task `fn-81-embedding-and-package-hardening.1` proves the core model: existing vector rows can carry fingerprint freshness without breaking old DBs or vector search writes. If it fails, reconsider whether fingerprint metadata belongs in `content_vectors` or in a sidecar freshness table before continuing downstream tasks.
 
 ## Requirement coverage
-| Req | Description | Task(s) | Gap justification |
-|-----|-------------|---------|-------------------|
-| R1 | Vector schema and DB contract include fingerprints | fn-81-embedding-and-package-hardening.1 | — |
-| R2 | Vector writes/backlog/status use exact fingerprint freshness | fn-81-embedding-and-package-hardening.1 | — |
-| R3 | Doctor terminal/JSON reports fingerprint health | fn-81-embedding-and-package-hardening.2 | — |
-| R4 | Same-run embed retry in shared and CLI paths | fn-81-embedding-and-package-hardening.3 | — |
-| R5 | Local packed-package smoke gate exists and fails loudly | fn-81-embedding-and-package-hardening.4 | — |
-| R6 | Specs/docs/release guidance match behavior | fn-81-embedding-and-package-hardening.2, fn-81-embedding-and-package-hardening.4 | — |
-| R7 | Hosted website docs/deploy match shipped behavior | fn-81-embedding-and-package-hardening.5 | — |
+
+| Req | Description                                                  | Task(s)                                                                          | Gap justification |
+| --- | ------------------------------------------------------------ | -------------------------------------------------------------------------------- | ----------------- |
+| R1  | Vector schema and DB contract include fingerprints           | fn-81-embedding-and-package-hardening.1                                          | —                 |
+| R2  | Vector writes/backlog/status use exact fingerprint freshness | fn-81-embedding-and-package-hardening.1                                          | —                 |
+| R3  | Doctor terminal/JSON reports fingerprint health              | fn-81-embedding-and-package-hardening.2                                          | —                 |
+| R4  | Same-run embed retry in shared and CLI paths                 | fn-81-embedding-and-package-hardening.3                                          | —                 |
+| R5  | Local packed-package smoke gate exists and fails loudly      | fn-81-embedding-and-package-hardening.4                                          | —                 |
+| R6  | Specs/docs/release guidance match behavior                   | fn-81-embedding-and-package-hardening.2, fn-81-embedding-and-package-hardening.4 | —                 |
+| R7  | Hosted website docs/deploy match shipped behavior            | fn-81-embedding-and-package-hardening.5                                          | —                 |
 
 ## References
+
 - `src/store/migrations/001-initial.ts:135` — current `content_vectors` schema.
 - `src/store/vector/types.ts:14` — vector row and stats port contracts.
 - `src/store/vector/stats.ts:66` — current backlog freshness SQL.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.1.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.1.md
@@ -49,9 +49,8 @@ Current primary key is `(mirror_hash, seq, model)`. If implementation wants mult
 - [ ] Tests cover fresh, stale timestamp, stale fingerprint, mixed fingerprint, and legacy empty-fingerprint cases.
 
 ## Done summary
-
-_Not started._
-
+Added vector embedding fingerprints to the DB freshness contract, vector writes, backlog/status counts, and DB spec. Tests cover fresh vectors, stale timestamps, stale/mixed fingerprints, and legacy empty-fingerprint rows.
 ## Evidence
-
-_Not started._
+- Commits: 0fb89eec272d0826f3d3abc39cedd32ee5e0df66
+- Tests: bun run lint:check, bun test test/store/vector/stats.test.ts test/store/vector/sqlite-vec.test.ts test/store/adapter.test.ts test/store/migrations.test.ts test/embed/backlog.test.ts test/spec/schemas/status.test.ts, bun test, bun run docs:verify
+- PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.1.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.1.md
@@ -49,8 +49,11 @@ Current primary key is `(mirror_hash, seq, model)`. If implementation wants mult
 - [ ] Tests cover fresh, stale timestamp, stale fingerprint, mixed fingerprint, and legacy empty-fingerprint cases.
 
 ## Done summary
+
 Added vector embedding fingerprints to the DB freshness contract, vector writes, backlog/status counts, and DB spec. Tests cover fresh vectors, stale timestamps, stale/mixed fingerprints, and legacy empty-fingerprint rows.
+
 ## Evidence
+
 - Commits: 0fb89eec272d0826f3d3abc39cedd32ee5e0df66
 - Tests: bun run lint:check, bun test test/store/vector/stats.test.ts test/store/vector/sqlite-vec.test.ts test/store/adapter.test.ts test/store/migrations.test.ts test/embed/backlog.test.ts test/spec/schemas/status.test.ts, bun test, bun run docs:verify
 - PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.1.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.1.md
@@ -3,12 +3,14 @@ satisfies: [R1, R2]
 ---
 
 ## Description
+
 Add per-vector embedding fingerprint metadata to the vector freshness contract. This task owns schema/migration, vector row contracts, vector writes, backlog/readiness SQL, and focused tests. Keep legacy empty-fingerprint rows readable; treat them as not current unless a later task explicitly adopts them.
 
 **Size:** M
 **Files:** `src/store/migrations/*`, `src/store/vector/types.ts`, `src/store/vector/stats.ts`, `src/store/vector/sqlite-vec.ts`, `src/store/sqlite/adapter.ts`, `src/embed/backlog.ts`, `src/cli/commands/embed.ts`, `spec/db/schema.sql`, `test/store/vector/*.test.ts`, `test/store/adapter.test.ts`
 
 ## Approach
+
 - Extend the existing `content_vectors` table from `src/store/migrations/001-initial.ts:135`; do not add a sidecar vector freshness table unless the migration proves unsafe.
 - Add an explicit fingerprint helper/contract near the existing vector or embedding compatibility seams. Signature-level shape only: `getEmbeddingFingerprint(input): string`.
 - Include resolved model URI, dimensions when known, embedding compatibility/profile identity, contextual formatting version, and chunking strategy/version in fingerprint inputs.
@@ -17,7 +19,9 @@ Add per-vector embedding fingerprint metadata to the vector freshness contract. 
 - Update vector upserts in `src/store/vector/sqlite-vec.ts:118`; preserve current storage-first behavior before vec0 writes.
 
 ## Investigation targets
+
 **Required**
+
 - `src/store/migrations/001-initial.ts:135` — current `content_vectors` schema.
 - `src/store/vector/types.ts:14` — vector row and stats port contracts.
 - `src/store/vector/stats.ts:66` — backlog freshness SQL.
@@ -27,12 +31,15 @@ Add per-vector embedding fingerprint metadata to the vector freshness contract. 
 - `test/store/adapter.test.ts:1089` — status/backlog count tests.
 
 **Optional**
+
 - `docs/CONFIGURATION.md:262` — existing re-embed semantics for changed model/profile behavior.
 
 ## Key context
+
 Current primary key is `(mirror_hash, seq, model)`. If implementation wants multiple same-model fingerprints to coexist, it must explicitly decide whether to change the key or continue replacing same-model rows while using fingerprint for freshness diagnostics. Default preference: avoid PK churn unless tests show it is required.
 
 ## Acceptance
+
 - [ ] `content_vectors` stores `embed_fingerprint` for new and migrated databases, with index coverage for freshness queries.
 - [ ] Vector writes populate fingerprint without breaking vec0 sync/rebuild behavior.
 - [ ] Backlog count/get queries require exact model+fingerprint freshness.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
@@ -3,12 +3,14 @@ satisfies: [R3, R6]
 ---
 
 ## Description
+
 Expose fingerprint freshness through `gno doctor` and update the affected CLI/schema/docs contracts. This task depends on the fingerprint storage contract from task 1 and should keep `gno status` lightweight.
 
 **Size:** M
 **Files:** `src/cli/commands/doctor.ts`, `spec/output-schemas/doctor.schema.json`, `spec/cli.md`, `docs/CLI.md`, `docs/TROUBLESHOOTING.md`, `docs/INSTALLATION.md`, `README.md`, `CHANGELOG.md`, `test/spec/schemas/*`, `test/cli/*`
 
 ## Approach
+
 - Extend the existing doctor result assembly in `src/cli/commands/doctor.ts:314` and terminal/JSON formatters in `src/cli/commands/doctor.ts:370` and `src/cli/commands/doctor.ts:420`.
 - Report stale, legacy, and mixed fingerprint states as `warn` by default, not `error`, unless the implementation finds a true runtime inability to search/embed.
 - Keep the JSON shape additive under the current doctor schema unless schema tests prove a version bump is needed.
@@ -16,7 +18,9 @@ Expose fingerprint freshness through `gno doctor` and update the affected CLI/sc
 - Update docs where behavior changes are visible; do not over-document internals in quickstart-style docs.
 
 ## Investigation targets
+
 **Required**
+
 - `src/cli/commands/doctor.ts:314` — doctor assembly.
 - `src/cli/commands/doctor.ts:370` — terminal formatting.
 - `spec/output-schemas/doctor.schema.json:1` — JSON schema.
@@ -26,13 +30,16 @@ Expose fingerprint freshness through `gno doctor` and update the affected CLI/sc
 - `docs/INSTALLATION.md:182` — doctor JSON example.
 
 **Optional**
+
 - `README.md:104` — upgrade/migration summary.
 - `docs/ARCHITECTURE.md:159` — storage table overview if it would otherwise drift.
 
 ## Key context
+
 Doctor should be the richer diagnostic surface. `gno status` should consume fingerprint-aware readiness from task 1 but should not import native model code or perform device/model probing.
 
 ## Acceptance
+
 - [ ] `gno doctor` terminal output includes current fingerprint, stale/pending count, legacy empty-fingerprint count, and mixed fingerprint groups.
 - [ ] `gno doctor --json` exposes stable machine-readable fingerprint details and validates against schema tests.
 - [ ] Stale/legacy/mixed fingerprint diagnostics are warnings with clear `gno embed` or `gno embed --force` recovery guidance.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
@@ -2,16 +2,20 @@
 satisfies: [R3, R6]
 ---
 
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.1 shipped src/store/vector/freshness.ts and src/store/migrations/008-vector-fingerprints.ts, not only the older inline seams -->
+
 ## Description
 
 Expose fingerprint freshness through `gno doctor` and update the affected CLI/schema/docs contracts. This task depends on the fingerprint storage contract from task 1 and should keep `gno status` lightweight.
 
 **Size:** M
-**Files:** `src/cli/commands/doctor.ts`, `spec/output-schemas/doctor.schema.json`, `spec/cli.md`, `docs/CLI.md`, `docs/TROUBLESHOOTING.md`, `docs/INSTALLATION.md`, `README.md`, `CHANGELOG.md`, `test/spec/schemas/*`, `test/cli/*`
+**Files:** `src/cli/commands/doctor.ts`, `src/embed/fingerprint.ts`, `src/store/vector/freshness.ts`, `src/store/sqlite/adapter.ts`, `spec/output-schemas/doctor.schema.json`, `spec/cli.md`, `docs/CLI.md`, `docs/TROUBLESHOOTING.md`, `docs/INSTALLATION.md`, `README.md`, `CHANGELOG.md`, `test/spec/schemas/*`, `test/cli/*`
 
 ## Approach
 
 - Extend the existing doctor result assembly in `src/cli/commands/doctor.ts:314` and terminal/JSON formatters in `src/cli/commands/doctor.ts:370` and `src/cli/commands/doctor.ts:420`.
+- Reuse the shipped fingerprint helpers from `src/embed/fingerprint.ts:17` and `src/store/vector/freshness.ts:26`; do not fork a second “current fingerprint” calculation inside doctor.
+- Reuse the fingerprint-aware readiness counts already wired into `src/store/sqlite/adapter.ts:3076` so `gno doctor` and `gno status` stay consistent while `gno status` remains lightweight.
 - Report stale, legacy, and mixed fingerprint states as `warn` by default, not `error`, unless the implementation finds a true runtime inability to search/embed.
 - Keep the JSON shape additive under the current doctor schema unless schema tests prove a version bump is needed.
 - Add or extend contract tests for doctor JSON; use the status schema test pattern at `test/spec/schemas/status.test.ts:1`.
@@ -23,6 +27,9 @@ Expose fingerprint freshness through `gno doctor` and update the affected CLI/sc
 
 - `src/cli/commands/doctor.ts:314` — doctor assembly.
 - `src/cli/commands/doctor.ts:370` — terminal formatting.
+- `src/embed/fingerprint.ts:17` — canonical fingerprint helper/shape.
+- `src/store/vector/freshness.ts:26` — stored/current fingerprint helper.
+- `src/store/sqlite/adapter.ts:3076` — fingerprint-aware status/readiness counts.
 - `spec/output-schemas/doctor.schema.json:1` — JSON schema.
 - `spec/cli.md:1146` — doctor CLI contract.
 - `docs/CLI.md:887` — doctor user docs.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
@@ -54,8 +54,11 @@ Doctor should be the richer diagnostic surface. `gno status` should consume fing
 - [ ] `spec/cli.md`, `spec/output-schemas/doctor.schema.json`, user docs, and changelog/docs release notes match the implemented behavior.
 
 ## Done summary
+
 Exposed embedding fingerprint freshness in gno doctor terminal/JSON output, including current fingerprint, pending/stale chunks, legacy vector counts, and stored fingerprint groups. Updated the doctor JSON schema/tests plus in-repo CLI, troubleshooting, installation, README, and changelog docs.
+
 ## Evidence
+
 - Commits: 658a072e55376e7a992e013a8e0e1cff3ac62699
 - Tests: bun run lint:check, bun run typecheck, bun test test/spec/schemas/doctor.test.ts test/spec/schemas/status.test.ts, bun test, bun run docs:verify, bun src/index.ts doctor --json | jq -e '.checks[] | select(.name == "embedding-fingerprint") | .embeddingFingerprint.pendingChunks >= 0'
 - PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.2.md
@@ -54,9 +54,8 @@ Doctor should be the richer diagnostic surface. `gno status` should consume fing
 - [ ] `spec/cli.md`, `spec/output-schemas/doctor.schema.json`, user docs, and changelog/docs release notes match the implemented behavior.
 
 ## Done summary
-
-_Not started._
-
+Exposed embedding fingerprint freshness in gno doctor terminal/JSON output, including current fingerprint, pending/stale chunks, legacy vector counts, and stored fingerprint groups. Updated the doctor JSON schema/tests plus in-repo CLI, troubleshooting, installation, README, and changelog docs.
 ## Evidence
-
-_Not started._
+- Commits: 658a072e55376e7a992e013a8e0e1cff3ac62699
+- Tests: bun run lint:check, bun run typecheck, bun test test/spec/schemas/doctor.test.ts test/spec/schemas/status.test.ts, bun test, bun run docs:verify, bun src/index.ts doctor --json | jq -e '.checks[] | select(.name == "embedding-fingerprint") | .embeddingFingerprint.pendingChunks >= 0'
+- PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
@@ -3,6 +3,7 @@ satisfies: [R4]
 ---
 
 <!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.1 kept duplicate embed loops in cli/sdk helpers, not only the old top-level cursor path -->
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.2 now reads `store.getStatus({ embedModel }).value.embeddingBacklog` into the `embedding-fingerprint` doctor check, so retry work must preserve that pending/stale contract -->
 
 ## Description
 
@@ -16,6 +17,7 @@ Make transient embedding failures retry within the same command run in both the 
 - Reuse `embedTextsWithRecovery()` from `src/embed/batch.ts:56`; do not introduce a second embedding recovery implementation.
 - Add retry state outside the forward cursor loop in `src/embed/backlog.ts:54`.
 - Align the separate CLI loop in `src/cli/commands/embed.ts:166` (`processBatches`) so CLI and shared paths do not diverge.
+- Preserve the `SqliteAdapter.getStatus({ embedModel })` backlog semantics that task 2 now exposes as `embedding-fingerprint.embeddingFingerprint.pendingChunks`; if retry timing changes those counts, update doctor contract/tests in the same patch.
 - Audit the force-only SDK batch loop in `src/sdk/embed.ts:116`; it now duplicates batch iteration and fingerprint writes, so retry behavior there must either stay intentionally out of scope or be kept explicitly aligned.
 - Retry only after later progress or final backlog drain; cap per-chunk attempts and preserve sample failure messages.
 - Treat retry state as in-memory only. Interrupted runs should still resume from normal backlog state on the next invocation.
@@ -29,6 +31,8 @@ Make transient embedding failures retry within the same command run in both the 
 - `src/cli/commands/embed.ts:166` — CLI `processBatches()` loop.
 - `src/cli/commands/embed.ts:221` — CLI batch failure/retry branch.
 - `src/cli/commands/embed.ts:330` — CLI fallback/sample reporting.
+- `src/cli/commands/doctor.ts:208` — doctor fingerprint check now reads active model + backlog counts.
+- `src/cli/commands/doctor.ts:270` — `pendingChunks` currently comes from `statusResult.value.embeddingBacklog`.
 - `test/embed/backlog.test.ts:215` — partial success storage coverage.
 - `test/embed/batch.test.ts:86` — fallback tests.
 
@@ -41,12 +45,13 @@ Make transient embedding failures retry within the same command run in both the 
 
 ## Key context
 
-Do not blindly retry validation/configuration errors, missing models, or unsupported dimensions. Transient classification may start conservative; permanent failures must remain visible in final summaries.
+Do not blindly retry validation/configuration errors, missing models, or unsupported dimensions. Transient classification may start conservative; permanent failures must remain visible in final summaries. The retry queue also feeds doctor-visible pending/stale counts now, so delayed retries must not silently undercount backlog health.
 
 ## Acceptance
 
 - [ ] Shared backlog retry queue retries failed chunks after later progress or final drain.
 - [ ] CLI embed loop uses matching retry semantics and summary counts.
+- [ ] `gno doctor` pending/stale fingerprint counts remain consistent with retry behavior, or the doctor contract/tests are updated in the same patch.
 - [ ] Retry attempts are capped per chunk and cannot loop forever.
 - [ ] Permanent failures include sample metadata and clear rerun/verbose guidance.
 - [ ] Tests cover one transient chunk failure that succeeds on retry and one permanent failure that stays counted as an error.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
@@ -57,9 +57,8 @@ Do not blindly retry validation/configuration errors, missing models, or unsuppo
 - [ ] Tests cover one transient chunk failure that succeeds on retry and one permanent failure that stays counted as an error.
 
 ## Done summary
-
-_Not started._
-
+Implemented bounded same-run retry for failed embedding chunks in the shared backlog processor and CLI embed loop while preserving DB-backed doctor pending/stale semantics. The SDK force-only embed loop is aligned with the same shared embed/store helper and retry cap; package smoke and hosted website tasks were not touched.
 ## Evidence
-
-_Not started._
+- Commits: 78670e732dd5d444d1602f74c4bb62ef16fe04a4
+- Tests: bun test test/embed/backlog.test.ts test/embed/batch.test.ts test/cli/embed.test.ts, bun test test/serve/embed-scheduler.test.ts, bun test, bunx tsc --noEmit, bunx oxlint --type-aware --type-check, bunx oxfmt --check src/cli/commands/embed.ts src/embed/backlog.ts src/embed/retry.ts src/sdk/embed.ts test/embed/backlog.test.ts, bun run docs:verify, bun run lint:check (failed only on pre-existing formatting in .flow/tasks/fn-81-embedding-and-package-hardening.2.md; task files passed targeted formatter check)
+- PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
@@ -57,8 +57,11 @@ Do not blindly retry validation/configuration errors, missing models, or unsuppo
 - [ ] Tests cover one transient chunk failure that succeeds on retry and one permanent failure that stays counted as an error.
 
 ## Done summary
+
 Implemented bounded same-run retry for failed embedding chunks in the shared backlog processor and CLI embed loop while preserving DB-backed doctor pending/stale semantics. The SDK force-only embed loop is aligned with the same shared embed/store helper and retry cap; package smoke and hosted website tasks were not touched.
+
 ## Evidence
+
 - Commits: 78670e732dd5d444d1602f74c4bb62ef16fe04a4
 - Tests: bun test test/embed/backlog.test.ts test/embed/batch.test.ts test/cli/embed.test.ts, bun test test/serve/embed-scheduler.test.ts, bun test, bunx tsc --noEmit, bunx oxlint --type-aware --type-check, bunx oxfmt --check src/cli/commands/embed.ts src/embed/backlog.ts src/embed/retry.ts src/sdk/embed.ts test/embed/backlog.test.ts, bun run docs:verify, bun run lint:check (failed only on pre-existing formatting in .flow/tasks/fn-81-embedding-and-package-hardening.2.md; task files passed targeted formatter check)
 - PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
@@ -2,6 +2,8 @@
 satisfies: [R4]
 ---
 
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.1 kept duplicate embed loops in cli/sdk helpers, not only the old top-level cursor path -->
+
 ## Description
 
 Make transient embedding failures retry within the same command run in both the shared backlog processor and the CLI embed loop. Preserve cursor safety, avoid infinite loops, and keep final failure reporting actionable.
@@ -13,7 +15,8 @@ Make transient embedding failures retry within the same command run in both the 
 
 - Reuse `embedTextsWithRecovery()` from `src/embed/batch.ts:56`; do not introduce a second embedding recovery implementation.
 - Add retry state outside the forward cursor loop in `src/embed/backlog.ts:54`.
-- Align the separate CLI loop in `src/cli/commands/embed.ts:596` so CLI and shared paths do not diverge.
+- Align the separate CLI loop in `src/cli/commands/embed.ts:166` (`processBatches`) so CLI and shared paths do not diverge.
+- Audit the force-only SDK batch loop in `src/sdk/embed.ts:116`; it now duplicates batch iteration and fingerprint writes, so retry behavior there must either stay intentionally out of scope or be kept explicitly aligned.
 - Retry only after later progress or final backlog drain; cap per-chunk attempts and preserve sample failure messages.
 - Treat retry state as in-memory only. Interrupted runs should still resume from normal backlog state on the next invocation.
 
@@ -23,8 +26,9 @@ Make transient embedding failures retry within the same command run in both the 
 
 - `src/embed/backlog.ts:54` — shared backlog processor.
 - `src/embed/batch.ts:56` — batch recovery helper.
-- `src/cli/commands/embed.ts:183` — CLI cursor/backlog loop.
-- `src/cli/commands/embed.ts:323` — CLI batch fallback reporting.
+- `src/cli/commands/embed.ts:166` — CLI `processBatches()` loop.
+- `src/cli/commands/embed.ts:221` — CLI batch failure/retry branch.
+- `src/cli/commands/embed.ts:330` — CLI fallback/sample reporting.
 - `test/embed/backlog.test.ts:215` — partial success storage coverage.
 - `test/embed/batch.test.ts:86` — fallback tests.
 
@@ -32,7 +36,8 @@ Make transient embedding failures retry within the same command run in both the 
 
 - `src/serve/embed-scheduler.ts:106` — shared backlog caller.
 - `src/mcp/tools/embed.ts:123` — MCP embed caller.
-- `src/sdk/embed.ts:280` — SDK embed caller.
+- `src/sdk/embed.ts:116` — SDK force-only batch loop.
+- `src/sdk/embed.ts:291` — SDK shared-backlog caller.
 
 ## Key context
 

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.3.md
@@ -3,12 +3,14 @@ satisfies: [R4]
 ---
 
 ## Description
+
 Make transient embedding failures retry within the same command run in both the shared backlog processor and the CLI embed loop. Preserve cursor safety, avoid infinite loops, and keep final failure reporting actionable.
 
 **Size:** M
 **Files:** `src/embed/backlog.ts`, `src/embed/batch.ts`, `src/cli/commands/embed.ts`, `test/embed/backlog.test.ts`, `test/embed/batch.test.ts`, `test/cli/*embed*`
 
 ## Approach
+
 - Reuse `embedTextsWithRecovery()` from `src/embed/batch.ts:56`; do not introduce a second embedding recovery implementation.
 - Add retry state outside the forward cursor loop in `src/embed/backlog.ts:54`.
 - Align the separate CLI loop in `src/cli/commands/embed.ts:596` so CLI and shared paths do not diverge.
@@ -16,7 +18,9 @@ Make transient embedding failures retry within the same command run in both the 
 - Treat retry state as in-memory only. Interrupted runs should still resume from normal backlog state on the next invocation.
 
 ## Investigation targets
+
 **Required**
+
 - `src/embed/backlog.ts:54` — shared backlog processor.
 - `src/embed/batch.ts:56` — batch recovery helper.
 - `src/cli/commands/embed.ts:183` — CLI cursor/backlog loop.
@@ -25,14 +29,17 @@ Make transient embedding failures retry within the same command run in both the 
 - `test/embed/batch.test.ts:86` — fallback tests.
 
 **Optional**
+
 - `src/serve/embed-scheduler.ts:106` — shared backlog caller.
 - `src/mcp/tools/embed.ts:123` — MCP embed caller.
 - `src/sdk/embed.ts:280` — SDK embed caller.
 
 ## Key context
+
 Do not blindly retry validation/configuration errors, missing models, or unsupported dimensions. Transient classification may start conservative; permanent failures must remain visible in final summaries.
 
 ## Acceptance
+
 - [ ] Shared backlog retry queue retries failed chunks after later progress or final drain.
 - [ ] CLI embed loop uses matching retry semantics and summary counts.
 - [ ] Retry attempts are capped per chunk and cannot loop forever.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
@@ -3,12 +3,14 @@ satisfies: [R5, R6]
 ---
 
 ## Description
+
 Add a reusable local package smoke gate that packs the published package shape, installs it into isolated temp layouts, and fails loudly when core CLI health is broken.
 
 **Size:** M
 **Files:** `scripts/package-smoke.ts`, `package.json`, `.github/workflows/publish.yml`, `docs/PACKAGING.md`, `.github/CONTRIBUTING.md`, `docs/INSTALLATION.md`, `test/helpers/cleanup.ts`
 
 ## Approach
+
 - Build a script under `scripts/` and expose it as `bun run test:package`.
 - Use tarball-first verification. Prefer `bun pm pack --quiet --destination <tmp>` or keep `npm pack` only if it better mirrors the publish workflow.
 - Install from the tarball into isolated temp `HOME`, `GNO_HOME`, package-manager cache, and install prefix/bin paths.
@@ -17,7 +19,9 @@ Add a reusable local package smoke gate that packs the published package shape, 
 - Reuse command-runner and cleanup patterns from `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts:62` and `test/helpers/cleanup.ts:18`.
 
 ## Investigation targets
+
 **Required**
+
 - `package.json:28` — package files allowlist.
 - `package.json:54` — scripts section.
 - `.github/workflows/publish.yml:217` — current CI package smoke baseline.
@@ -27,13 +31,16 @@ Add a reusable local package smoke gate that packs the published package shape, 
 - `.github/CONTRIBUTING.md:44` — release/checklist guidance.
 
 **Optional**
+
 - `test/cli/smoke.test.ts:52` — isolated CLI env pattern.
 - `test/cli/search-smoke.test.ts:100` — temp content smoke pattern.
 
 ## Key context
+
 Avoid `npm link` as proof; it does not test packed file layout. Preserve temp dirs/tarballs only behind a debug flag or on explicit failure guidance, not by default.
 
 ## Acceptance
+
 - [ ] `bun run test:package` creates a tarball in a temp directory and verifies required runtime files are present.
 - [ ] Smoke installs from the tarball into isolated temp paths without using host user config.
 - [ ] Smoke runs `gno --version`, `gno --help`, and `gno doctor --json`; failures include exact command, stdout, stderr, and temp path guidance.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
@@ -58,8 +58,11 @@ Avoid `npm link` as proof; it does not test packed file layout. Task 3 moved ret
 - [ ] Packaging/release docs mention the new gate if wired into prerelease or CI.
 
 ## Done summary
+
 Added a reusable tarball-first package smoke gate exposed as `bun run test:package`, with isolated npm/global install paths, packed file assertions including `src/embed/retry.ts`, and packaged doctor fingerprint JSON shape validation. Updated publish CI and package/release docs to use the same local gate.
+
 ## Evidence
+
 - Commits: 8dca5768d6e7f0fd5ed7b937e84870188c8735c1
 - Tests: bun test test/spec/schemas/doctor.test.ts, bun run docs:verify, bun run lint:check, bun run test:package, bun run typecheck, bun test
 - PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
@@ -58,9 +58,8 @@ Avoid `npm link` as proof; it does not test packed file layout. Task 3 moved ret
 - [ ] Packaging/release docs mention the new gate if wired into prerelease or CI.
 
 ## Done summary
-
-_Not started._
-
+Added a reusable tarball-first package smoke gate exposed as `bun run test:package`, with isolated npm/global install paths, packed file assertions including `src/embed/retry.ts`, and packaged doctor fingerprint JSON shape validation. Updated publish CI and package/release docs to use the same local gate.
 ## Evidence
-
-_Not started._
+- Commits: 8dca5768d6e7f0fd5ed7b937e84870188c8735c1
+- Tests: bun test test/spec/schemas/doctor.test.ts, bun run docs:verify, bun run lint:check, bun run test:package, bun run typecheck, bun test
+- PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
@@ -3,6 +3,7 @@ satisfies: [R5, R6]
 ---
 
 <!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.2 shipped additive `embedding-fingerprint` doctor JSON fields, so package smoke should assert that exact check/shape instead of only generic doctor success -->
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.3 extracted shared same-run retry logic into `src/embed/retry.ts` and aligned the SDK force path, so package smoke should prove that helper ships in the tarball and not only the doctor-only CLI path -->
 
 ## Description
 
@@ -16,7 +17,7 @@ Add a reusable local package smoke gate that packs the published package shape, 
 - Build a script under `scripts/` and expose it as `bun run test:package`.
 - Use tarball-first verification. Prefer `bun pm pack --quiet --destination <tmp>` or keep `npm pack` only if it better mirrors the publish workflow.
 - Install from the tarball into isolated temp `HOME`, `GNO_HOME`, package-manager cache, and install prefix/bin paths.
-- Verify package contents against `package.json:28` and executable behavior with `gno --version`, `gno --help`, and `gno doctor --json`.
+- Verify package contents against `package.json:28`, including runtime embed files now required by task 3 such as `src/embed/retry.ts`, and executable behavior with `gno --version`, `gno --help`, and `gno doctor --json`.
 - Assert the shipped doctor contract from task 2: the JSON output should contain the `embedding-fingerprint` check and its additive `embeddingFingerprint` payload (`currentFingerprint`, `pendingChunks`, `legacyChunks`, `mixedGroups`, `groups`), not just parse as generic JSON.
 - Make doctor failures fatal for this smoke. Optional model-heavy init/embed checks may skip with explicit reason.
 - Reuse command-runner and cleanup patterns from `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts:62` and `test/helpers/cleanup.ts:18`.
@@ -29,6 +30,7 @@ Add a reusable local package smoke gate that packs the published package shape, 
 - `package.json:54` — scripts section.
 - `.github/workflows/publish.yml:217` — current CI package smoke baseline.
 - `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts:62` — command runner pattern.
+- `src/embed/retry.ts:1` — shared same-run retry helper now imported by CLI and SDK embed paths.
 - `src/cli/commands/doctor.ts:185` — `embedding-fingerprint` check name and JSON payload source.
 - `spec/output-schemas/doctor.schema.json:45` — additive doctor JSON contract for fingerprint health.
 - `test/spec/schemas/doctor.test.ts:17` — concrete schema example for the packaged smoke assertion.
@@ -43,11 +45,11 @@ Add a reusable local package smoke gate that packs the published package shape, 
 
 ## Key context
 
-Avoid `npm link` as proof; it does not test packed file layout. Preserve temp dirs/tarballs only behind a debug flag or on explicit failure guidance, not by default.
+Avoid `npm link` as proof; it does not test packed file layout. Task 3 moved retry behavior into `src/embed/retry.ts`, so the smoke should fail if that runtime file is missing from the tarball even when `gno doctor --json` still works. Preserve temp dirs/tarballs only behind a debug flag or on explicit failure guidance, not by default.
 
 ## Acceptance
 
-- [ ] `bun run test:package` creates a tarball in a temp directory and verifies required runtime files are present.
+- [ ] `bun run test:package` creates a tarball in a temp directory and verifies required runtime files are present, including the task 3 retry helper path used by packaged embed flows.
 - [ ] Smoke installs from the tarball into isolated temp paths without using host user config.
 - [ ] Smoke runs `gno --version`, `gno --help`, and `gno doctor --json`; failures include exact command, stdout, stderr, and temp path guidance.
 - [ ] Packaged `gno doctor --json` proves the shipped `embedding-fingerprint` check shape from task 2, not merely overall JSON validity.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.4.md
@@ -2,12 +2,14 @@
 satisfies: [R5, R6]
 ---
 
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.2 shipped additive `embedding-fingerprint` doctor JSON fields, so package smoke should assert that exact check/shape instead of only generic doctor success -->
+
 ## Description
 
 Add a reusable local package smoke gate that packs the published package shape, installs it into isolated temp layouts, and fails loudly when core CLI health is broken.
 
 **Size:** M
-**Files:** `scripts/package-smoke.ts`, `package.json`, `.github/workflows/publish.yml`, `docs/PACKAGING.md`, `.github/CONTRIBUTING.md`, `docs/INSTALLATION.md`, `test/helpers/cleanup.ts`
+**Files:** `scripts/package-smoke.ts`, `package.json`, `.github/workflows/publish.yml`, `docs/PACKAGING.md`, `.github/CONTRIBUTING.md`, `docs/INSTALLATION.md`, `spec/output-schemas/doctor.schema.json`, `src/cli/commands/doctor.ts`, `test/spec/schemas/doctor.test.ts`, `test/helpers/cleanup.ts`
 
 ## Approach
 
@@ -15,6 +17,7 @@ Add a reusable local package smoke gate that packs the published package shape, 
 - Use tarball-first verification. Prefer `bun pm pack --quiet --destination <tmp>` or keep `npm pack` only if it better mirrors the publish workflow.
 - Install from the tarball into isolated temp `HOME`, `GNO_HOME`, package-manager cache, and install prefix/bin paths.
 - Verify package contents against `package.json:28` and executable behavior with `gno --version`, `gno --help`, and `gno doctor --json`.
+- Assert the shipped doctor contract from task 2: the JSON output should contain the `embedding-fingerprint` check and its additive `embeddingFingerprint` payload (`currentFingerprint`, `pendingChunks`, `legacyChunks`, `mixedGroups`, `groups`), not just parse as generic JSON.
 - Make doctor failures fatal for this smoke. Optional model-heavy init/embed checks may skip with explicit reason.
 - Reuse command-runner and cleanup patterns from `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts:62` and `test/helpers/cleanup.ts:18`.
 
@@ -26,6 +29,9 @@ Add a reusable local package smoke gate that packs the published package shape, 
 - `package.json:54` — scripts section.
 - `.github/workflows/publish.yml:217` — current CI package smoke baseline.
 - `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts:62` — command runner pattern.
+- `src/cli/commands/doctor.ts:185` — `embedding-fingerprint` check name and JSON payload source.
+- `spec/output-schemas/doctor.schema.json:45` — additive doctor JSON contract for fingerprint health.
+- `test/spec/schemas/doctor.test.ts:17` — concrete schema example for the packaged smoke assertion.
 - `test/helpers/cleanup.ts:18` — temp cleanup helper.
 - `docs/PACKAGING.md:170` — verification minimums.
 - `.github/CONTRIBUTING.md:44` — release/checklist guidance.
@@ -44,6 +50,7 @@ Avoid `npm link` as proof; it does not test packed file layout. Preserve temp di
 - [ ] `bun run test:package` creates a tarball in a temp directory and verifies required runtime files are present.
 - [ ] Smoke installs from the tarball into isolated temp paths without using host user config.
 - [ ] Smoke runs `gno --version`, `gno --help`, and `gno doctor --json`; failures include exact command, stdout, stderr, and temp path guidance.
+- [ ] Packaged `gno doctor --json` proves the shipped `embedding-fingerprint` check shape from task 2, not merely overall JSON validity.
 - [ ] Optional model-heavy checks skip explicitly when offline/no-model conditions prevent them.
 - [ ] Publish workflow reuses or matches the local smoke so local and CI gates do not drift.
 - [ ] Packaging/release docs mention the new gate if wired into prerelease or CI.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
@@ -3,12 +3,14 @@ satisfies: [R7]
 ---
 
 ## Description
+
 Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.sh` for the user-facing behavior and release-gate changes from this spec. This is a release blocker. Do not mark the spec complete, call the implementation shipped, tag/release, or hand off as done while the hosted website is stale for shipped behavior.
 
 **Size:** M
 **Files:** `/Users/gordon/work/gno.sh/**`, `/Users/gordon/work/gno/docs/**` as source references only
 
 ## Approach
+
 - Treat `/Users/gordon/work/gno.sh` as the production website source. Do not use this repo's legacy `website/` tree as a substitute.
 - Compare all in-repo docs/spec/changelog changes from tasks `.1` to `.4` against the public website. Update every affected product, install, docs/reference, troubleshooting, FAQ, and comparison page.
 - Cover embedding fingerprints, doctor diagnostics/JSON, same-run embed retry behavior, package smoke/release gates, and any changed recovery command guidance.
@@ -17,7 +19,9 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 - If deployment cannot happen, do not hide it. Record the blocker and exact remaining deploy/verification command in Flow evidence.
 
 ## Investigation targets
+
 **Required**
+
 - `AGENTS.md:383` — hosted website docs requirement.
 - `AGENTS.md:389` — canonical hosted website repo path.
 - `/Users/gordon/work/gno.sh` — production website source.
@@ -28,12 +32,15 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 - `/Users/gordon/work/gno/CHANGELOG.md` — shipped behavior summary if user-visible.
 
 **Optional**
+
 - `/Users/gordon/work/gno/README.md` — high-level migration/release messaging.
 
 ## Key context
+
 The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Website drift is user-visible drift.
 
 ## Acceptance
+
 - [ ] `/Users/gordon/work/gno.sh` is audited against all user-facing changes from this spec, not just the obvious reference page.
 - [ ] Hosted docs reflect shipped fingerprint diagnostics, retry behavior, doctor JSON/user guidance, and package smoke gate wherever user-facing.
 - [ ] Hosted docs avoid claims that go beyond implemented GNO behavior.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
@@ -3,6 +3,7 @@ satisfies: [R7]
 ---
 
 <!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.2 shipped public `embedding-fingerprint` doctor diagnostics plus `gno embed` / `gno embed --force` recovery guidance; hosted docs must reflect those exact terms before release -->
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.3 aligned same-run retry across backlog and `gno embed --force`, so hosted docs must describe retry/recovery for the force path too, not only generic embed wording -->
 
 ## Description
 
@@ -14,8 +15,8 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 ## Approach
 
 - Treat `/Users/gordon/work/gno.sh` as the production website source. Do not use this repo's legacy `website/` tree as a substitute.
-- Compare all in-repo docs/spec/changelog changes from tasks `.1` to `.4` against the public website. Update every affected product, install, docs/reference, troubleshooting, FAQ, and comparison page.
-- Cover embedding fingerprints, doctor diagnostics/JSON, same-run embed retry behavior, package smoke/release gates, and any changed recovery command guidance.
+- Compare shipped user-facing behavior plus all in-repo docs/spec/changelog changes from tasks `.1` to `.4` against the public website. Update every affected product, install, docs/reference, troubleshooting, FAQ, and comparison page.
+- Cover embedding fingerprints, doctor diagnostics/JSON, same-run retry behavior in both normal backlog and `gno embed --force` flows, package smoke/release gates, and any changed recovery command guidance.
 - Use the shipped doctor terms from task 2 exactly where user-facing: `embedding-fingerprint`, current fingerprint, pending/stale chunks, legacy vectors, mixed fingerprint groups, plus `gno embed` / `gno embed --force` recovery guidance.
 - Keep website copy conservative: public docs must not claim behavior that is not implemented and verified in GNO.
 - Build and deploy from `/Users/gordon/work/gno.sh` in the same delivery path when website changes are part of the shipped work.
@@ -39,13 +40,13 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 
 ## Key context
 
-The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Task 2 already changed the in-repo public doc surface (`README.md`, `docs/CLI.md`, `docs/INSTALLATION.md`, `docs/TROUBLESHOOTING.md`, `CHANGELOG.md`) and website drift remains release-blocking until deploy/verification is done or explicitly blocked in evidence.
+The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Task 2 changed the in-repo public doc surface (`README.md`, `docs/CLI.md`, `docs/INSTALLATION.md`, `docs/TROUBLESHOOTING.md`, `CHANGELOG.md`), and task 3 broadened the shipped retry behavior to cover `gno embed --force`; website drift remains release-blocking until deploy/verification is done or explicitly blocked in evidence.
 
 ## Acceptance
 
 - [ ] `/Users/gordon/work/gno.sh` is audited against all user-facing changes from this spec, not just the obvious reference page.
-- [ ] Hosted docs reflect shipped fingerprint diagnostics, retry behavior, doctor JSON/user guidance, and package smoke gate wherever user-facing.
-- [ ] Hosted docs use the implemented doctor terminology and recovery commands from task 2 (`embedding-fingerprint`, `gno embed`, `gno embed --force`) rather than older generic wording.
+- [ ] Hosted docs reflect shipped fingerprint diagnostics, retry behavior for `gno embed` and `gno embed --force`, doctor JSON/user guidance, and package smoke gate wherever user-facing.
+- [ ] Hosted docs use the implemented doctor terminology and recovery commands from tasks 2 and 3 (`embedding-fingerprint`, `gno embed`, `gno embed --force`, same-run retry guidance) rather than older generic wording.
 - [ ] Hosted docs avoid claims that go beyond implemented GNO behavior.
 - [ ] Website repo checks/build pass using that repo's package manager/runtime.
 - [ ] Production deploy runs from `/Users/gordon/work/gno.sh` when the behavior is shipped.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
@@ -4,20 +4,22 @@ satisfies: [R7]
 
 <!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.2 shipped public `embedding-fingerprint` doctor diagnostics plus `gno embed` / `gno embed --force` recovery guidance; hosted docs must reflect those exact terms before release -->
 <!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.3 aligned same-run retry across backlog and `gno embed --force`, so hosted docs must describe retry/recovery for the force path too, not only generic embed wording -->
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.4 shipped `scripts/package-smoke.ts` as `bun run test:package`, using `npm pack` + tarball install smoke, required tarball entries including `src/embed/retry.ts`, and exact `embedding-fingerprint.embeddingFingerprint` doctor JSON assertions; hosted docs must describe that shipped release gate precisely -->
 
 ## Description
 
 Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.sh` for the user-facing behavior and release-gate changes from this spec. This is a release blocker. Do not mark the spec complete, call the implementation shipped, tag/release, or hand off as done while the hosted website is stale for shipped behavior.
 
 **Size:** M
-**Files:** `/Users/gordon/work/gno.sh/**`, `/Users/gordon/work/gno/docs/**`, `/Users/gordon/work/gno/spec/cli.md`, `/Users/gordon/work/gno/spec/output-schemas/doctor.schema.json`, `/Users/gordon/work/gno/README.md`, `/Users/gordon/work/gno/CHANGELOG.md` as source references only
+**Files:** `/Users/gordon/work/gno.sh/**`, `/Users/gordon/work/gno/docs/**`, `/Users/gordon/work/gno/scripts/package-smoke.ts`, `/Users/gordon/work/gno/package.json`, `/Users/gordon/work/gno/spec/cli.md`, `/Users/gordon/work/gno/spec/output-schemas/doctor.schema.json`, `/Users/gordon/work/gno/README.md`, `/Users/gordon/work/gno/CHANGELOG.md` as source references only
 
 ## Approach
 
 - Treat `/Users/gordon/work/gno.sh` as the production website source. Do not use this repo's legacy `website/` tree as a substitute.
 - Compare shipped user-facing behavior plus all in-repo docs/spec/changelog changes from tasks `.1` to `.4` against the public website. Update every affected product, install, docs/reference, troubleshooting, FAQ, and comparison page.
-- Cover embedding fingerprints, doctor diagnostics/JSON, same-run retry behavior in both normal backlog and `gno embed --force` flows, package smoke/release gates, and any changed recovery command guidance.
+- Cover embedding fingerprints, doctor diagnostics/JSON, same-run retry behavior in both normal backlog and `gno embed --force` flows, exact package smoke/release gate behavior from task `.4`, and any changed recovery command guidance.
 - Use the shipped doctor terms from task 2 exactly where user-facing: `embedding-fingerprint`, current fingerprint, pending/stale chunks, legacy vectors, mixed fingerprint groups, plus `gno embed` / `gno embed --force` recovery guidance.
+- Describe the shipped package gate precisely where user-facing: `scripts/package-smoke.ts`, exposed as `bun run test:package`, tarball-first via `npm pack`, install from the npm tarball into isolated temp paths, required package contents including `src/embed/retry.ts`, and packaged `gno doctor --json` asserting the `embedding-fingerprint.embeddingFingerprint` payload shape (`currentFingerprint`, `pendingChunks`, `legacyChunks`, `mixedGroups`, `groups`).
 - Keep website copy conservative: public docs must not claim behavior that is not implemented and verified in GNO.
 - Build and deploy from `/Users/gordon/work/gno.sh` in the same delivery path when website changes are part of the shipped work.
 - If deployment cannot happen, do not hide it. Record the blocker and exact remaining deploy/verification command in Flow evidence.
@@ -33,6 +35,8 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 - `/Users/gordon/work/gno/docs/TROUBLESHOOTING.md` — source troubleshooting guidance.
 - `/Users/gordon/work/gno/docs/INSTALLATION.md` — source doctor/install verification guidance.
 - `/Users/gordon/work/gno/docs/PACKAGING.md` — source package/release verification guidance.
+- `/Users/gordon/work/gno/scripts/package-smoke.ts` — shipped tarball smoke implementation and exact assertions.
+- `/Users/gordon/work/gno/package.json` — `test:package` script entry and prerelease wiring.
 - `/Users/gordon/work/gno/spec/cli.md` — source doctor JSON/terminal contract.
 - `/Users/gordon/work/gno/spec/output-schemas/doctor.schema.json` — shipped machine-readable doctor shape.
 - `/Users/gordon/work/gno/README.md` — high-level doctor/re-embed messaging already updated in-repo.
@@ -40,13 +44,15 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 
 ## Key context
 
-The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Task 2 changed the in-repo public doc surface (`README.md`, `docs/CLI.md`, `docs/INSTALLATION.md`, `docs/TROUBLESHOOTING.md`, `CHANGELOG.md`), and task 3 broadened the shipped retry behavior to cover `gno embed --force`; website drift remains release-blocking until deploy/verification is done or explicitly blocked in evidence.
+The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Task 2 changed the in-repo public doc surface (`README.md`, `docs/CLI.md`, `docs/INSTALLATION.md`, `docs/TROUBLESHOOTING.md`, `CHANGELOG.md`), task 3 broadened the shipped retry behavior to cover `gno embed --force`, and task 4 hardened the public release gate around `bun run test:package` with tarball install/package-content/fingerprint-shape proof. Website drift remains release-blocking until deploy/verification is done or explicitly blocked in evidence.
 
 ## Acceptance
 
 - [ ] `/Users/gordon/work/gno.sh` is audited against all user-facing changes from this spec, not just the obvious reference page.
-- [ ] Hosted docs reflect shipped fingerprint diagnostics, retry behavior for `gno embed` and `gno embed --force`, doctor JSON/user guidance, and package smoke gate wherever user-facing.
+- [ ] Hosted docs reflect shipped fingerprint diagnostics, retry behavior for `gno embed` and `gno embed --force`, doctor JSON/user guidance, and the exact package smoke gate wherever user-facing.
 - [ ] Hosted docs use the implemented doctor terminology and recovery commands from tasks 2 and 3 (`embedding-fingerprint`, `gno embed`, `gno embed --force`, same-run retry guidance) rather than older generic wording.
+- [ ] Hosted docs name the actual release gate from task `.4` as `bun run test:package` / `scripts/package-smoke.ts`, describe npm tarball-first install verification, and mention required packed contents including `src/embed/retry.ts` when that proof is user-facing.
+- [ ] Hosted docs describe the packaged doctor proof at the implemented fidelity: `gno doctor --json` must include the `embedding-fingerprint` check and its `embeddingFingerprint` payload shape, not just “doctor passes”.
 - [ ] Hosted docs avoid claims that go beyond implemented GNO behavior.
 - [ ] Website repo checks/build pass using that repo's package manager/runtime.
 - [ ] Production deploy runs from `/Users/gordon/work/gno.sh` when the behavior is shipped.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
@@ -2,18 +2,21 @@
 satisfies: [R7]
 ---
 
+<!-- Updated by plan-sync: fn-81-embedding-and-package-hardening.2 shipped public `embedding-fingerprint` doctor diagnostics plus `gno embed` / `gno embed --force` recovery guidance; hosted docs must reflect those exact terms before release -->
+
 ## Description
 
 Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.sh` for the user-facing behavior and release-gate changes from this spec. This is a release blocker. Do not mark the spec complete, call the implementation shipped, tag/release, or hand off as done while the hosted website is stale for shipped behavior.
 
 **Size:** M
-**Files:** `/Users/gordon/work/gno.sh/**`, `/Users/gordon/work/gno/docs/**` as source references only
+**Files:** `/Users/gordon/work/gno.sh/**`, `/Users/gordon/work/gno/docs/**`, `/Users/gordon/work/gno/spec/cli.md`, `/Users/gordon/work/gno/spec/output-schemas/doctor.schema.json`, `/Users/gordon/work/gno/README.md`, `/Users/gordon/work/gno/CHANGELOG.md` as source references only
 
 ## Approach
 
 - Treat `/Users/gordon/work/gno.sh` as the production website source. Do not use this repo's legacy `website/` tree as a substitute.
 - Compare all in-repo docs/spec/changelog changes from tasks `.1` to `.4` against the public website. Update every affected product, install, docs/reference, troubleshooting, FAQ, and comparison page.
 - Cover embedding fingerprints, doctor diagnostics/JSON, same-run embed retry behavior, package smoke/release gates, and any changed recovery command guidance.
+- Use the shipped doctor terms from task 2 exactly where user-facing: `embedding-fingerprint`, current fingerprint, pending/stale chunks, legacy vectors, mixed fingerprint groups, plus `gno embed` / `gno embed --force` recovery guidance.
 - Keep website copy conservative: public docs must not claim behavior that is not implemented and verified in GNO.
 - Build and deploy from `/Users/gordon/work/gno.sh` in the same delivery path when website changes are part of the shipped work.
 - If deployment cannot happen, do not hide it. Record the blocker and exact remaining deploy/verification command in Flow evidence.
@@ -29,20 +32,20 @@ Update and deploy the canonical hosted website repo at `/Users/gordon/work/gno.s
 - `/Users/gordon/work/gno/docs/TROUBLESHOOTING.md` — source troubleshooting guidance.
 - `/Users/gordon/work/gno/docs/INSTALLATION.md` — source doctor/install verification guidance.
 - `/Users/gordon/work/gno/docs/PACKAGING.md` — source package/release verification guidance.
+- `/Users/gordon/work/gno/spec/cli.md` — source doctor JSON/terminal contract.
+- `/Users/gordon/work/gno/spec/output-schemas/doctor.schema.json` — shipped machine-readable doctor shape.
+- `/Users/gordon/work/gno/README.md` — high-level doctor/re-embed messaging already updated in-repo.
 - `/Users/gordon/work/gno/CHANGELOG.md` — shipped behavior summary if user-visible.
-
-**Optional**
-
-- `/Users/gordon/work/gno/README.md` — high-level migration/release messaging.
 
 ## Key context
 
-The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Website drift is user-visible drift.
+The instruction files say new features, CLI/MCP/API output changes, model behavior, and troubleshooting updates must also be reflected in `/Users/gordon/work/gno.sh` when they affect website docs, product pages, install pages, comparisons, or FAQs. This spec changes CLI diagnostics, embedding behavior, troubleshooting, install/release verification, and likely public docs. Task 2 already changed the in-repo public doc surface (`README.md`, `docs/CLI.md`, `docs/INSTALLATION.md`, `docs/TROUBLESHOOTING.md`, `CHANGELOG.md`) and website drift remains release-blocking until deploy/verification is done or explicitly blocked in evidence.
 
 ## Acceptance
 
 - [ ] `/Users/gordon/work/gno.sh` is audited against all user-facing changes from this spec, not just the obvious reference page.
 - [ ] Hosted docs reflect shipped fingerprint diagnostics, retry behavior, doctor JSON/user guidance, and package smoke gate wherever user-facing.
+- [ ] Hosted docs use the implemented doctor terminology and recovery commands from task 2 (`embedding-fingerprint`, `gno embed`, `gno embed --force`) rather than older generic wording.
 - [ ] Hosted docs avoid claims that go beyond implemented GNO behavior.
 - [ ] Website repo checks/build pass using that repo's package manager/runtime.
 - [ ] Production deploy runs from `/Users/gordon/work/gno.sh` when the behavior is shipped.

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
@@ -60,8 +60,11 @@ The instruction files say new features, CLI/MCP/API output changes, model behavi
 - [ ] If deploy is blocked, Flow evidence explicitly says the hosted website remains stale and lists the exact remaining command/verification steps.
 
 ## Done summary
+
 Updated the canonical hosted website repo with public docs for embedding fingerprint diagnostics, same-run embed retry recovery, and the packed npm package smoke gate. Website changes were committed and pushed to gno.sh main, but production deploy is blocked by SSH timeout to root@178.104.180.89:22; live site remains stale for the new /docs/packaging page until deploy runs.
+
 ## Evidence
+
 - Commits: 2e6881abc0b5d5c064da4ba6901492779733f110
 - Tests: cd /Users/gordon/work/gno.sh && bun run typecheck (pass), cd /Users/gordon/work/gno.sh && bun run test (pass: 76 passed, 3 skipped), cd /Users/gordon/work/gno.sh && bun run check (pass after formatting), cd /Users/gordon/work/gno.sh && bun run build (pass; prerendered /docs/packaging), cd /Users/gordon/work/gno.sh && git push origin main (pass; 2e6881a pushed), cd /Users/gordon/work/gno.sh && DEPLOY_HOST=root@178.104.180.89 ./scripts/deploy-prod.sh (blocked: ssh connect to host 178.104.180.89 port 22 Operation timed out), curl -fsSI https://gno.sh (pass: HTTP/2 200), curl -fsSL https://gno.sh/docs/packaging | head -20 (blocked/stale: HTTP 404 because deploy did not complete), ssh -o ConnectTimeout=15 root@178.104.180.89 "systemctl is-active gno-sh && cd /srv/gno-sh/repo && git rev-parse --short HEAD" (blocked: ssh connect to host 178.104.180.89 port 22 Operation timed out)
 - PRs:

--- a/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
+++ b/.flow/tasks/fn-81-embedding-and-package-hardening.5.md
@@ -60,9 +60,8 @@ The instruction files say new features, CLI/MCP/API output changes, model behavi
 - [ ] If deploy is blocked, Flow evidence explicitly says the hosted website remains stale and lists the exact remaining command/verification steps.
 
 ## Done summary
-
-_Not started._
-
+Updated the canonical hosted website repo with public docs for embedding fingerprint diagnostics, same-run embed retry recovery, and the packed npm package smoke gate. Website changes were committed and pushed to gno.sh main, but production deploy is blocked by SSH timeout to root@178.104.180.89:22; live site remains stale for the new /docs/packaging page until deploy runs.
 ## Evidence
-
-_Not started._
+- Commits: 2e6881abc0b5d5c064da4ba6901492779733f110
+- Tests: cd /Users/gordon/work/gno.sh && bun run typecheck (pass), cd /Users/gordon/work/gno.sh && bun run test (pass: 76 passed, 3 skipped), cd /Users/gordon/work/gno.sh && bun run check (pass after formatting), cd /Users/gordon/work/gno.sh && bun run build (pass; prerendered /docs/packaging), cd /Users/gordon/work/gno.sh && git push origin main (pass; 2e6881a pushed), cd /Users/gordon/work/gno.sh && DEPLOY_HOST=root@178.104.180.89 ./scripts/deploy-prod.sh (blocked: ssh connect to host 178.104.180.89 port 22 Operation timed out), curl -fsSI https://gno.sh (pass: HTTP/2 200), curl -fsSL https://gno.sh/docs/packaging | head -20 (blocked/stale: HTTP 404 because deploy did not complete), ssh -o ConnectTimeout=15 root@178.104.180.89 "systemctl is-active gno-sh && cd /srv/gno-sh/repo && git rev-parse --short HEAD" (blocked: ssh connect to host 178.104.180.89 port 22 Operation timed out)
+- PRs:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,6 +46,8 @@ Desktop beta rollout scaffolding:
 ```bash
 bun run lint:check      # Must pass
 bun test                # Must pass
+bun run docs:verify     # Must pass
+bun run test:package    # Must pass
 bun run eval            # Must pass 70% threshold
 ```
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -214,26 +214,15 @@ jobs:
       - name: Build CSS
         run: bun run build:css
 
-      - name: Pack
-        run: npm pack
-
-      - name: Test packed tarball
-        run: |
-          # Install from tarball globally (use npm - bun has issues with local tarballs)
-          npm install -g ./gmickel-gno-*.tgz
-
-          # Verify CLI works
-          gno --version
-          gno --help
-
-          # Run doctor (may fail if no index, but should at least run)
-          gno doctor --json || true
+      - name: Test packed package
+        run: GNO_PACKAGE_SMOKE_KEEP_TEMP=1 bun run test:package
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: npm-package
-          path: gmickel-gno-*.tgz
+          path: /tmp/gno-package-smoke-*/pack/gmickel-gno-*.tgz
+          if-no-files-found: ignore
 
   publish:
     needs: pack-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `gno doctor` embedding fingerprint diagnostics for current freshness
+  fingerprint, pending/stale chunks, legacy vectors, and mixed stored
+  fingerprint groups.
+
 ## [1.6.0] - 2026-05-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ gno daemon --detach  # headless continuous indexing (background; --status / --st
 - **Retrieval Quality Upgrade**: stronger BM25 lexical handling, code-aware chunking, terminal result hyperlinks, and per-collection model overrides
 - **Code Embedding Benchmarks**: new benchmark workflow across canonical, real-GNO, and pinned OSS slices for comparing alternate embedding models
 - **Default Embed Model**: built-in presets now use `Qwen3-Embedding-0.6B-GGUF` after it beat `bge-m3` on both code and multilingual prose benchmark lanes
-- **Regression Fixes**: tightened phrase/negation/hyphen/underscore BM25 behavior, cleaned non-TTY hyperlink output, improved `gno doctor` chunking visibility, and fixed the embedding autoresearch harness
+- **Regression Fixes**: tightened phrase/negation/hyphen/underscore BM25 behavior, cleaned non-TTY hyperlink output, improved `gno doctor` chunking and embedding fingerprint visibility, and fixed the embedding autoresearch harness
 
 ### Upgrading Existing Collections
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -901,6 +901,8 @@ Checks include:
 - vendored `fts5-snowball` extension loading
 - `sqlite-vec` extension loading
 - local model cache readiness
+- embedding fingerprint freshness: current fingerprint, pending/stale chunks,
+  legacy empty-fingerprint vectors, and mixed stored fingerprint groups
 
 ### gno cleanup
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -23,6 +23,10 @@ bun install -g @gmickel/gno
 gno doctor
 ```
 
+Release packages are smoke-tested with `bun run test:package`, which installs
+the packed npm tarball into isolated temp paths and verifies packaged
+`gno --version`, `gno --help`, and `gno doctor --json` before publish.
+
 If you want a guided setup after install, run `gno serve` and open `http://localhost:3000`. The first-run dashboard can add a folder, explain health, show bootstrap/runtime status, and trigger model downloads without more terminal work.
 
 If you want a headless long-running process instead, run:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -205,7 +205,12 @@ gno doctor --json
       "status": "warn",
       "message": "rerank model not cached"
     },
-    { "name": "gen-model", "status": "ok", "message": "gen model cached" }
+    { "name": "gen-model", "status": "ok", "message": "gen model cached" },
+    {
+      "name": "embedding-fingerprint",
+      "status": "ok",
+      "message": "current abc123def456, 0 pending/stale, 0 legacy, 1 group"
+    }
   ]
 }
 ```

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -175,6 +175,18 @@ Before claiming a surface as Supported/Beta:
 - `bun run typecheck`
 - `bun test`
 - `bun run docs:verify`
+- `bun run test:package`
+
+CLI package proof:
+
+- packs the npm tarball from the same `package.json` file allowlist used for
+  publish
+- verifies required runtime files ship, including `src/embed/retry.ts`
+- installs from the tarball into isolated `HOME`, `GNO_*`, npm cache, and npm
+  prefix paths
+- runs packaged `gno --version`, `gno --help`, and `gno doctor --json`
+- asserts the packaged doctor JSON includes the `embedding-fingerprint` check
+  and its `embeddingFingerprint` payload
 
 Desktop-specific proof:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -459,6 +459,23 @@ The same is true if a release changes the formatting profile for your active
 embedding model. If document/query vectors are produced differently after the
 upgrade, run `gno embed` again so stored vectors match the new formatter.
 
+`gno doctor` reports this as the `embedding-fingerprint` check. It shows the
+current fingerprint, pending/stale chunks, legacy empty-fingerprint vectors, and
+stored fingerprint groups. Warnings mean vector search can still run, but you
+should re-embed:
+
+```bash
+gno doctor
+gno embed
+```
+
+If doctor still reports stale or mixed vectors after a normal embed, force a
+full refresh:
+
+```bash
+gno embed --force
+```
+
 ### I want to remove old embeddings after switching models
 
 Use collection-level cleanup when you want to reclaim space or remove stale

--- a/evals/helpers/retrieval-candidate-benchmark.ts
+++ b/evals/helpers/retrieval-candidate-benchmark.ts
@@ -21,6 +21,7 @@ import type { VectorIndexPort, VectorRow } from "../../src/store/vector/types";
 
 import { createDefaultConfig } from "../../src/config";
 import { DEFAULT_MODEL_PRESETS } from "../../src/config/types";
+import { getEmbeddingFingerprint } from "../../src/embed/fingerprint";
 import { LlmAdapter } from "../../src/llm/nodeLlamaCpp/adapter";
 import {
   processAnswerResult,
@@ -502,6 +503,10 @@ async function ensureVectorIndex(runtime: {
         mirrorHash: row.mirrorHash,
         seq: row.seq,
         model: embedUri,
+        embedFingerprint: getEmbeddingFingerprint({
+          modelUri: embedUri,
+          dimensions: embedBatchResult.value[batchIndex]?.length,
+        }),
         embedding: new Float32Array(embedBatchResult.value[batchIndex] ?? []),
       }));
       const upsertResult = await vectorIndex.upsertVectors(vectorRows);

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:web": "bun test test/serve/public --timeout 30000",
     "test:e2e": "bun scripts/web-ui-smoke.ts",
     "test:e2e:install": "bunx playwright install chromium",
+    "test:package": "bun scripts/package-smoke.ts",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
     "test:coverage:html": "bun test --coverage --html",
@@ -130,7 +131,7 @@
     "version:patch": "npm version patch --no-git-tag-version",
     "version:minor": "npm version minor --no-git-tag-version",
     "version:major": "npm version major --no-git-tag-version",
-    "prerelease": "bun run lint:check && bun test",
+    "prerelease": "bun run lint:check && bun test && bun run docs:verify && bun run test:package",
     "release:dry-run": "gh workflow run publish.yml -f publish=false",
     "release:trigger": "gh workflow run publish.yml -f publish=true",
     "prepare": "lefthook install"

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -1,0 +1,260 @@
+// node:fs/promises: temp dir structure and cleanup have no Bun-native equivalent.
+import { mkdir, mkdtemp } from "node:fs/promises";
+// node:os: tmpdir has no Bun-native equivalent.
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { safeRm } from "../test/helpers/cleanup";
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+interface DoctorCheck {
+  name: string;
+  status: "ok" | "warn" | "error";
+  message: string;
+  embeddingFingerprint?: {
+    currentFingerprint: string;
+    pendingChunks: number;
+    legacyChunks: number;
+    mixedGroups: number;
+    groups: unknown[];
+  };
+}
+
+interface DoctorResult {
+  healthy: boolean;
+  checks: DoctorCheck[];
+}
+
+interface NpmPackResult {
+  filename: string;
+}
+
+const rootDir = resolve(import.meta.dir, "..");
+const preserveTemp = process.env.GNO_PACKAGE_SMOKE_KEEP_TEMP === "1";
+
+function formatCommand(cmd: string[]): string {
+  return cmd
+    .map((part) => (part.includes(" ") ? JSON.stringify(part) : part))
+    .join(" ");
+}
+
+function runCommand(
+  cmd: string[],
+  cwd: string,
+  env: Record<string, string>
+): CommandResult {
+  const result = Bun.spawnSync(cmd, {
+    cwd,
+    env: { ...process.env, ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const stdout = result.stdout ? new TextDecoder().decode(result.stdout) : "";
+  const stderr = result.stderr ? new TextDecoder().decode(result.stderr) : "";
+  if (result.exitCode !== 0) {
+    throw new Error(
+      [
+        `Command failed: ${formatCommand(cmd)}`,
+        `Exit: ${result.exitCode}`,
+        "Stdout:",
+        stdout || "(empty)",
+        "Stderr:",
+        stderr || "(empty)",
+      ].join("\n")
+    );
+  }
+  return { stdout, stderr };
+}
+
+function parseNpmPackOutput(stdout: string): NpmPackResult {
+  const jsonStart = stdout.indexOf("[");
+  const jsonEnd = stdout.lastIndexOf("]");
+  const jsonPayload =
+    jsonStart >= 0 && jsonEnd > jsonStart
+      ? stdout.slice(jsonStart, jsonEnd + 1)
+      : stdout;
+  try {
+    const results = JSON.parse(jsonPayload) as NpmPackResult[];
+    const first = results[0];
+    if (first?.filename) {
+      return first;
+    }
+  } catch {
+    // Fall through to the explicit error below.
+  }
+  throw new Error(`Unable to parse npm pack JSON output:\n${stdout}`);
+}
+
+function assertTarEntry(entries: string[], path: string): void {
+  if (!entries.includes(path)) {
+    throw new Error(`Packed tarball missing required file: ${path}`);
+  }
+}
+
+function assertTarPrefix(entries: string[], path: string): void {
+  if (!entries.some((entry) => entry.startsWith(path))) {
+    throw new Error(`Packed tarball missing required package path: ${path}`);
+  }
+}
+
+async function verifyTarballContents(tarballPath: string): Promise<void> {
+  const packageJson = (await Bun.file(
+    join(rootDir, "package.json")
+  ).json()) as {
+    files?: string[];
+  };
+  const entries = runCommand(["tar", "-tzf", tarballPath], rootDir, {})
+    .stdout.split("\n")
+    .filter(Boolean);
+
+  for (const allowlistedPath of packageJson.files ?? []) {
+    assertTarPrefix(entries, `package/${allowlistedPath}`);
+  }
+
+  for (const requiredFile of [
+    "package/package.json",
+    "package/bunfig.toml",
+    "package/src/index.ts",
+    "package/src/sdk/index.ts",
+    "package/src/embed/retry.ts",
+    "package/src/serve/public/globals.built.css",
+    "package/THIRD_PARTY_NOTICES.md",
+  ]) {
+    assertTarEntry(entries, requiredFile);
+  }
+}
+
+function parseDoctorJson(stdout: string): DoctorResult {
+  try {
+    return JSON.parse(stdout) as DoctorResult;
+  } catch (error) {
+    throw new Error(
+      `gno doctor --json did not produce valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }\n${stdout}`
+    );
+  }
+}
+
+function assertEmbeddingFingerprintShape(result: DoctorResult): void {
+  const check = result.checks.find(
+    (candidate) => candidate.name === "embedding-fingerprint"
+  );
+  if (!check) {
+    throw new Error("doctor output missing embedding-fingerprint check");
+  }
+  const payload = check.embeddingFingerprint;
+  if (!payload) {
+    throw new Error("embedding-fingerprint check missing embeddingFingerprint");
+  }
+
+  const validShape =
+    typeof payload.currentFingerprint === "string" &&
+    Number.isInteger(payload.pendingChunks) &&
+    Number.isInteger(payload.legacyChunks) &&
+    Number.isInteger(payload.mixedGroups) &&
+    Array.isArray(payload.groups);
+  if (!validShape) {
+    throw new Error(
+      `embeddingFingerprint has unexpected shape:\n${JSON.stringify(payload, null, 2)}`
+    );
+  }
+}
+
+function assertNoDoctorErrors(result: DoctorResult): void {
+  const errors = result.checks.filter((check) => check.status === "error");
+  if (errors.length > 0) {
+    throw new Error(
+      `gno doctor --json reported error checks:\n${JSON.stringify(errors, null, 2)}`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const tempRoot = await mkdtemp(join(tmpdir(), "gno-package-smoke-"));
+  const packDir = join(tempRoot, "pack");
+  const installPrefix = join(tempRoot, "prefix");
+  const npmCacheDir = join(tempRoot, "npm-cache");
+  const npmUserConfig = join(tempRoot, "npmrc");
+  const homeDir = join(tempRoot, "home");
+  const notesDir = join(tempRoot, "notes");
+  const env = {
+    GNO_CACHE_DIR: join(tempRoot, "gno-cache"),
+    GNO_CONFIG_DIR: join(tempRoot, "gno-config"),
+    GNO_DATA_DIR: join(tempRoot, "gno-data"),
+    GNO_NO_AUTO_DOWNLOAD: "1",
+    HOME: homeDir,
+    npm_config_cache: npmCacheDir,
+    npm_config_prefix: installPrefix,
+    npm_config_userconfig: npmUserConfig,
+    XDG_CACHE_HOME: join(tempRoot, "xdg-cache"),
+    XDG_CONFIG_HOME: join(tempRoot, "xdg-config"),
+    XDG_DATA_HOME: join(tempRoot, "xdg-data"),
+  };
+
+  try {
+    await mkdir(packDir, { recursive: true });
+    await mkdir(homeDir, { recursive: true });
+    await mkdir(notesDir, { recursive: true });
+    await Bun.write(npmUserConfig, "");
+    await Bun.write(join(notesDir, "hello.md"), "# Hello\n\nPackage smoke.\n");
+
+    const pack = runCommand(
+      ["npm", "pack", "--json", "--pack-destination", packDir],
+      rootDir,
+      env
+    );
+    const packed = parseNpmPackOutput(pack.stdout);
+    const tarballPath = join(packDir, packed.filename);
+    await verifyTarballContents(tarballPath);
+
+    runCommand(
+      [
+        "npm",
+        "install",
+        "--global",
+        "--prefix",
+        installPrefix,
+        "--cache",
+        npmCacheDir,
+        tarballPath,
+      ],
+      tempRoot,
+      env
+    );
+
+    const gnoBin = join(installPrefix, "bin", "gno");
+    runCommand([gnoBin, "--version"], tempRoot, env);
+    runCommand([gnoBin, "--help"], tempRoot, env);
+    runCommand(
+      [gnoBin, "init", notesDir, "--name", "package-smoke"],
+      tempRoot,
+      env
+    );
+
+    const doctor = parseDoctorJson(
+      runCommand([gnoBin, "doctor", "--json"], tempRoot, env).stdout
+    );
+    assertEmbeddingFingerprintShape(doctor);
+    assertNoDoctorErrors(doctor);
+
+    console.log(`Package smoke passed: ${tarballPath}`);
+  } catch (error) {
+    console.error(`Package smoke temp root: ${tempRoot}`);
+    console.error(
+      "Set GNO_PACKAGE_SMOKE_KEEP_TEMP=1 to preserve temp dirs on success."
+    );
+    throw error;
+  } finally {
+    if (!preserveTemp) {
+      await safeRm(tempRoot);
+    }
+  }
+}
+
+await main();

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -1180,10 +1180,41 @@ gno doctor [--json|--md]
       "name": "node-llama-cpp",
       "status": "ok",
       "message": "node-llama-cpp loaded successfully"
+    },
+    {
+      "name": "embedding-fingerprint",
+      "status": "warn",
+      "message": "current abc123def456, 12 pending/stale, 3 legacy, 2 groups",
+      "details": [
+        "Run: gno embed",
+        "If vectors still look stale, run: gno embed --force"
+      ],
+      "embeddingFingerprint": {
+        "model": "hf:Qwen/Qwen3-Embedding-0.6B-GGUF:Qwen3-Embedding-0.6B-Q8_0.gguf",
+        "currentFingerprint": "abc123def4567890",
+        "pendingChunks": 12,
+        "legacyChunks": 3,
+        "mixedGroups": 2,
+        "groups": [
+          {
+            "model": "hf:Qwen/Qwen3-Embedding-0.6B-GGUF:Qwen3-Embedding-0.6B-Q8_0.gguf",
+            "fingerprint": "abc123def4567890",
+            "count": 42,
+            "current": true,
+            "legacy": false
+          }
+        ]
+      }
     }
   ]
 }
 ```
+
+The `embedding-fingerprint` check is additive doctor-only diagnostics. It uses
+the active embed model and stored vector dimensions to report the current
+freshness fingerprint, pending/stale chunks, legacy empty-fingerprint vectors,
+and stored fingerprint groups. Stale, legacy, and mixed groups are warnings;
+recover with `gno embed`, or `gno embed --force` if vectors still look stale.
 
 **Exit Codes:**
 

--- a/spec/db/schema.sql
+++ b/spec/db/schema.sql
@@ -167,6 +167,7 @@ CREATE TABLE IF NOT EXISTS content_vectors (
   mirror_hash TEXT NOT NULL,
   seq INTEGER NOT NULL,
   model TEXT NOT NULL,              -- Model identifier (e.g., 'bge-m3')
+  embed_fingerprint TEXT NOT NULL DEFAULT '',
   embedding BLOB NOT NULL,          -- Float32Array serialized
   embedded_at TEXT NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (mirror_hash, seq, model),
@@ -174,6 +175,8 @@ CREATE TABLE IF NOT EXISTS content_vectors (
 );
 
 CREATE INDEX IF NOT EXISTS idx_vectors_model ON content_vectors(model);
+CREATE INDEX IF NOT EXISTS idx_vectors_freshness
+  ON content_vectors(model, embed_fingerprint, mirror_hash, seq, embedded_at);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- LLM Cache (EPIC 6+)

--- a/spec/output-schemas/doctor.schema.json
+++ b/spec/output-schemas/doctor.schema.json
@@ -29,6 +29,76 @@
           "message": {
             "type": "string",
             "description": "Human-readable status message"
+          },
+          "details": {
+            "type": "array",
+            "description": "Additional diagnostic details and recovery guidance",
+            "items": {
+              "type": "string"
+            }
+          },
+          "embeddingFingerprint": {
+            "type": "object",
+            "description": "Embedding freshness fingerprint diagnostics",
+            "required": [
+              "model",
+              "currentFingerprint",
+              "pendingChunks",
+              "legacyChunks",
+              "mixedGroups",
+              "groups"
+            ],
+            "properties": {
+              "model": {
+                "type": "string"
+              },
+              "currentFingerprint": {
+                "type": "string"
+              },
+              "pendingChunks": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "legacyChunks": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "mixedGroups": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "model",
+                    "fingerprint",
+                    "count",
+                    "current",
+                    "legacy"
+                  ],
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "fingerprint": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "current": {
+                      "type": "boolean"
+                    },
+                    "legacy": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -17,13 +17,15 @@ import { getConfigPaths, isInitialized, loadConfig } from "../../config";
 import { getCodeChunkingStatus } from "../../ingestion/chunker";
 import { ModelCache } from "../../llm/cache";
 import { LlmAdapter } from "../../llm/nodeLlamaCpp/adapter";
-import { getActivePreset } from "../../llm/registry";
+import { getActivePreset, resolveModelUri } from "../../llm/registry";
+import { SqliteAdapter } from "../../store/sqlite/adapter";
 import { loadFts5Snowball } from "../../store/sqlite/fts5-snowball";
 import {
   getCustomSqlitePath,
   getExtensionLoadingMode,
   getLoadAttempts,
 } from "../../store/sqlite/setup";
+import { getStoredEmbeddingFingerprint } from "../../store/vector/freshness";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -37,6 +39,25 @@ export interface DoctorCheck {
   message: string;
   /** Additional diagnostic details (shown in verbose/json output) */
   details?: string[];
+  /** Embedding fingerprint diagnostics for machine consumers */
+  embeddingFingerprint?: EmbeddingFingerprintHealth;
+}
+
+export interface EmbeddingFingerprintGroup {
+  model: string;
+  fingerprint: string;
+  count: number;
+  current: boolean;
+  legacy: boolean;
+}
+
+export interface EmbeddingFingerprintHealth {
+  model: string;
+  currentFingerprint: string;
+  pendingChunks: number;
+  legacyChunks: number;
+  mixedGroups: number;
+  groups: EmbeddingFingerprintGroup[];
 }
 
 export interface DoctorOptions {
@@ -135,6 +156,160 @@ function checkCodeChunking(): DoctorCheck {
       "Chunking mode is automatic-only in the first pass.",
     ],
   };
+}
+
+const FINGERPRINT_DISPLAY_LENGTH = 12;
+
+function shortFingerprint(fingerprint: string): string {
+  return fingerprint.slice(0, FINGERPRINT_DISPLAY_LENGTH);
+}
+
+function describeFingerprintGroup(group: EmbeddingFingerprintGroup): string {
+  if (group.current) {
+    return "current";
+  }
+  if (group.legacy) {
+    return "legacy";
+  }
+  return "stale";
+}
+
+async function checkEmbeddingFingerprints(
+  config: Config
+): Promise<DoctorCheck> {
+  const dbPath = getIndexDbPath();
+  try {
+    await stat(dbPath);
+  } catch {
+    return {
+      name: "embedding-fingerprint",
+      status: "warn",
+      message: "Database not found. Run: gno init",
+    };
+  }
+
+  const store = new SqliteAdapter();
+  const paths = getConfigPaths();
+  store.setConfigPath(paths.configFile);
+
+  const openResult = await store.open(dbPath, config.ftsTokenizer);
+  if (!openResult.ok) {
+    return {
+      name: "embedding-fingerprint",
+      status: "warn",
+      message: `Fingerprint health unavailable: ${openResult.error.message}`,
+      details: ["Run: gno doctor --json", "Then run: gno embed"],
+    };
+  }
+
+  try {
+    const db = store.getRawDb();
+    const model = resolveModelUri(config, "embed");
+    const currentFingerprint = getStoredEmbeddingFingerprint(db, model);
+    const statusResult = await store.getStatus({ embedModel: model });
+    if (!statusResult.ok) {
+      return {
+        name: "embedding-fingerprint",
+        status: "warn",
+        message: `Fingerprint health unavailable: ${statusResult.error.message}`,
+        details: ["Run: gno embed"],
+      };
+    }
+
+    const legacyChunks =
+      db
+        .query<{ count: number }, [string]>(
+          `
+          SELECT COUNT(*) as count
+          FROM content_vectors v
+          JOIN content_chunks c
+            ON c.mirror_hash = v.mirror_hash
+           AND c.seq = v.seq
+          WHERE v.model = ?
+            AND v.embed_fingerprint = ''
+            AND EXISTS (
+              SELECT 1 FROM documents d
+              WHERE d.mirror_hash = c.mirror_hash
+                AND d.active = 1
+            )
+        `
+        )
+        .get(model)?.count ?? 0;
+
+    const groups = db
+      .query<{ model: string; fingerprint: string; count: number }, []>(
+        `
+        SELECT
+          v.model as model,
+          v.embed_fingerprint as fingerprint,
+          COUNT(*) as count
+        FROM content_vectors v
+        JOIN content_chunks c
+          ON c.mirror_hash = v.mirror_hash
+         AND c.seq = v.seq
+        WHERE EXISTS (
+          SELECT 1 FROM documents d
+          WHERE d.mirror_hash = c.mirror_hash
+            AND d.active = 1
+        )
+        GROUP BY v.model, v.embed_fingerprint
+        ORDER BY count DESC, v.model ASC, v.embed_fingerprint ASC
+      `
+      )
+      .all()
+      .map((group) => ({
+        model: group.model,
+        fingerprint: group.fingerprint,
+        count: group.count,
+        current:
+          group.model === model && group.fingerprint === currentFingerprint,
+        legacy: group.fingerprint === "",
+      }));
+
+    const mixedGroups = groups.length;
+    const pendingChunks = statusResult.value.embeddingBacklog;
+    const hasWarnings =
+      pendingChunks > 0 || legacyChunks > 0 || mixedGroups > 1;
+
+    const health: EmbeddingFingerprintHealth = {
+      model,
+      currentFingerprint,
+      pendingChunks,
+      legacyChunks,
+      mixedGroups,
+      groups,
+    };
+
+    const message =
+      `current ${shortFingerprint(currentFingerprint)}, ` +
+      `${pendingChunks} pending/stale, ${legacyChunks} legacy, ` +
+      `${mixedGroups} group${mixedGroups === 1 ? "" : "s"}`;
+    const details: string[] = [];
+
+    if (hasWarnings) {
+      details.push("Run: gno embed");
+      details.push("If vectors still look stale, run: gno embed --force");
+      for (const group of groups) {
+        const label = describeFingerprintGroup(group);
+        const fingerprint = group.legacy
+          ? "(empty)"
+          : shortFingerprint(group.fingerprint);
+        details.push(
+          `${label}: ${group.count} chunks model=${group.model} fingerprint=${fingerprint}`
+        );
+      }
+    }
+
+    return {
+      name: "embedding-fingerprint",
+      status: hasWarnings ? "warn" : "ok",
+      message,
+      details: details.length > 0 ? details : undefined,
+      embeddingFingerprint: health,
+    };
+  } finally {
+    await store.close();
+  }
 }
 
 async function checkNodeLlamaCpp(config: Config): Promise<DoctorCheck> {
@@ -340,6 +515,9 @@ export async function doctor(
 
   // Code chunking capability
   checks.push(checkCodeChunking());
+
+  // Embedding fingerprint freshness
+  checks.push(await checkEmbeddingFingerprints(config));
 
   // Determine overall health
   const hasErrors = checks.some((c) => c.status === "error");

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -37,7 +37,6 @@ import {
   type VectorIndexPort,
   type VectorStatsPort,
 } from "../../store/vector";
-import { getStoredEmbeddingFingerprint } from "../../store/vector/freshness";
 import { getGlobals } from "../program";
 import {
   createProgressRenderer,
@@ -447,45 +446,26 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
     // Create stats port for backlog detection
     const stats: VectorStatsPort = createVectorStatsPort(db);
 
-    // Get backlog count first (before loading model)
-    const backlogResult = force
-      ? await getActiveChunkCount(db, options.collection)
-      : await stats.countBacklog(
-          modelUri,
-          getStoredEmbeddingFingerprint(db, modelUri),
-          { collection: options.collection }
-        );
+    let totalToEmbed = 0;
+    if (force) {
+      const forceCount = await getActiveChunkCount(db, options.collection);
+      if (!forceCount.ok) {
+        return { success: false, error: forceCount.error.message };
+      }
+      totalToEmbed = forceCount.value;
 
-    if (!backlogResult.ok) {
-      return { success: false, error: backlogResult.error.message };
-    }
-
-    const totalToEmbed = backlogResult.value;
-
-    if (totalToEmbed === 0) {
-      const vecAvailable = await checkVecAvailable(db);
-      return {
-        success: true,
-        embedded: 0,
-        errors: 0,
-        duration: 0,
-        model: modelUri,
-        searchAvailable: vecAvailable,
-        errorSamples: [],
-      };
-    }
-
-    if (dryRun) {
-      const vecAvailable = await checkVecAvailable(db);
-      return {
-        success: true,
-        embedded: totalToEmbed,
-        errors: 0,
-        duration: 0,
-        model: modelUri,
-        searchAvailable: vecAvailable,
-        errorSamples: [],
-      };
+      if (totalToEmbed === 0 || dryRun) {
+        const vecAvailable = await checkVecAvailable(db);
+        return {
+          success: true,
+          embedded: totalToEmbed,
+          errors: 0,
+          duration: 0,
+          model: modelUri,
+          searchAvailable: vecAvailable,
+          errorSamples: [],
+        };
+      }
     }
 
     // Create LLM adapter and embedding port with auto-download
@@ -554,6 +534,38 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
       return { success: false, error: vectorResult.error.message };
     }
     vectorIndex = vectorResult.value;
+
+    if (!force) {
+      const embedFingerprint = getEmbeddingFingerprint({
+        modelUri,
+        dimensions,
+      });
+      const backlogResult = await stats.countBacklog(
+        modelUri,
+        embedFingerprint,
+        {
+          collection: options.collection,
+        }
+      );
+
+      if (!backlogResult.ok) {
+        return { success: false, error: backlogResult.error.message };
+      }
+
+      totalToEmbed = backlogResult.value;
+
+      if (totalToEmbed === 0 || dryRun) {
+        return {
+          success: true,
+          embedded: totalToEmbed,
+          errors: 0,
+          duration: 0,
+          model: modelUri,
+          searchAvailable: vectorIndex.searchAvailable,
+          errorSamples: [],
+        };
+      }
+    }
 
     // Process batches
     const result = await processBatches({

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -18,6 +18,7 @@ import {
   loadConfig,
 } from "../../config";
 import { embedTextsWithRecovery } from "../../embed/batch";
+import { getEmbeddingFingerprint } from "../../embed/fingerprint";
 import { LlmAdapter } from "../../llm/nodeLlamaCpp/adapter";
 import { resolveDownloadPolicy } from "../../llm/policy";
 import { resolveModelUri } from "../../llm/registry";
@@ -32,6 +33,7 @@ import {
   type VectorRow,
   type VectorStatsPort,
 } from "../../store/vector";
+import { getStoredEmbeddingFingerprint } from "../../store/vector/freshness";
 import { getGlobals } from "../program";
 import {
   createProgressRenderer,
@@ -168,6 +170,10 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
   const errorSamples: string[] = [];
   let suggestion: string | undefined;
   let cursor: Cursor | undefined;
+  const embedFingerprint = getEmbeddingFingerprint({
+    modelUri: ctx.modelUri,
+    dimensions: ctx.vectorIndex.dimensions,
+  });
 
   const pushErrorSamples = (samples: string[]): void => {
     for (const sample of samples) {
@@ -184,7 +190,7 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
     // Get next batch using seek pagination (cursor-based)
     const batchResult = ctx.force
       ? await getActiveChunks(ctx.db, ctx.batchSize, cursor, ctx.collection)
-      : await ctx.stats.getBacklog(ctx.modelUri, {
+      : await ctx.stats.getBacklog(ctx.modelUri, embedFingerprint, {
           limit: ctx.batchSize,
           after: cursor,
           collection: ctx.collection,
@@ -249,6 +255,7 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
                 mirrorHash: item.mirrorHash,
                 seq: item.seq,
                 model: ctx.modelUri,
+                embedFingerprint,
                 embedding: new Float32Array(embedding),
               });
             }
@@ -348,6 +355,7 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
         mirrorHash: item.mirrorHash,
         seq: item.seq,
         model: ctx.modelUri,
+        embedFingerprint,
         embedding: new Float32Array(embedding),
       });
     }
@@ -491,7 +499,11 @@ export async function embed(options: EmbedOptions = {}): Promise<EmbedResult> {
     // Get backlog count first (before loading model)
     const backlogResult = force
       ? await getActiveChunkCount(db, options.collection)
-      : await stats.countBacklog(modelUri, { collection: options.collection });
+      : await stats.countBacklog(
+          modelUri,
+          getStoredEmbeddingFingerprint(db, modelUri),
+          { collection: options.collection }
+        );
 
     if (!backlogResult.ok) {
       return { success: false, error: backlogResult.error.message };

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -17,12 +17,17 @@ import {
   isInitialized,
   loadConfig,
 } from "../../config";
-import { embedTextsWithRecovery } from "../../embed/batch";
 import { getEmbeddingFingerprint } from "../../embed/fingerprint";
+import {
+  addUniqueSamples,
+  chunkRetryKey,
+  embedAndStoreBatch,
+  MAX_EMBED_CHUNK_ATTEMPTS,
+  type EmbedStoreBatchResult,
+} from "../../embed/retry";
 import { LlmAdapter } from "../../llm/nodeLlamaCpp/adapter";
 import { resolveDownloadPolicy } from "../../llm/policy";
 import { resolveModelUri } from "../../llm/registry";
-import { formatDocForEmbedding } from "../../pipeline/contextual";
 import { SqliteAdapter } from "../../store/sqlite/adapter";
 import { err, ok } from "../../store/types";
 import {
@@ -30,7 +35,6 @@ import {
   createVectorIndexPort,
   createVectorStatsPort,
   type VectorIndexPort,
-  type VectorRow,
   type VectorStatsPort,
 } from "../../store/vector";
 import { getStoredEmbeddingFingerprint } from "../../store/vector/freshness";
@@ -94,26 +98,6 @@ function formatDuration(seconds: number): string {
   return `${mins}m ${secs.toFixed(0)}s`;
 }
 
-function formatLlmFailure(
-  error: { message: string; cause?: unknown } | undefined
-): string {
-  if (!error) {
-    return "Unknown embedding failure";
-  }
-  const cause =
-    error.cause &&
-    typeof error.cause === "object" &&
-    "message" in error.cause &&
-    typeof error.cause.message === "string"
-      ? error.cause.message
-      : typeof error.cause === "string"
-        ? error.cause
-        : "";
-  return cause && cause !== error.message
-    ? `${error.message} - ${cause}`
-    : error.message;
-}
-
 function isDisposedBatchError(message: string): boolean {
   return message.toLowerCase().includes("object is disposed");
 }
@@ -170,20 +154,148 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
   const errorSamples: string[] = [];
   let suggestion: string | undefined;
   let cursor: Cursor | undefined;
+  const retryQueue = new Map<string, { item: BacklogItem; attempts: number }>();
   const embedFingerprint = getEmbeddingFingerprint({
     modelUri: ctx.modelUri,
     dimensions: ctx.vectorIndex.dimensions,
   });
 
   const pushErrorSamples = (samples: string[]): void => {
-    for (const sample of samples) {
-      if (errorSamples.length >= 5) {
-        break;
-      }
-      if (!errorSamples.includes(sample)) {
-        errorSamples.push(sample);
+    addUniqueSamples(errorSamples, samples);
+  };
+
+  const enqueueRetryItems = (items: BacklogItem[], attempts: number): void => {
+    for (const item of items) {
+      const key = chunkRetryKey(item);
+      const existing = retryQueue.get(key);
+      retryQueue.set(key, {
+        item,
+        attempts: Math.max(existing?.attempts ?? 0, attempts),
+      });
+    }
+  };
+
+  const writeBatchDiagnostics = (
+    batch: BacklogItem[],
+    result: EmbedStoreBatchResult
+  ): void => {
+    if (ctx.verbose && result.batchFailed) {
+      const titles = batch
+        .slice(0, 3)
+        .map((item) => item.title ?? item.mirrorHash.slice(0, 8))
+        .join(", ");
+      process.stderr.write(
+        `\n[embed] Batch fallback (${batch.length} chunks: ${titles}${batch.length > 3 ? "..." : ""}): ${result.batchError ?? "unknown batch error"}\n`
+      );
+    }
+    if (ctx.verbose && result.errorSamples.length > 0) {
+      for (const sample of result.errorSamples) {
+        process.stderr.write(`\n[embed] Sample failure: ${sample}\n`);
       }
     }
+  };
+
+  const processStoreBatch = async (
+    batch: BacklogItem[]
+  ): Promise<EmbedStoreBatchResult> => {
+    let result = await embedAndStoreBatch({
+      embedPort: ctx.embedPort,
+      vectorIndex: ctx.vectorIndex,
+      items: batch,
+      modelUri: ctx.modelUri,
+      embedFingerprint,
+    });
+
+    if (
+      ctx.recreateEmbedPort &&
+      result.retryItems.length === batch.length &&
+      result.batchError &&
+      isDisposedBatchError(result.batchError)
+    ) {
+      if (ctx.verbose) {
+        process.stderr.write(
+          "\n[embed] Embedding port disposed; recreating model/contexts and retrying batch once\n"
+        );
+      }
+      const recreated = await ctx.recreateEmbedPort();
+      if (recreated.ok) {
+        ctx.embedPort = recreated.value;
+        result = await embedAndStoreBatch({
+          embedPort: ctx.embedPort,
+          vectorIndex: ctx.vectorIndex,
+          items: batch,
+          modelUri: ctx.modelUri,
+          embedFingerprint,
+        });
+        if (ctx.verbose && result.embedded > 0) {
+          process.stderr.write("\n[embed] Retry after port reset succeeded\n");
+        }
+      }
+    }
+
+    return result;
+  };
+
+  const renderProgress = (): void => {
+    if (!ctx.showProgress) {
+      return;
+    }
+    const embeddedDisplay = Math.min(embedded, ctx.totalToEmbed);
+    const completed = Math.min(embedded + errors, ctx.totalToEmbed);
+    const pct = (completed / ctx.totalToEmbed) * 100;
+    const elapsed = (Date.now() - startTime) / 1000;
+    const rate = embedded / Math.max(elapsed, 0.001);
+    const eta =
+      Math.max(0, ctx.totalToEmbed - completed) / Math.max(rate, 0.001);
+    process.stdout.write(
+      `\rEmbedding: ${embeddedDisplay.toLocaleString()}/${ctx.totalToEmbed.toLocaleString()} (${pct.toFixed(1)}%) | ${rate.toFixed(1)} chunks/s | ETA ${formatDuration(eta)}`
+    );
+  };
+
+  const drainRetryQueue = async (): Promise<number> => {
+    if (retryQueue.size === 0) {
+      return 0;
+    }
+    let retryEmbedded = 0;
+    const entries = [...retryQueue.values()].filter(
+      (entry) => entry.attempts < MAX_EMBED_CHUNK_ATTEMPTS
+    );
+    for (let idx = 0; idx < entries.length; idx += ctx.batchSize) {
+      const slice = entries.slice(idx, idx + ctx.batchSize);
+      for (const entry of slice) {
+        retryQueue.delete(chunkRetryKey(entry.item));
+        entry.attempts += 1;
+      }
+
+      const retryResult = await processStoreBatch(
+        slice.map((entry) => entry.item)
+      );
+      writeBatchDiagnostics(
+        slice.map((entry) => entry.item),
+        retryResult
+      );
+      pushErrorSamples(retryResult.errorSamples);
+      suggestion ||= retryResult.suggestion;
+      embedded += retryResult.embedded;
+      errors += retryResult.errors;
+      retryEmbedded += retryResult.embedded;
+
+      const retryByKey = new Set(
+        retryResult.retryItems.map((item) => chunkRetryKey(item))
+      );
+      for (const entry of slice) {
+        if (!retryByKey.has(chunkRetryKey(entry.item))) {
+          continue;
+        }
+        if (entry.attempts >= MAX_EMBED_CHUNK_ATTEMPTS) {
+          errors += 1;
+        } else {
+          retryQueue.set(chunkRetryKey(entry.item), entry);
+        }
+      }
+      renderProgress();
+    }
+    return retryEmbedded;
   };
 
   while (embedded + errors < ctx.totalToEmbed) {
@@ -211,191 +323,30 @@ async function processBatches(ctx: BatchContext): Promise<BatchResult> {
       cursor = { mirrorHash: lastItem.mirrorHash, seq: lastItem.seq };
     }
 
-    // Embed batch with contextual formatting (title prefix)
-    const batchEmbedResult = await embedTextsWithRecovery(
-      ctx.embedPort,
-      batch.map((b) =>
-        formatDocForEmbedding(b.text, b.title ?? undefined, ctx.modelUri)
-      )
-    );
-    if (!batchEmbedResult.ok) {
-      const formattedError = formatLlmFailure(batchEmbedResult.error);
-      if (ctx.recreateEmbedPort && isDisposedBatchError(formattedError)) {
-        if (ctx.verbose) {
-          process.stderr.write(
-            "\n[embed] Embedding port disposed; recreating model/contexts and retrying batch once\n"
-          );
-        }
-        const recreated = await ctx.recreateEmbedPort();
-        if (recreated.ok) {
-          ctx.embedPort = recreated.value;
-          const retryResult = await embedTextsWithRecovery(
-            ctx.embedPort,
-            batch.map((b) =>
-              formatDocForEmbedding(b.text, b.title ?? undefined, ctx.modelUri)
-            )
-          );
-          if (retryResult.ok) {
-            if (ctx.verbose) {
-              process.stderr.write(
-                "\n[embed] Retry after port reset succeeded\n"
-              );
-            }
-            pushErrorSamples(retryResult.value.failureSamples);
-            suggestion ||= retryResult.value.retrySuggestion;
+    const beforeEmbedded = embedded;
+    const batchStoreResult = await processStoreBatch(batch);
+    writeBatchDiagnostics(batch, batchStoreResult);
+    pushErrorSamples(batchStoreResult.errorSamples);
+    suggestion ||= batchStoreResult.suggestion;
+    embedded += batchStoreResult.embedded;
+    errors += batchStoreResult.errors;
+    enqueueRetryItems(batchStoreResult.retryItems, 1);
 
-            const retryVectors: VectorRow[] = [];
-            for (const [idx, item] of batch.entries()) {
-              const embedding = retryResult.value.vectors[idx];
-              if (!embedding) {
-                errors += 1;
-                continue;
-              }
-              retryVectors.push({
-                mirrorHash: item.mirrorHash,
-                seq: item.seq,
-                model: ctx.modelUri,
-                embedFingerprint,
-                embedding: new Float32Array(embedding),
-              });
-            }
-
-            if (retryVectors.length === 0) {
-              if (ctx.verbose) {
-                process.stderr.write(
-                  "\n[embed] No recoverable embeddings in retry batch\n"
-                );
-              }
-              continue;
-            }
-
-            const retryStoreResult =
-              await ctx.vectorIndex.upsertVectors(retryVectors);
-            if (!retryStoreResult.ok) {
-              if (ctx.verbose) {
-                process.stderr.write(
-                  `\n[embed] Store failed: ${retryStoreResult.error.message}\n`
-                );
-              }
-              pushErrorSamples([retryStoreResult.error.message]);
-              suggestion ??=
-                "Store write failed. Rerun `gno embed` once more; if it repeats, run `gno doctor` and `gno vec sync`.";
-              errors += retryVectors.length;
-              continue;
-            }
-
-            embedded += retryVectors.length;
-            if (ctx.showProgress) {
-              const embeddedDisplay = Math.min(embedded, ctx.totalToEmbed);
-              const completed = Math.min(embedded + errors, ctx.totalToEmbed);
-              const pct = (completed / ctx.totalToEmbed) * 100;
-              const elapsed = (Date.now() - startTime) / 1000;
-              const rate = embedded / Math.max(elapsed, 0.001);
-              const eta =
-                Math.max(0, ctx.totalToEmbed - completed) /
-                Math.max(rate, 0.001);
-              process.stdout.write(
-                `\rEmbedding: ${embeddedDisplay.toLocaleString()}/${ctx.totalToEmbed.toLocaleString()} (${pct.toFixed(1)}%) | ${rate.toFixed(1)} chunks/s | ETA ${formatDuration(eta)}`
-              );
-            }
-            continue;
-          }
-        }
-      }
-
-      if (ctx.verbose) {
-        const err = batchEmbedResult.error;
-        const cause = err.cause;
-        const causeMsg =
-          cause && typeof cause === "object" && "message" in cause
-            ? (cause as { message: string }).message
-            : typeof cause === "string"
-              ? cause
-              : "";
-        const titles = batch
-          .slice(0, 3)
-          .map((b) => b.title ?? b.mirrorHash.slice(0, 8))
-          .join(", ");
-        process.stderr.write(
-          `\n[embed] Batch failed (${batch.length} chunks: ${titles}${batch.length > 3 ? "..." : ""}): ${err.message}${causeMsg ? ` - ${causeMsg}` : ""}\n`
-        );
-      }
-      pushErrorSamples([formattedError]);
-      suggestion =
-        "Try rerunning the same command. If failures persist, rerun with `gno --verbose embed --batch-size 1` to isolate failing chunks.";
-      errors += batch.length;
-      continue;
+    if (embedded > beforeEmbedded) {
+      await drainRetryQueue();
     }
 
-    if (ctx.verbose && batchEmbedResult.value.batchFailed) {
-      const titles = batch
-        .slice(0, 3)
-        .map((b) => b.title ?? b.mirrorHash.slice(0, 8))
-        .join(", ");
-      process.stderr.write(
-        `\n[embed] Batch fallback (${batch.length} chunks: ${titles}${batch.length > 3 ? "..." : ""}): ${batchEmbedResult.value.batchError ?? "unknown batch error"}\n`
-      );
-    }
-    pushErrorSamples(batchEmbedResult.value.failureSamples);
-    suggestion ||= batchEmbedResult.value.retrySuggestion;
-    if (ctx.verbose && batchEmbedResult.value.failureSamples.length > 0) {
-      for (const sample of batchEmbedResult.value.failureSamples) {
-        process.stderr.write(`\n[embed] Sample failure: ${sample}\n`);
-      }
-    }
+    renderProgress();
+  }
 
-    const vectors: VectorRow[] = [];
-    for (const [idx, item] of batch.entries()) {
-      const embedding = batchEmbedResult.value.vectors[idx];
-      if (!embedding) {
-        errors += 1;
-        continue;
-      }
-      vectors.push({
-        mirrorHash: item.mirrorHash,
-        seq: item.seq,
-        model: ctx.modelUri,
-        embedFingerprint,
-        embedding: new Float32Array(embedding),
-      });
-    }
+  await drainRetryQueue();
 
-    if (vectors.length === 0) {
-      if (ctx.verbose) {
-        process.stderr.write("\n[embed] No recoverable embeddings in batch\n");
-      }
-      continue;
-    }
-
-    const storeResult = await ctx.vectorIndex.upsertVectors(vectors);
-    if (!storeResult.ok) {
-      if (ctx.verbose) {
-        process.stderr.write(
-          `\n[embed] Store failed: ${storeResult.error.message}\n`
-        );
-      }
-      pushErrorSamples([storeResult.error.message]);
-      suggestion ??=
-        "Store write failed. Rerun `gno embed` once more; if it repeats, run `gno doctor` and `gno vec sync`.";
-      errors += vectors.length;
-      continue;
-    }
-
-    embedded += vectors.length;
-
-    // Progress output
-    if (ctx.showProgress) {
-      const embeddedDisplay = Math.min(embedded, ctx.totalToEmbed);
-      const completed = Math.min(embedded + errors, ctx.totalToEmbed);
-      const pct = (completed / ctx.totalToEmbed) * 100;
-      const elapsed = (Date.now() - startTime) / 1000;
-      const rate = embedded / Math.max(elapsed, 0.001);
-      const eta =
-        Math.max(0, ctx.totalToEmbed - completed) / Math.max(rate, 0.001);
-      process.stdout.write(
-        `\rEmbedding: ${embeddedDisplay.toLocaleString()}/${ctx.totalToEmbed.toLocaleString()} (${pct.toFixed(1)}%) | ${rate.toFixed(1)} chunks/s | ETA ${formatDuration(eta)}`
-      );
-    }
+  if (retryQueue.size > 0) {
+    errors += retryQueue.size;
+    pushErrorSamples(["Some chunks failed after same-run retry attempts"]);
+    suggestion ??=
+      "Some chunks failed after retry. Rerun `gno --verbose embed --batch-size 1` to isolate failing chunks.";
+    retryQueue.clear();
   }
 
   if (ctx.showProgress) {

--- a/src/embed/backlog.ts
+++ b/src/embed/backlog.ts
@@ -17,6 +17,7 @@ import type {
 import { formatDocForEmbedding } from "../pipeline/contextual";
 import { err, ok } from "../store/types";
 import { embedTextsWithRecovery } from "./batch";
+import { getEmbeddingFingerprint } from "./fingerprint";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -56,6 +57,10 @@ export async function embedBacklog(
 ): Promise<StoreResult<EmbedBacklogResult>> {
   const { statsPort, embedPort, vectorIndex, modelUri, collection } = deps;
   const batchSize = deps.batchSize ?? 32;
+  const embedFingerprint = getEmbeddingFingerprint({
+    modelUri,
+    dimensions: vectorIndex.dimensions,
+  });
 
   let embedded = 0;
   let errors = 0;
@@ -64,11 +69,15 @@ export async function embedBacklog(
   try {
     while (true) {
       // Get next batch using seek pagination
-      const batchResult = await statsPort.getBacklog(modelUri, {
-        limit: batchSize,
-        after: cursor,
-        collection,
-      });
+      const batchResult = await statsPort.getBacklog(
+        modelUri,
+        embedFingerprint,
+        {
+          limit: batchSize,
+          after: cursor,
+          collection,
+        }
+      );
 
       if (!batchResult.ok) {
         return err("QUERY_FAILED", batchResult.error.message);
@@ -113,6 +122,7 @@ export async function embedBacklog(
           mirrorHash: item.mirrorHash,
           seq: item.seq,
           model: modelUri,
+          embedFingerprint,
           embedding: new Float32Array(embedding),
         });
       }

--- a/src/embed/backlog.ts
+++ b/src/embed/backlog.ts
@@ -10,14 +10,16 @@ import type { StoreResult } from "../store/types";
 import type {
   BacklogItem,
   VectorIndexPort,
-  VectorRow,
   VectorStatsPort,
 } from "../store/vector";
 
-import { formatDocForEmbedding } from "../pipeline/contextual";
 import { err, ok } from "../store/types";
-import { embedTextsWithRecovery } from "./batch";
 import { getEmbeddingFingerprint } from "./fingerprint";
+import {
+  chunkRetryKey,
+  embedAndStoreBatch,
+  MAX_EMBED_CHUNK_ATTEMPTS,
+} from "./retry";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -65,6 +67,65 @@ export async function embedBacklog(
   let embedded = 0;
   let errors = 0;
   let cursor: Cursor | undefined;
+  const retryQueue = new Map<string, { item: BacklogItem; attempts: number }>();
+
+  const enqueueRetryItems = (items: BacklogItem[], attempts: number): void => {
+    for (const item of items) {
+      const key = chunkRetryKey(item);
+      const existing = retryQueue.get(key);
+      retryQueue.set(key, {
+        item,
+        attempts: Math.max(existing?.attempts ?? 0, attempts),
+      });
+    }
+  };
+
+  const drainRetryQueue = async (): Promise<number> => {
+    if (retryQueue.size === 0) {
+      return 0;
+    }
+
+    let retryEmbedded = 0;
+    const entries = [...retryQueue.values()].filter(
+      (entry) => entry.attempts < MAX_EMBED_CHUNK_ATTEMPTS
+    );
+
+    for (let idx = 0; idx < entries.length; idx += batchSize) {
+      const slice = entries.slice(idx, idx + batchSize);
+      for (const entry of slice) {
+        retryQueue.delete(chunkRetryKey(entry.item));
+        entry.attempts += 1;
+      }
+
+      const retryResult = await embedAndStoreBatch({
+        embedPort,
+        vectorIndex,
+        items: slice.map((entry) => entry.item),
+        modelUri,
+        embedFingerprint,
+      });
+
+      embedded += retryResult.embedded;
+      errors += retryResult.errors;
+      retryEmbedded += retryResult.embedded;
+
+      const retryByKey = new Set(
+        retryResult.retryItems.map((item) => chunkRetryKey(item))
+      );
+      for (const entry of slice) {
+        if (!retryByKey.has(chunkRetryKey(entry.item))) {
+          continue;
+        }
+        if (entry.attempts >= MAX_EMBED_CHUNK_ATTEMPTS) {
+          errors += 1;
+        } else {
+          retryQueue.set(chunkRetryKey(entry.item), entry);
+        }
+      }
+    }
+
+    return retryEmbedded;
+  };
 
   try {
     while (true) {
@@ -94,48 +155,24 @@ export async function embedBacklog(
         cursor = { mirrorHash: lastItem.mirrorHash, seq: lastItem.seq };
       }
 
-      // Embed batch with contextual formatting (title prefix)
-      const embedResult = await embedTextsWithRecovery(
+      const beforeEmbedded = embedded;
+      const batchStoreResult = await embedAndStoreBatch({
         embedPort,
-        batch.map((b: BacklogItem) =>
-          formatDocForEmbedding(
-            b.text,
-            b.title ?? undefined,
-            embedPort.modelUri
-          )
-        )
-      );
+        vectorIndex,
+        items: batch,
+        modelUri,
+        embedFingerprint,
+      });
+      embedded += batchStoreResult.embedded;
+      errors += batchStoreResult.errors;
+      enqueueRetryItems(batchStoreResult.retryItems, 1);
 
-      if (!embedResult.ok) {
-        errors += batch.length;
-        continue;
-      }
-
-      const vectors: VectorRow[] = [];
-      for (const [idx, item] of batch.entries()) {
-        const embedding = embedResult.value.vectors[idx];
-        if (!embedding) {
-          errors += 1;
-          continue;
-        }
-        vectors.push({
-          mirrorHash: item.mirrorHash,
-          seq: item.seq,
-          model: modelUri,
-          embedFingerprint,
-          embedding: new Float32Array(embedding),
-        });
-      }
-
-      if (vectors.length > 0) {
-        const storeResult = await vectorIndex.upsertVectors(vectors);
-        if (!storeResult.ok) {
-          errors += vectors.length;
-          continue;
-        }
-        embedded += vectors.length;
+      if (embedded > beforeEmbedded) {
+        await drainRetryQueue();
       }
     }
+
+    await drainRetryQueue();
 
     // Sync vec index once at end if any vec0 writes failed
     let syncError: string | undefined;

--- a/src/embed/fingerprint.ts
+++ b/src/embed/fingerprint.ts
@@ -1,0 +1,37 @@
+/**
+ * Embedding freshness fingerprint.
+ *
+ * @module src/embed/fingerprint
+ */
+
+import { getEmbeddingCompatibilityProfile } from "../llm/embedding-compatibility";
+
+export const EMBEDDING_CONTEXTUAL_FORMAT_VERSION = "contextual-embedding-v1";
+export const EMBEDDING_CHUNKING_STRATEGY_VERSION = "markdown-char-semantic-v1";
+
+export interface EmbeddingFingerprintInput {
+  modelUri: string;
+  dimensions?: number;
+}
+
+export function getEmbeddingFingerprint(
+  input: EmbeddingFingerprintInput
+): string {
+  const profile = getEmbeddingCompatibilityProfile(input.modelUri);
+  const payload = {
+    chunking: EMBEDDING_CHUNKING_STRATEGY_VERSION,
+    contextualFormatting: EMBEDDING_CONTEXTUAL_FORMAT_VERSION,
+    dimensions: input.dimensions ?? null,
+    modelUri: input.modelUri,
+    profile: {
+      batchEmbeddingTrusted: profile.batchEmbeddingTrusted,
+      documentFormat: profile.documentFormat,
+      id: profile.id,
+      queryFormat: profile.queryFormat,
+    },
+  };
+
+  return new Bun.CryptoHasher("sha256")
+    .update(JSON.stringify(payload))
+    .digest("hex");
+}

--- a/src/embed/retry.ts
+++ b/src/embed/retry.ts
@@ -1,0 +1,137 @@
+import type { EmbeddingPort } from "../llm/types";
+import type { BacklogItem, VectorIndexPort, VectorRow } from "../store/vector";
+
+import { formatDocForEmbedding } from "../pipeline/contextual";
+import { embedTextsWithRecovery } from "./batch";
+
+export const MAX_EMBED_CHUNK_ATTEMPTS = 2;
+export const MAX_EMBED_FAILURE_SAMPLES = 5;
+
+export interface EmbedStoreBatchResult {
+  embedded: number;
+  errors: number;
+  retryItems: BacklogItem[];
+  errorSamples: string[];
+  suggestion?: string;
+  batchFailed: boolean;
+  batchError?: string;
+}
+
+export function chunkRetryKey(item: Pick<BacklogItem, "mirrorHash" | "seq">) {
+  return `${item.mirrorHash}\0${item.seq}`;
+}
+
+export function addUniqueSamples(target: string[], samples: string[]): void {
+  for (const sample of samples) {
+    if (target.length >= MAX_EMBED_FAILURE_SAMPLES) {
+      break;
+    }
+    if (!target.includes(sample)) {
+      target.push(sample);
+    }
+  }
+}
+
+export function formatLlmFailure(
+  error: { message: string; cause?: unknown } | undefined
+): string {
+  if (!error) {
+    return "Unknown embedding failure";
+  }
+  const cause =
+    error.cause &&
+    typeof error.cause === "object" &&
+    "message" in error.cause &&
+    typeof error.cause.message === "string"
+      ? error.cause.message
+      : typeof error.cause === "string"
+        ? error.cause
+        : "";
+  return cause && cause !== error.message
+    ? `${error.message} - ${cause}`
+    : error.message;
+}
+
+export async function embedAndStoreBatch(params: {
+  embedPort: EmbeddingPort;
+  vectorIndex: VectorIndexPort;
+  items: BacklogItem[];
+  modelUri: string;
+  embedFingerprint: string;
+}): Promise<EmbedStoreBatchResult> {
+  const { embedPort, vectorIndex, items, modelUri, embedFingerprint } = params;
+  const embedResult = await embedTextsWithRecovery(
+    embedPort,
+    items.map((item) =>
+      formatDocForEmbedding(item.text, item.title ?? undefined, modelUri)
+    )
+  );
+
+  if (!embedResult.ok) {
+    const formattedError = formatLlmFailure(embedResult.error);
+    return {
+      embedded: 0,
+      errors: embedResult.error.retryable ? 0 : items.length,
+      retryItems: embedResult.error.retryable ? items : [],
+      errorSamples: [formattedError],
+      suggestion: embedResult.error.retryable
+        ? "Try rerunning the same command. If failures persist, rerun with `gno --verbose embed --batch-size 1` to isolate failing chunks."
+        : embedResult.error.suggestion,
+      batchFailed: true,
+      batchError: formattedError,
+    };
+  }
+
+  const vectors: VectorRow[] = [];
+  const retryItems: BacklogItem[] = [];
+  for (const [idx, item] of items.entries()) {
+    const embedding = embedResult.value.vectors[idx];
+    if (!embedding) {
+      retryItems.push(item);
+      continue;
+    }
+    vectors.push({
+      mirrorHash: item.mirrorHash,
+      seq: item.seq,
+      model: modelUri,
+      embedFingerprint,
+      embedding: new Float32Array(embedding),
+    });
+  }
+
+  if (vectors.length === 0) {
+    return {
+      embedded: 0,
+      errors: 0,
+      retryItems,
+      errorSamples: embedResult.value.failureSamples,
+      suggestion: embedResult.value.retrySuggestion,
+      batchFailed: embedResult.value.batchFailed,
+      batchError: embedResult.value.batchError,
+    };
+  }
+
+  const storeResult = await vectorIndex.upsertVectors(vectors);
+  if (!storeResult.ok) {
+    return {
+      embedded: 0,
+      errors: vectors.length,
+      retryItems,
+      errorSamples: [storeResult.error.message],
+      suggestion:
+        "Store write failed. Rerun `gno embed` once more; if it repeats, run `gno doctor` and `gno vec sync`.",
+      batchFailed: embedResult.value.batchFailed,
+      batchError: embedResult.value.batchError,
+    };
+  }
+
+  return {
+    embedded: vectors.length,
+    errors: 0,
+    retryItems,
+    errorSamples: embedResult.value.failureSamples,
+    suggestion: embedResult.value.retrySuggestion,
+    batchFailed: embedResult.value.batchFailed,
+    batchError: embedResult.value.batchError,
+  };
+}

--- a/src/sdk/embed.ts
+++ b/src/sdk/embed.ts
@@ -28,7 +28,6 @@ import {
 import { resolveModelUri } from "../llm/registry";
 import { err, ok } from "../store/types";
 import { createVectorIndexPort, createVectorStatsPort } from "../store/vector";
-import { getStoredEmbeddingFingerprint } from "../store/vector/freshness";
 import { sdkError } from "./errors";
 
 interface EmbedRuntimeOptions {
@@ -262,28 +261,25 @@ export async function runEmbed(
   const db = runtime.store.getRawDb();
   const stats: VectorStatsPort = createVectorStatsPort(db);
 
-  const backlogResult = force
-    ? await getActiveChunkCount(db)
-    : await stats.countBacklog(
-        modelUri,
-        getStoredEmbeddingFingerprint(db, modelUri),
-        { collection: options.collection }
-      );
-  if (!backlogResult.ok) {
-    throw sdkError("STORE", backlogResult.error.message, {
-      cause: backlogResult.error.cause,
-    });
-  }
+  let totalToEmbed = 0;
+  if (force) {
+    const forceCount = await getActiveChunkCount(db);
+    if (!forceCount.ok) {
+      throw sdkError("STORE", forceCount.error.message, {
+        cause: forceCount.error.cause,
+      });
+    }
 
-  const totalToEmbed = backlogResult.value;
-  if (totalToEmbed === 0 || dryRun) {
-    return {
-      embedded: totalToEmbed,
-      errors: 0,
-      duration: 0,
-      model: modelUri,
-      searchAvailable: await checkVecAvailable(db),
-    };
+    totalToEmbed = forceCount.value;
+    if (totalToEmbed === 0 || dryRun) {
+      return {
+        embedded: totalToEmbed,
+        errors: 0,
+        duration: 0,
+        model: modelUri,
+        searchAvailable: await checkVecAvailable(db),
+      };
+    }
   }
 
   const embedResult = await runtime.llm.createEmbeddingPort(modelUri, {
@@ -315,6 +311,36 @@ export async function runEmbed(
     }
 
     const vectorIndex = vectorResult.value;
+    if (!force) {
+      const embedFingerprint = getEmbeddingFingerprint({
+        modelUri,
+        dimensions: vectorIndex.dimensions,
+      });
+      const backlogResult = await stats.countBacklog(
+        modelUri,
+        embedFingerprint,
+        {
+          collection: options.collection,
+        }
+      );
+      if (!backlogResult.ok) {
+        throw sdkError("STORE", backlogResult.error.message, {
+          cause: backlogResult.error.cause,
+        });
+      }
+
+      totalToEmbed = backlogResult.value;
+      if (totalToEmbed === 0 || dryRun) {
+        return {
+          embedded: totalToEmbed,
+          errors: 0,
+          duration: 0,
+          model: modelUri,
+          searchAvailable: vectorIndex.searchAvailable,
+        };
+      }
+    }
+
     const startedAt = Date.now();
     let result: { embedded: number; errors: number };
     if (force) {

--- a/src/sdk/embed.ts
+++ b/src/sdk/embed.ts
@@ -19,16 +19,15 @@ import type {
 import type { GnoEmbedOptions, GnoEmbedResult } from "./types";
 
 import { embedBacklog } from "../embed";
-import { embedTextsWithRecovery } from "../embed/batch";
 import { getEmbeddingFingerprint } from "../embed/fingerprint";
-import { resolveModelUri } from "../llm/registry";
-import { formatDocForEmbedding } from "../pipeline/contextual";
-import { err, ok } from "../store/types";
 import {
-  createVectorIndexPort,
-  createVectorStatsPort,
-  type VectorRow,
-} from "../store/vector";
+  chunkRetryKey,
+  embedAndStoreBatch,
+  MAX_EMBED_CHUNK_ATTEMPTS,
+} from "../embed/retry";
+import { resolveModelUri } from "../llm/registry";
+import { err, ok } from "../store/types";
+import { createVectorIndexPort, createVectorStatsPort } from "../store/vector";
 import { getStoredEmbeddingFingerprint } from "../store/vector/freshness";
 import { sdkError } from "./errors";
 
@@ -123,10 +122,68 @@ async function forceEmbedAll(
   let embedded = 0;
   let errors = 0;
   let cursor: { mirrorHash: string; seq: number } | undefined;
+  const retryQueue = new Map<string, { item: BacklogItem; attempts: number }>();
   const embedFingerprint = getEmbeddingFingerprint({
     modelUri,
     dimensions: vectorIndex.dimensions,
   });
+
+  const enqueueRetryItems = (items: BacklogItem[], attempts: number): void => {
+    for (const item of items) {
+      const key = chunkRetryKey(item);
+      const existing = retryQueue.get(key);
+      retryQueue.set(key, {
+        item,
+        attempts: Math.max(existing?.attempts ?? 0, attempts),
+      });
+    }
+  };
+
+  const drainRetryQueue = async (): Promise<number> => {
+    if (retryQueue.size === 0) {
+      return 0;
+    }
+
+    let retryEmbedded = 0;
+    const entries = [...retryQueue.values()].filter(
+      (entry) => entry.attempts < MAX_EMBED_CHUNK_ATTEMPTS
+    );
+
+    for (let idx = 0; idx < entries.length; idx += batchSize) {
+      const slice = entries.slice(idx, idx + batchSize);
+      for (const entry of slice) {
+        retryQueue.delete(chunkRetryKey(entry.item));
+        entry.attempts += 1;
+      }
+
+      const retryResult = await embedAndStoreBatch({
+        embedPort,
+        vectorIndex,
+        items: slice.map((entry) => entry.item),
+        modelUri,
+        embedFingerprint,
+      });
+      embedded += retryResult.embedded;
+      errors += retryResult.errors;
+      retryEmbedded += retryResult.embedded;
+
+      const retryByKey = new Set(
+        retryResult.retryItems.map((item) => chunkRetryKey(item))
+      );
+      for (const entry of slice) {
+        if (!retryByKey.has(chunkRetryKey(entry.item))) {
+          continue;
+        }
+        if (entry.attempts >= MAX_EMBED_CHUNK_ATTEMPTS) {
+          errors += 1;
+        } else {
+          retryQueue.set(chunkRetryKey(entry.item), entry);
+        }
+      }
+    }
+
+    return retryEmbedded;
+  };
 
   while (true) {
     const batchResult = await getActiveChunks(db, batchSize, cursor);
@@ -146,46 +203,27 @@ async function forceEmbedAll(
       cursor = { mirrorHash: lastItem.mirrorHash, seq: lastItem.seq };
     }
 
-    const embedResult = await embedTextsWithRecovery(
+    const beforeEmbedded = embedded;
+    const embedResult = await embedAndStoreBatch({
       embedPort,
-      batch.map((item) =>
-        formatDocForEmbedding(
-          item.text,
-          item.title ?? undefined,
-          embedPort.modelUri
-        )
-      )
-    );
+      vectorIndex,
+      items: batch,
+      modelUri,
+      embedFingerprint,
+    });
+    embedded += embedResult.embedded;
+    errors += embedResult.errors;
+    enqueueRetryItems(embedResult.retryItems, 1);
 
-    if (!embedResult.ok) {
-      errors += batch.length;
-      continue;
+    if (embedded > beforeEmbedded) {
+      await drainRetryQueue();
     }
+  }
 
-    const vectors: VectorRow[] = [];
-    for (const [idx, item] of batch.entries()) {
-      const embedding = embedResult.value.vectors[idx];
-      if (!embedding) {
-        errors += 1;
-        continue;
-      }
-      vectors.push({
-        mirrorHash: item.mirrorHash,
-        seq: item.seq,
-        model: modelUri,
-        embedFingerprint,
-        embedding: new Float32Array(embedding),
-      });
-    }
-
-    if (vectors.length > 0) {
-      const storeResult = await vectorIndex.upsertVectors(vectors);
-      if (!storeResult.ok) {
-        errors += vectors.length;
-        continue;
-      }
-      embedded += vectors.length;
-    }
+  await drainRetryQueue();
+  if (retryQueue.size > 0) {
+    errors += retryQueue.size;
+    retryQueue.clear();
   }
 
   if (vectorIndex.vecDirty) {

--- a/src/sdk/embed.ts
+++ b/src/sdk/embed.ts
@@ -20,6 +20,7 @@ import type { GnoEmbedOptions, GnoEmbedResult } from "./types";
 
 import { embedBacklog } from "../embed";
 import { embedTextsWithRecovery } from "../embed/batch";
+import { getEmbeddingFingerprint } from "../embed/fingerprint";
 import { resolveModelUri } from "../llm/registry";
 import { formatDocForEmbedding } from "../pipeline/contextual";
 import { err, ok } from "../store/types";
@@ -28,6 +29,7 @@ import {
   createVectorStatsPort,
   type VectorRow,
 } from "../store/vector";
+import { getStoredEmbeddingFingerprint } from "../store/vector/freshness";
 import { sdkError } from "./errors";
 
 interface EmbedRuntimeOptions {
@@ -121,6 +123,10 @@ async function forceEmbedAll(
   let embedded = 0;
   let errors = 0;
   let cursor: { mirrorHash: string; seq: number } | undefined;
+  const embedFingerprint = getEmbeddingFingerprint({
+    modelUri,
+    dimensions: vectorIndex.dimensions,
+  });
 
   while (true) {
     const batchResult = await getActiveChunks(db, batchSize, cursor);
@@ -167,6 +173,7 @@ async function forceEmbedAll(
         mirrorHash: item.mirrorHash,
         seq: item.seq,
         model: modelUri,
+        embedFingerprint,
         embedding: new Float32Array(embedding),
       });
     }
@@ -219,7 +226,11 @@ export async function runEmbed(
 
   const backlogResult = force
     ? await getActiveChunkCount(db)
-    : await stats.countBacklog(modelUri, { collection: options.collection });
+    : await stats.countBacklog(
+        modelUri,
+        getStoredEmbeddingFingerprint(db, modelUri),
+        { collection: options.collection }
+      );
   if (!backlogResult.ok) {
     throw sdkError("STORE", backlogResult.error.message, {
       cause: backlogResult.error.cause,

--- a/src/store/migrations/008-vector-fingerprints.ts
+++ b/src/store/migrations/008-vector-fingerprints.ts
@@ -1,0 +1,25 @@
+/**
+ * Migration: vector embedding freshness fingerprints.
+ *
+ * @module src/store/migrations/008-vector-fingerprints
+ */
+
+import type { Database } from "bun:sqlite";
+
+import type { Migration } from "./runner";
+
+export const migration: Migration = {
+  version: 8,
+  name: "vector_fingerprints",
+
+  up(db: Database): void {
+    db.exec(`
+      ALTER TABLE content_vectors ADD COLUMN embed_fingerprint TEXT NOT NULL DEFAULT ''
+    `);
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_vectors_freshness
+      ON content_vectors(model, embed_fingerprint, mirror_hash, seq, embedded_at)
+    `);
+  },
+};

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -21,6 +21,7 @@ import { migration as m004 } from "./004-doc-links";
 import { migration as m005 } from "./005-graph-indexes";
 import { migration as m006 } from "./006-document-metadata";
 import { migration as m007 } from "./007-document-date-fields";
+import { migration as m008 } from "./008-vector-fingerprints";
 
 /** All migrations in order */
-export const migrations = [m001, m002, m003, m004, m005, m006, m007];
+export const migrations = [m001, m002, m003, m004, m005, m006, m007, m008];

--- a/src/store/sqlite/adapter.ts
+++ b/src/store/sqlite/adapter.ts
@@ -53,6 +53,7 @@ import { analyzeGraphCommunities } from "../../core/graph-analysis";
 import { normalizeWikiName, stripWikiMdExt } from "../../core/links";
 import { migrations, runMigrations } from "../migrations";
 import { err, ok } from "../types";
+import { getStoredEmbeddingFingerprint } from "../vector/freshness";
 import { modelTableName } from "../vector/sqlite-vec";
 import { loadFts5Snowball } from "./fts5-snowball";
 
@@ -3065,10 +3066,14 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
 
   async getStatus(options?: {
     embedModel?: string;
+    embedFingerprint?: string;
   }): Promise<StoreResult<IndexStatus>> {
     try {
       const db = this.ensureOpen();
       const embedModel = options?.embedModel ?? null;
+      const embedFingerprint =
+        options?.embedFingerprint ??
+        (embedModel ? getStoredEmbeddingFingerprint(db, embedModel) : null);
 
       // Get version
       const versionRow = db
@@ -3097,7 +3102,7 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       }
 
       const collectionStats = db
-        .query<CollectionStat, [string | null, string | null]>(
+        .query<CollectionStat, [string | null, string | null, string | null]>(
           `
           SELECT
             c.name,
@@ -3120,7 +3125,10 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
                SELECT 1 FROM content_vectors cv
                WHERE cv.mirror_hash = cc.mirror_hash
                  AND cv.seq = cc.seq
-                 AND (? IS NULL OR cv.model = ?)
+                 AND (? IS NULL OR (
+                   cv.model = ?
+                   AND cv.embed_fingerprint = ?
+                 ))
                  AND cv.embedded_at >= cc.created_at
              )) as embedded_count
           FROM collections c
@@ -3128,7 +3136,7 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
           GROUP BY c.name, c.path
         `
         )
-        .all(embedModel, embedModel);
+        .all(embedModel, embedModel, embedFingerprint);
 
       // Get totals
       const totalsRow = db
@@ -3152,7 +3160,10 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
       // Embedding backlog: chunks from active docs without vectors
       // Uses EXISTS to avoid duplicates when multiple docs share mirror_hash
       const backlogRow = db
-        .query<{ count: number }, [string | null, string | null]>(
+        .query<
+          { count: number },
+          [string | null, string | null, string | null]
+        >(
           `
           SELECT COUNT(*) as count FROM content_chunks c
           WHERE EXISTS (
@@ -3163,12 +3174,15 @@ export class SqliteAdapter implements StorePort, SqliteDbProvider {
             SELECT 1 FROM content_vectors v
             WHERE v.mirror_hash = c.mirror_hash
               AND v.seq = c.seq
-              AND (? IS NULL OR v.model = ?)
+              AND (? IS NULL OR (
+                v.model = ?
+                AND v.embed_fingerprint = ?
+              ))
               AND v.embedded_at >= c.created_at
           )
         `
         )
-        .get(embedModel, embedModel);
+        .get(embedModel, embedModel, embedFingerprint);
 
       // Recent errors (last 24h)
       const recentErrorsRow = db

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -984,6 +984,7 @@ export interface StorePort {
    */
   getStatus(options?: {
     embedModel?: string;
+    embedFingerprint?: string;
   }): Promise<StoreResult<IndexStatus>>;
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/src/store/vector/freshness.ts
+++ b/src/store/vector/freshness.ts
@@ -1,0 +1,34 @@
+/**
+ * Vector freshness helpers.
+ *
+ * @module src/store/vector/freshness
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { getEmbeddingFingerprint } from "../../embed/fingerprint";
+
+export function getStoredEmbeddingDimensions(
+  db: Database,
+  model: string
+): number | undefined {
+  const row = db
+    .prepare("SELECT embedding FROM content_vectors WHERE model = ? LIMIT 1")
+    .get(model) as { embedding: Uint8Array } | undefined;
+
+  if (!row?.embedding) {
+    return undefined;
+  }
+
+  return row.embedding.byteLength / Float32Array.BYTES_PER_ELEMENT;
+}
+
+export function getStoredEmbeddingFingerprint(
+  db: Database,
+  modelUri: string
+): string {
+  return getEmbeddingFingerprint({
+    modelUri,
+    dimensions: getStoredEmbeddingDimensions(db, modelUri),
+  });
+}

--- a/src/store/vector/sqlite-vec.ts
+++ b/src/store/vector/sqlite-vec.ts
@@ -116,8 +116,10 @@ export async function createVectorIndexPort(
 
   // Prepared statements for content_vectors table
   const upsertVectorStmt = db.prepare(`
-    INSERT OR REPLACE INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-    VALUES (?, ?, ?, ?, datetime('now'))
+    INSERT OR REPLACE INTO content_vectors (
+      mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+    )
+    VALUES (?, ?, ?, ?, ?, datetime('now'))
   `);
 
   const deleteVectorStmt = db.prepare(`
@@ -172,6 +174,7 @@ export async function createVectorIndexPort(
               row.mirrorHash,
               row.seq,
               row.model,
+              row.embedFingerprint,
               encodeEmbedding(row.embedding)
             );
           }

--- a/src/store/vector/stats.ts
+++ b/src/store/vector/stats.ts
@@ -65,6 +65,7 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
 
     countBacklog(
       model: string,
+      embedFingerprint: string,
       options?: { collection?: string }
     ): Promise<StoreResult<number>> {
       try {
@@ -80,10 +81,13 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
             WHERE v.mirror_hash = c.mirror_hash
               AND v.seq = c.seq
               AND v.model = ?
+              AND v.embed_fingerprint = ?
               AND v.embedded_at >= c.created_at
           )
         `;
-        const result = db.prepare(sql).get(...activeDoc.params, model) as {
+        const result = db
+          .prepare(sql)
+          .get(...activeDoc.params, model, embedFingerprint) as {
           count: number;
         };
         return Promise.resolve(ok(result.count));
@@ -99,6 +103,7 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
 
     getBacklog(
       model: string,
+      embedFingerprint: string,
       options?: {
         limit?: number;
         after?: { mirrorHash: string; seq: number };
@@ -123,6 +128,7 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
                 WHERE v.mirror_hash = c.mirror_hash
                   AND v.seq = c.seq
                   AND v.model = ?
+                  AND v.embed_fingerprint = ?
               ) THEN 'new'
               ELSE 'changed'
             END as reason
@@ -133,6 +139,7 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
             WHERE v.mirror_hash = c.mirror_hash
               AND v.seq = c.seq
               AND v.model = ?
+              AND v.embed_fingerprint = ?
               AND v.embedded_at >= c.created_at
           )
           AND (c.mirror_hash > ? OR (c.mirror_hash = ? AND c.seq > ?))
@@ -148,6 +155,7 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
                 WHERE v.mirror_hash = c.mirror_hash
                   AND v.seq = c.seq
                   AND v.model = ?
+                  AND v.embed_fingerprint = ?
               ) THEN 'new'
               ELSE 'changed'
             END as reason
@@ -158,6 +166,7 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
             WHERE v.mirror_hash = c.mirror_hash
               AND v.seq = c.seq
               AND v.model = ?
+              AND v.embed_fingerprint = ?
               AND v.embedded_at >= c.created_at
           )
           ORDER BY c.mirror_hash, c.seq
@@ -167,14 +176,23 @@ export function createVectorStatsPort(db: Database): VectorStatsPort {
         const params = after
           ? [
               model,
+              embedFingerprint,
               ...activeDoc.params,
               model,
+              embedFingerprint,
               after.mirrorHash,
               after.mirrorHash,
               after.seq,
               limit,
             ]
-          : [model, ...activeDoc.params, model, limit];
+          : [
+              model,
+              embedFingerprint,
+              ...activeDoc.params,
+              model,
+              embedFingerprint,
+              limit,
+            ];
 
         const results = db.prepare(sql).all(...params) as BacklogItem[];
         return Promise.resolve(ok(results));

--- a/src/store/vector/types.ts
+++ b/src/store/vector/types.ts
@@ -16,6 +16,7 @@ export interface VectorRow {
   mirrorHash: string;
   seq: number;
   model: string;
+  embedFingerprint: string;
   embedding: Float32Array;
   // embeddedAt is set by DB via datetime('now')
 }
@@ -112,12 +113,14 @@ export interface VectorStatsPort {
   /** Count chunks needing embedding for a model */
   countBacklog(
     model: string,
+    embedFingerprint: string,
     options?: { collection?: string }
   ): Promise<StoreResult<number>>;
 
   /** Get chunks needing embedding for a model (seek pagination) */
   getBacklog(
     model: string,
+    embedFingerprint: string,
     options?: { limit?: number; after?: BacklogCursor; collection?: string }
   ): Promise<StoreResult<BacklogItem[]>>;
 }

--- a/test/embed/backlog.test.ts
+++ b/test/embed/backlog.test.ts
@@ -279,4 +279,135 @@ describe("embedBacklog", () => {
     expect(typeof upserts[0]?.[0]?.embedFingerprint).toBe("string");
     expect(upserts[0]?.[0]?.embedFingerprint.length).toBeGreaterThan(0);
   });
+
+  test("retries a transient failed chunk within the same run", async () => {
+    const failuresByText = new Map<string, number>();
+    const embedPort = {
+      embedBatch: mock(() =>
+        Promise.resolve({
+          ok: false as const,
+          error: {
+            code: "INFERENCE_FAILED" as const,
+            message: "batch failed",
+            retryable: true,
+          },
+        })
+      ),
+      embed: mock((text: string) => {
+        const count = failuresByText.get(text) ?? 0;
+        failuresByText.set(text, count + 1);
+        if (text.includes("second") && count === 0) {
+          return Promise.resolve({
+            ok: false as const,
+            error: {
+              code: "INFERENCE_FAILED" as const,
+              message: "single failed once",
+              retryable: true,
+            },
+          });
+        }
+        return Promise.resolve({ ok: true as const, value: [0.1, 0.2, 0.3] });
+      }),
+      dimensions: () => 3,
+      init: () => Promise.resolve({ ok: true as const, value: undefined }),
+      dispose: () => Promise.resolve(),
+      modelUri: "hf:test/embed.gguf",
+    } as unknown as EmbeddingPort;
+
+    const vectorIndex = createMockVectorIndex();
+    const upserts: VectorRow[][] = [];
+    vectorIndex.upsertVectors = mock((rows: VectorRow[]) => {
+      upserts.push(rows);
+      return Promise.resolve({ ok: true as const, value: undefined });
+    }) as typeof vectorIndex.upsertVectors;
+
+    const result = await embedBacklog({
+      statsPort: createMockStatsPort([
+        { mirrorHash: "abc123", seq: 0, text: "first content", title: "First" },
+        {
+          mirrorHash: "abc123",
+          seq: 1,
+          text: "second content",
+          title: "Second",
+        },
+      ]),
+      embedPort,
+      vectorIndex,
+      modelUri: "hf:test/embed.gguf",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.value.embedded).toBe(2);
+    expect(result.value.errors).toBe(0);
+    expect(upserts).toHaveLength(2);
+    expect(upserts[0]?.map((row) => row.seq)).toEqual([0]);
+    expect(upserts[1]?.map((row) => row.seq)).toEqual([1]);
+  });
+
+  test("counts a permanently failed chunk after retry cap", async () => {
+    const embedPort = {
+      embedBatch: mock(() =>
+        Promise.resolve({
+          ok: false as const,
+          error: {
+            code: "INFERENCE_FAILED" as const,
+            message: "batch failed",
+            retryable: true,
+          },
+        })
+      ),
+      embed: mock((text: string) =>
+        Promise.resolve(
+          text.includes("second")
+            ? {
+                ok: false as const,
+                error: {
+                  code: "INFERENCE_FAILED" as const,
+                  message: "single failed",
+                  retryable: true,
+                },
+              }
+            : { ok: true as const, value: [0.1, 0.2, 0.3] }
+        )
+      ),
+      dimensions: () => 3,
+      init: () => Promise.resolve({ ok: true as const, value: undefined }),
+      dispose: () => Promise.resolve(),
+      modelUri: "hf:test/embed.gguf",
+    } as unknown as EmbeddingPort;
+
+    const vectorIndex = createMockVectorIndex();
+    const upserts: VectorRow[][] = [];
+    vectorIndex.upsertVectors = mock((rows: VectorRow[]) => {
+      upserts.push(rows);
+      return Promise.resolve({ ok: true as const, value: undefined });
+    }) as typeof vectorIndex.upsertVectors;
+
+    const result = await embedBacklog({
+      statsPort: createMockStatsPort([
+        { mirrorHash: "abc123", seq: 0, text: "first content", title: "First" },
+        {
+          mirrorHash: "abc123",
+          seq: 1,
+          text: "second content",
+          title: "Second",
+        },
+      ]),
+      embedPort,
+      vectorIndex,
+      modelUri: "hf:test/embed.gguf",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.value.embedded).toBe(1);
+    expect(result.value.errors).toBe(1);
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]?.map((row) => row.seq)).toEqual([0]);
+  });
 });

--- a/test/embed/backlog.test.ts
+++ b/test/embed/backlog.test.ts
@@ -56,6 +56,7 @@ function createMockEmbedPort() {
     dimensions: () => 3,
     init: () => Promise.resolve({ ok: true }),
     dispose: () => Promise.resolve(),
+    modelUri: "test-model",
   } as unknown as EmbeddingPort;
 }
 
@@ -275,5 +276,7 @@ describe("embedBacklog", () => {
     expect(upserts).toHaveLength(1);
     expect(upserts[0]).toHaveLength(1);
     expect(upserts[0]?.[0]?.seq).toBe(0);
+    expect(typeof upserts[0]?.[0]?.embedFingerprint).toBe("string");
+    expect(upserts[0]?.[0]?.embedFingerprint.length).toBeGreaterThan(0);
   });
 });

--- a/test/sdk/embed.test.ts
+++ b/test/sdk/embed.test.ts
@@ -1,0 +1,115 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Config } from "../../src/config/types";
+import type { LlmAdapter } from "../../src/llm/nodeLlamaCpp/adapter";
+import type { EmbeddingPort } from "../../src/llm/types";
+import type { SqliteAdapter } from "../../src/store/sqlite/adapter";
+
+import { CONFIG_VERSION } from "../../src/config/types";
+import { getEmbeddingFingerprint } from "../../src/embed/fingerprint";
+import { runEmbed } from "../../src/sdk/embed";
+import { encodeEmbedding } from "../../src/store/vector";
+import { safeRm } from "../helpers/cleanup";
+
+const MODEL_URI = "hf:test/model.gguf";
+
+describe("runEmbed", () => {
+  let db: Database | undefined;
+  let testDir: string | undefined;
+
+  afterEach(async () => {
+    db?.close();
+    db = undefined;
+    if (testDir) {
+      await safeRm(testDir);
+      testDir = undefined;
+    }
+  });
+
+  test("dry-run backlog uses current model dimensions instead of arbitrary stored vectors", async () => {
+    testDir = await mkdtemp(join(tmpdir(), "gno-sdk-embed-test-"));
+    db = new Database(join(testDir, "index.sqlite"), { create: true });
+    db.exec(`
+      CREATE TABLE documents (
+        id INTEGER PRIMARY KEY,
+        mirror_hash TEXT,
+        title TEXT,
+        collection TEXT,
+        active INTEGER DEFAULT 1
+      );
+
+      CREATE TABLE content_chunks (
+        mirror_hash TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (mirror_hash, seq)
+      );
+
+      CREATE TABLE content_vectors (
+        mirror_hash TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        model TEXT NOT NULL,
+        embed_fingerprint TEXT NOT NULL DEFAULT '',
+        embedding BLOB NOT NULL,
+        embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (mirror_hash, seq, model)
+      );
+    `);
+
+    const staleStoredFingerprint = getEmbeddingFingerprint({
+      modelUri: MODEL_URI,
+      dimensions: 2,
+    });
+
+    db.prepare(
+      "INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1)"
+    ).run();
+    db.prepare(
+      "INSERT INTO content_chunks (mirror_hash, seq, text, created_at) VALUES ('h1', 0, 'chunk', datetime('now', '-1 minute'))"
+    ).run();
+    db.prepare(
+      `INSERT INTO content_vectors (
+        mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+      ) VALUES (?, ?, ?, ?, ?, datetime('now'))`
+    ).run(
+      "h1",
+      0,
+      MODEL_URI,
+      staleStoredFingerprint,
+      encodeEmbedding(new Float32Array([1, 2]))
+    );
+
+    const embedPort: EmbeddingPort = {
+      modelUri: MODEL_URI,
+      init: async () => ({ ok: true, value: undefined }),
+      embed: async () => ({ ok: true, value: [1, 2, 3] }),
+      embedBatch: async () => ({ ok: true, value: [[1, 2, 3]] }),
+      dimensions: () => 3,
+      dispose: async () => {},
+    };
+    const llm = {
+      createEmbeddingPort: async () => ({ ok: true, value: embedPort }),
+    } as unknown as LlmAdapter;
+    const store = {
+      getRawDb: () => db as Database,
+    } as unknown as SqliteAdapter;
+    const config: Config = {
+      version: CONFIG_VERSION,
+      ftsTokenizer: "unicode61",
+      collections: [],
+      contexts: [],
+    };
+
+    const result = await runEmbed(
+      { config, store, llm },
+      { model: MODEL_URI, dryRun: true }
+    );
+
+    expect(result.embedded).toBe(1);
+  });
+});

--- a/test/spec/schemas/doctor.test.ts
+++ b/test/spec/schemas/doctor.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { assertInvalid, assertValid, loadSchema } from "./validator";
+
+describe("doctor schema", () => {
+  let schema: object;
+
+  beforeAll(async () => {
+    schema = await loadSchema("doctor");
+  });
+
+  test("validates embedding fingerprint diagnostics", () => {
+    const doctor = {
+      healthy: true,
+      checks: [
+        {
+          name: "embedding-fingerprint",
+          status: "warn",
+          message: "current abc123def456, 2 pending/stale, 1 legacy, 2 groups",
+          details: [
+            "Run: gno embed",
+            "If vectors still look stale, run: gno embed --force",
+          ],
+          embeddingFingerprint: {
+            model: "hf:model/embed.gguf",
+            currentFingerprint: "abc123def4567890",
+            pendingChunks: 2,
+            legacyChunks: 1,
+            mixedGroups: 2,
+            groups: [
+              {
+                model: "hf:model/embed.gguf",
+                fingerprint: "abc123def4567890",
+                count: 10,
+                current: true,
+                legacy: false,
+              },
+              {
+                model: "hf:model/embed.gguf",
+                fingerprint: "",
+                count: 1,
+                current: false,
+                legacy: true,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(assertValid(doctor, schema)).toBe(true);
+  });
+
+  test("rejects negative fingerprint counts", () => {
+    const doctor = {
+      healthy: true,
+      checks: [
+        {
+          name: "embedding-fingerprint",
+          status: "ok",
+          message: "current abc123def456, 0 pending/stale, 0 legacy, 0 groups",
+          embeddingFingerprint: {
+            model: "hf:model/embed.gguf",
+            currentFingerprint: "abc123def4567890",
+            pendingChunks: -1,
+            legacyChunks: 0,
+            mixedGroups: 0,
+            groups: [],
+          },
+        },
+      ],
+    };
+
+    expect(assertInvalid(doctor, schema)).toBe(true);
+  });
+});

--- a/test/spec/schemas/validator.ts
+++ b/test/spec/schemas/validator.ts
@@ -16,6 +16,7 @@ async function loadAllSchemas(): Promise<void> {
     "search-result",
     "search-results",
     "status",
+    "doctor",
     "get",
     "multi-get",
     "ask",

--- a/test/store/adapter.test.ts
+++ b/test/store/adapter.test.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import type { Collection, Context } from "../../src/config/types";
 import type { ChunkInput, DocumentInput } from "../../src/store/types";
 
+import { getEmbeddingFingerprint } from "../../src/embed/fingerprint";
 import { SqliteAdapter } from "../../src/store";
 import { safeRm } from "../helpers/cleanup";
 
@@ -67,7 +68,7 @@ describe("SqliteAdapter", () => {
       expect(result.value.applied).toContain(2);
       expect(result.value.applied).toContain(3);
       expect(result.value.applied).toContain(4);
-      expect(result.value.currentVersion).toBe(7);
+      expect(result.value.currentVersion).toBe(8);
       expect(result.value.ftsTokenizer).toBe("unicode61");
     });
 
@@ -85,7 +86,7 @@ describe("SqliteAdapter", () => {
       }
 
       expect(result.value.applied).toHaveLength(0);
-      expect(result.value.currentVersion).toBe(7);
+      expect(result.value.currentVersion).toBe(8);
     });
 
     test("rejects tokenizer mismatch", async () => {
@@ -1074,7 +1075,7 @@ describe("SqliteAdapter", () => {
         return;
       }
 
-      expect(result.value.version).toBe("7");
+      expect(result.value.version).toBe("8");
       expect(result.value.ftsTokenizer).toBe("unicode61");
       expect(result.value.dbPath).toBe(dbPath);
       expect(result.value.totalDocuments).toBe(1);
@@ -1114,15 +1115,22 @@ describe("SqliteAdapter", () => {
       ]);
 
       const vectorDb = adapter.getRawDb();
+      const oldModelFingerprint = getEmbeddingFingerprint({
+        modelUri: "old-embed-model",
+        dimensions: 1,
+      });
       vectorDb
         .prepare(
-          `INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-           VALUES (?, ?, ?, ?, datetime('now'))`
+          `INSERT INTO content_vectors (
+             mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+           )
+           VALUES (?, ?, ?, ?, ?, datetime('now'))`
         )
         .run(
           "status_mirror_model",
           0,
           "old-embed-model",
+          oldModelFingerprint,
           new Uint8Array([0, 0, 0, 0])
         );
 
@@ -1145,6 +1153,17 @@ describe("SqliteAdapter", () => {
       }
       expect(freshStatus.value.embeddingBacklog).toBe(0);
       expect(freshStatus.value.collections[0]?.embeddedChunks).toBe(1);
+
+      const fingerprintStatus = await adapter.getStatus({
+        embedModel: "old-embed-model",
+        embedFingerprint: "different-fingerprint",
+      });
+      expect(fingerprintStatus.ok).toBe(true);
+      if (!fingerprintStatus.ok) {
+        return;
+      }
+      expect(fingerprintStatus.value.embeddingBacklog).toBe(1);
+      expect(fingerprintStatus.value.collections[0]?.embeddedChunks).toBe(0);
     });
   });
 

--- a/test/store/migrations.test.ts
+++ b/test/store/migrations.test.ts
@@ -52,7 +52,7 @@ describe("store migrations", () => {
 
       const upgradeResult = runMigrations(db, migrations, "unicode61");
       expect(upgradeResult.ok).toBe(true);
-      expect(getSchemaVersion(db)).toBe(7);
+      expect(getSchemaVersion(db)).toBe(8);
 
       const indexedRow = db
         .query<{ indexed_at: string | null }, []>(
@@ -61,6 +61,12 @@ describe("store migrations", () => {
         .get();
       expect(indexedRow).toBeDefined();
       expect(indexedRow?.indexed_at).not.toBeNull();
+
+      const vectorColumns = db
+        .query<{ name: string }, []>("PRAGMA table_info(content_vectors)")
+        .all()
+        .map((column) => column.name);
+      expect(vectorColumns).toContain("embed_fingerprint");
     } finally {
       db.close();
     }

--- a/test/store/vector/sqlite-vec-works.test.ts
+++ b/test/store/vector/sqlite-vec-works.test.ts
@@ -22,6 +22,7 @@ import { createVectorIndexPort } from "../../../src/store/vector/sqlite-vec";
 const isCI = Boolean(process.env.CI);
 const isDarwin = platform() === "darwin";
 const mode = getExtensionLoadingMode();
+const TEST_FINGERPRINT = "test-fingerprint";
 
 describe("sqlite-vec integration", () => {
   test("vector search works end-to-end", async () => {
@@ -43,6 +44,7 @@ describe("sqlite-vec integration", () => {
           mirror_hash TEXT NOT NULL,
           seq INTEGER NOT NULL,
           model TEXT NOT NULL,
+          embed_fingerprint TEXT NOT NULL DEFAULT '',
           embedding BLOB NOT NULL,
           embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
           PRIMARY KEY (mirror_hash, seq, model)
@@ -79,18 +81,21 @@ describe("sqlite-vec integration", () => {
           mirrorHash: "doc1",
           seq: 0,
           model: "test-model",
+          embedFingerprint: TEST_FINGERPRINT,
           embedding: new Float32Array([1.0, 0.0, 0.0, 0.0]), // Unit vector in x
         },
         {
           mirrorHash: "doc2",
           seq: 0,
           model: "test-model",
+          embedFingerprint: TEST_FINGERPRINT,
           embedding: new Float32Array([0.0, 1.0, 0.0, 0.0]), // Unit vector in y
         },
         {
           mirrorHash: "doc3",
           seq: 0,
           model: "test-model",
+          embedFingerprint: TEST_FINGERPRINT,
           embedding: new Float32Array([0.9, 0.1, 0.0, 0.0]), // Close to doc1
         },
       ];
@@ -138,6 +143,7 @@ describe("sqlite-vec integration", () => {
           mirror_hash TEXT NOT NULL,
           seq INTEGER NOT NULL,
           model TEXT NOT NULL,
+          embed_fingerprint TEXT NOT NULL DEFAULT '',
           embedding BLOB NOT NULL,
           embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
           PRIMARY KEY (mirror_hash, seq, model)
@@ -181,6 +187,7 @@ describe("sqlite-vec integration", () => {
           mirror_hash TEXT NOT NULL,
           seq INTEGER NOT NULL,
           model TEXT NOT NULL,
+          embed_fingerprint TEXT NOT NULL DEFAULT '',
           embedding BLOB NOT NULL,
           embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
           PRIMARY KEY (mirror_hash, seq, model)
@@ -204,6 +211,7 @@ describe("sqlite-vec integration", () => {
           mirrorHash: "rebuild1",
           seq: 0,
           model: "rebuild-test",
+          embedFingerprint: TEST_FINGERPRINT,
           embedding: new Float32Array([1, 0, 0, 0]),
         },
       ]);
@@ -243,6 +251,7 @@ describe("sqlite-vec integration", () => {
           mirror_hash TEXT NOT NULL,
           seq INTEGER NOT NULL,
           model TEXT NOT NULL,
+          embed_fingerprint TEXT NOT NULL DEFAULT '',
           embedding BLOB NOT NULL,
           embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
           PRIMARY KEY (mirror_hash, seq, model)
@@ -265,6 +274,7 @@ describe("sqlite-vec integration", () => {
           mirrorHash: "doc1",
           seq: 0,
           model: "replace-test",
+          embedFingerprint: TEST_FINGERPRINT,
           embedding: new Float32Array([1, 0, 0, 0]),
         },
       ]);
@@ -274,6 +284,7 @@ describe("sqlite-vec integration", () => {
           mirrorHash: "doc1",
           seq: 0,
           model: "replace-test",
+          embedFingerprint: TEST_FINGERPRINT,
           embedding: new Float32Array([0, 1, 0, 0]),
         },
       ]);

--- a/test/store/vector/sqlite-vec.test.ts
+++ b/test/store/vector/sqlite-vec.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../../../src/store/vector/sqlite-vec";
 import { safeRm } from "../../helpers/cleanup";
 
+const TEST_FINGERPRINT = "test-fingerprint";
+
 describe("encodeEmbedding/decodeEmbedding", () => {
   test("round-trips Float32Array correctly", () => {
     const original = new Float32Array([1.0, 2.0, 3.0, 4.0]);
@@ -74,6 +76,7 @@ describe("createVectorIndexPort", () => {
         mirror_hash TEXT NOT NULL,
         seq INTEGER NOT NULL,
         model TEXT NOT NULL,
+        embed_fingerprint TEXT NOT NULL DEFAULT '',
         embedding BLOB NOT NULL,
         embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (mirror_hash, seq, model)
@@ -120,12 +123,14 @@ describe("createVectorIndexPort", () => {
         mirrorHash: "hash1",
         seq: 0,
         model: "test-model",
+        embedFingerprint: TEST_FINGERPRINT,
         embedding: new Float32Array([1.0, 2.0, 3.0, 4.0]),
       },
       {
         mirrorHash: "hash1",
         seq: 1,
         model: "test-model",
+        embedFingerprint: TEST_FINGERPRINT,
         embedding: new Float32Array([5.0, 6.0, 7.0, 8.0]),
       },
     ];
@@ -136,8 +141,13 @@ describe("createVectorIndexPort", () => {
     // Verify stored in content_vectors
     const rows = db
       .prepare("SELECT * FROM content_vectors WHERE model = ?")
-      .all("test-model") as { mirror_hash: string; seq: number }[];
+      .all("test-model") as {
+      embed_fingerprint: string;
+      mirror_hash: string;
+      seq: number;
+    }[];
     expect(rows.length).toBe(2);
+    expect(rows[0]?.embed_fingerprint).toBe(TEST_FINGERPRINT);
   });
 
   test("upsertVectors replaces existing vectors", async () => {
@@ -158,6 +168,7 @@ describe("createVectorIndexPort", () => {
         mirrorHash: "hash1",
         seq: 0,
         model: "test-model",
+        embedFingerprint: TEST_FINGERPRINT,
         embedding: new Float32Array([1.0, 2.0, 3.0, 4.0]),
       },
     ]);
@@ -168,15 +179,18 @@ describe("createVectorIndexPort", () => {
         mirrorHash: "hash1",
         seq: 0,
         model: "test-model",
+        embedFingerprint: "updated-fingerprint",
         embedding: new Float32Array([9.0, 9.0, 9.0, 9.0]),
       },
     ]);
 
     // Should still be 1 row
     const rows = db.prepare("SELECT * FROM content_vectors").all() as {
+      embed_fingerprint: string;
       mirror_hash: string;
     }[];
     expect(rows.length).toBe(1);
+    expect(rows[0]?.embed_fingerprint).toBe("updated-fingerprint");
   });
 
   test("deleteVectorsForMirror removes vectors for mirror hash", async () => {
@@ -197,12 +211,14 @@ describe("createVectorIndexPort", () => {
         mirrorHash: "hash1",
         seq: 0,
         model: "test-model",
+        embedFingerprint: TEST_FINGERPRINT,
         embedding: new Float32Array([1, 2, 3, 4]),
       },
       {
         mirrorHash: "hash2",
         seq: 0,
         model: "test-model",
+        embedFingerprint: TEST_FINGERPRINT,
         embedding: new Float32Array([5, 6, 7, 8]),
       },
     ]);

--- a/test/store/vector/stats.test.ts
+++ b/test/store/vector/stats.test.ts
@@ -11,6 +11,9 @@ import { join } from "node:path";
 import { createVectorStatsPort } from "../../../src/store/vector/stats";
 import { safeRm } from "../../helpers/cleanup";
 
+const TEST_FINGERPRINT = "test-fingerprint";
+const OTHER_FINGERPRINT = "other-fingerprint";
+
 describe("VectorStatsPort", () => {
   let db: Database;
   let testDir: string;
@@ -47,6 +50,7 @@ describe("VectorStatsPort", () => {
         mirror_hash TEXT NOT NULL,
         seq INTEGER NOT NULL,
         model TEXT NOT NULL,
+        embed_fingerprint TEXT NOT NULL DEFAULT '',
         embedding BLOB NOT NULL,
         embedded_at TEXT DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (mirror_hash, seq, model)
@@ -102,12 +106,14 @@ describe("VectorStatsPort", () => {
         INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
         INSERT INTO content_chunks (mirror_hash, seq, text, created_at)
         VALUES ('h1', 0, 'chunk text', datetime('now', '-1 minute'));
-        INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-        VALUES ('h1', 0, 'test-model', x'00000000', datetime('now'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        )
+        VALUES ('h1', 0, 'test-model', '${TEST_FINGERPRINT}', x'00000000', datetime('now'));
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.countBacklog("test-model");
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -123,12 +129,14 @@ describe("VectorStatsPort", () => {
           ('h1', 0, 'chunk 0'),
           ('h1', 1, 'chunk 1'),
           ('h1', 2, 'chunk 2');
-        INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-        VALUES ('h1', 0, 'test-model', x'00000000', datetime('now'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        )
+        VALUES ('h1', 0, 'test-model', '${TEST_FINGERPRINT}', x'00000000', datetime('now'));
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.countBacklog("test-model");
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -148,7 +156,7 @@ describe("VectorStatsPort", () => {
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.countBacklog("test-model");
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -162,16 +170,78 @@ describe("VectorStatsPort", () => {
         INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
         INSERT INTO content_chunks (mirror_hash, seq, text, created_at)
         VALUES ('h1', 0, 'updated chunk', datetime('now'));
-        INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-        VALUES ('h1', 0, 'test-model', x'00000000', datetime('now', '-1 minute'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        )
+        VALUES ('h1', 0, 'test-model', '${TEST_FINGERPRINT}', x'00000000', datetime('now', '-1 minute'));
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.countBacklog("test-model");
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value).toBe(1); // stale vector
+      }
+    });
+
+    test("counts stale fingerprint vectors as backlog", async () => {
+      db.exec(`
+        INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
+        INSERT INTO content_chunks (mirror_hash, seq, text, created_at)
+        VALUES ('h1', 0, 'chunk text', datetime('now', '-1 minute'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        )
+        VALUES ('h1', 0, 'test-model', '${OTHER_FINGERPRINT}', x'00000000', datetime('now'));
+      `);
+
+      const stats = createVectorStatsPort(db);
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(1);
+      }
+    });
+
+    test("counts mixed fingerprint rows by exact current fingerprint", async () => {
+      db.exec(`
+        INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
+        INSERT INTO content_chunks (mirror_hash, seq, text, created_at) VALUES
+          ('h1', 0, 'current chunk', datetime('now', '-1 minute')),
+          ('h1', 1, 'stale chunk', datetime('now', '-1 minute'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        ) VALUES
+          ('h1', 0, 'test-model', '${TEST_FINGERPRINT}', x'00000000', datetime('now')),
+          ('h1', 1, 'test-model', '${OTHER_FINGERPRINT}', x'00000000', datetime('now'));
+      `);
+
+      const stats = createVectorStatsPort(db);
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(1);
+      }
+    });
+
+    test("treats legacy empty-fingerprint rows as backlog", async () => {
+      db.exec(`
+        INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
+        INSERT INTO content_chunks (mirror_hash, seq, text, created_at)
+        VALUES ('h1', 0, 'legacy chunk', datetime('now', '-1 minute'));
+        INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
+        VALUES ('h1', 0, 'test-model', x'00000000', datetime('now'));
+      `);
+
+      const stats = createVectorStatsPort(db);
+      const result = await stats.countBacklog("test-model", TEST_FINGERPRINT);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(1);
       }
     });
 
@@ -186,10 +256,10 @@ describe("VectorStatsPort", () => {
       `);
 
       const stats = createVectorStatsPort(db);
-      const notes = await stats.countBacklog("test-model", {
+      const notes = await stats.countBacklog("test-model", TEST_FINGERPRINT, {
         collection: "notes",
       });
-      const other = await stats.countBacklog("test-model", {
+      const other = await stats.countBacklog("test-model", TEST_FINGERPRINT, {
         collection: "other",
       });
 
@@ -210,12 +280,14 @@ describe("VectorStatsPort", () => {
         INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
         INSERT INTO content_chunks (mirror_hash, seq, text, created_at)
         VALUES ('h1', 0, 'chunk', datetime('now', '-1 minute'));
-        INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-        VALUES ('h1', 0, 'test-model', x'00000000', datetime('now'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        )
+        VALUES ('h1', 0, 'test-model', '${TEST_FINGERPRINT}', x'00000000', datetime('now'));
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.getBacklog("test-model");
+      const result = await stats.getBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -232,7 +304,7 @@ describe("VectorStatsPort", () => {
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.getBacklog("test-model");
+      const result = await stats.getBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -256,7 +328,9 @@ describe("VectorStatsPort", () => {
       const stats = createVectorStatsPort(db);
 
       // Get first 2
-      const result1 = await stats.getBacklog("test-model", { limit: 2 });
+      const result1 = await stats.getBacklog("test-model", TEST_FINGERPRINT, {
+        limit: 2,
+      });
       expect(result1.ok).toBe(true);
       if (!result1.ok) {
         return;
@@ -267,7 +341,7 @@ describe("VectorStatsPort", () => {
 
       // Get next 2 using cursor from last item
       const lastItem = result1.value[1];
-      const result2 = await stats.getBacklog("test-model", {
+      const result2 = await stats.getBacklog("test-model", TEST_FINGERPRINT, {
         limit: 2,
         after: {
           mirrorHash: lastItem?.mirrorHash ?? "",
@@ -288,12 +362,14 @@ describe("VectorStatsPort", () => {
         INSERT INTO documents (id, mirror_hash, active) VALUES (1, 'h1', 1);
         INSERT INTO content_chunks (mirror_hash, seq, text, created_at)
         VALUES ('h1', 0, 'updated chunk', datetime('now'));
-        INSERT INTO content_vectors (mirror_hash, seq, model, embedding, embedded_at)
-        VALUES ('h1', 0, 'test-model', x'00000000', datetime('now', '-1 minute'));
+        INSERT INTO content_vectors (
+          mirror_hash, seq, model, embed_fingerprint, embedding, embedded_at
+        )
+        VALUES ('h1', 0, 'test-model', '${TEST_FINGERPRINT}', x'00000000', datetime('now', '-1 minute'));
       `);
 
       const stats = createVectorStatsPort(db);
-      const result = await stats.getBacklog("test-model");
+      const result = await stats.getBacklog("test-model", TEST_FINGERPRINT);
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -313,7 +389,7 @@ describe("VectorStatsPort", () => {
       `);
 
       const stats = createVectorStatsPort(db);
-      const notes = await stats.getBacklog("test-model", {
+      const notes = await stats.getBacklog("test-model", TEST_FINGERPRINT, {
         collection: "notes",
       });
 


### PR DESCRIPTION
# Embedding and package hardening

GNO now makes vector freshness model-aware, retries transient embedding failures in the same run, and adds a packed npm package smoke gate for release verification.

> **Spec:** [fn-81-embedding-and-package-hardening](.flow/specs/fn-81-embedding-and-package-hardening.md)
> **Branch:** `feat/fn-81-embedding-and-package-hardening` -> `origin/main`
> **Tasks:** 5 completed
> **R-ID coverage:** 7/7 satisfied

## TL;DR

- Adds per-vector embedding fingerprints so stale/mixed/legacy vector rows are observable instead of silently treated as fresh.
- Extends `gno doctor` terminal and JSON output with fingerprint diagnostics, pending/stale counts, legacy rows, and stored fingerprint groups.
- Retries transient embedding chunk failures inside the same embed run while preserving existing backlog pagination behavior.
- Adds `bun run test:package`, a tarball-first package smoke that installs from the packed npm artifact and validates CLI/runtime shape.
- Updates in-repo specs, docs, changelog, release guidance, and hosted docs source for the new behavior.

## R-ID coverage

| R-ID | Acceptance criterion | Task | Evidence |
|------|----------------------|------|----------|
| R1 | `content_vectors` has an `embed_fingerprint` column, useful index coverage, migration coverage, and matching DB spec updates. | [fn-81-embedding-and-package-hardening.1](.flow/tasks/fn-81-embedding-and-package-hardening.1.md) | [`0fb89ee`](../../commit/0fb89eec272d0826f3d3abc39cedd32ee5e0df66) |
| R2 | Vector writes, backlog counts, and status paths use exact model+fingerprint freshness while preserving legacy rows. | [fn-81-embedding-and-package-hardening.1](.flow/tasks/fn-81-embedding-and-package-hardening.1.md) | [`0fb89ee`](../../commit/0fb89eec272d0826f3d3abc39cedd32ee5e0df66) |
| R3 | `gno doctor` terminal and JSON output report fingerprint health without making `gno status` probe native models. | [fn-81-embedding-and-package-hardening.2](.flow/tasks/fn-81-embedding-and-package-hardening.2.md) | [`658a072`](../../commit/658a072e55376e7a992e013a8e0e1cff3ac62699) |
| R4 | Shared backlog and CLI embedding retry transient failed chunks within one command run and report permanent failures clearly. | [fn-81-embedding-and-package-hardening.3](.flow/tasks/fn-81-embedding-and-package-hardening.3.md) | [`78670e7`](../../commit/78670e732dd5d444d1602f74c4bb62ef16fe04a4) |
| R5 | `bun run test:package` packs, installs from the tarball, verifies package contents, and fails on CLI or doctor failures. | [fn-81-embedding-and-package-hardening.4](.flow/tasks/fn-81-embedding-and-package-hardening.4.md) | [`8dca576`](../../commit/8dca5768d6e7f0fd5ed7b937e84870188c8735c1) |
| R6 | User-facing docs, CLI/spec contracts, troubleshooting, packaging/release guidance, and changelog entries match behavior. | [fn-81-embedding-and-package-hardening.2](.flow/tasks/fn-81-embedding-and-package-hardening.2.md), [fn-81-embedding-and-package-hardening.4](.flow/tasks/fn-81-embedding-and-package-hardening.4.md) | [`658a072`](../../commit/658a072e55376e7a992e013a8e0e1cff3ac62699), [`8dca576`](../../commit/8dca5768d6e7f0fd5ed7b937e84870188c8735c1) |
| R7 | Hosted website docs source is updated in the same delivery path for the user-facing changes. | [fn-81-embedding-and-package-hardening.5](.flow/tasks/fn-81-embedding-and-package-hardening.5.md) | [`2e6881a`](https://github.com/gmickel/gno.sh/commit/2e6881abc0b5d5c064da4ba6901492779733f110) |

## Critical changes

- **High-churn:** [`src/cli/commands/embed.ts`](src/cli/commands/embed.ts) (+172/-209 lines) aligns the CLI embed loop with bounded same-run retry behavior.
- **High-churn:** [`scripts/package-smoke.ts`](scripts/package-smoke.ts) (+260/-0 lines) adds the packed npm artifact smoke gate.
- **High-churn:** [`src/cli/commands/doctor.ts`](src/cli/commands/doctor.ts) (+179/-1 lines) adds embedding fingerprint diagnostics to doctor output.
- **High-churn:** [`src/embed/backlog.ts`](src/embed/backlog.ts) (+92/-45 lines) updates shared backlog processing for fingerprint freshness and retry flow.
- **High-churn:** [`src/embed/retry.ts`](src/embed/retry.ts) (+137/-0 lines) adds bounded retry state for failed embedding chunks.
- **Public interface:** [`src/store/migrations/index.ts`](src/store/migrations/index.ts) updates the exported `migrations` list for the new vector fingerprint migration.
- **Security-sensitive:** [`.github/workflows/publish.yml`](.github/workflows/publish.yml) changes release CI package smoke coverage.

## Structural changes

Embedding freshness now flows through store, CLI, and diagnostic surfaces. [`src/embed/fingerprint.ts`](src/embed/fingerprint.ts) defines the fingerprint helper, [`src/store/vector/stats.ts`](src/store/vector/stats.ts) and [`src/store/vector/sqlite-vec.ts`](src/store/vector/sqlite-vec.ts) apply it to vector freshness and writes, and [`src/cli/commands/doctor.ts`](src/cli/commands/doctor.ts) exposes the resulting health state. The retry path is separated into [`src/embed/retry.ts`](src/embed/retry.ts), with both shared backlog processing and CLI embedding using the same bounded retry model.

```mermaid
flowchart LR
  fingerprint["src/embed/fingerprint.ts"] --> storeStats["src/store/vector/stats.ts"]
  fingerprint --> storeVec["src/store/vector/sqlite-vec.ts"]
  storeStats --> backlog["src/embed/backlog.ts"]
  retry["src/embed/retry.ts"] --> backlog
  retry --> embedCli["src/cli/commands/embed.ts"]
  storeStats --> doctor["src/cli/commands/doctor.ts"]
```

## Where to look

- **Architecture:** Does [`src/embed/retry.ts`](src/embed/retry.ts) keep retry state bounded and separate from the forward backlog cursor?
- **Business correctness:** Does [`src/cli/commands/doctor.ts`](src/cli/commands/doctor.ts) report fingerprint health clearly enough for users to know whether re-embedding is needed?
- **Package safety:** Does [`scripts/package-smoke.ts`](scripts/package-smoke.ts) verify the runtime files and commands that matter for a real packed install?
- **Release CI:** Does [`.github/workflows/publish.yml`](.github/workflows/publish.yml) run the same package smoke gate expected locally?
- **Tests:** Do [`test/embed/backlog.test.ts`](test/embed/backlog.test.ts), [`test/spec/schemas/doctor.test.ts`](test/spec/schemas/doctor.test.ts), and vector store tests cover the new freshness and retry behavior?

## Verification

- `bun run lint:check`
- `bun run typecheck`
- `bun run docs:verify`
- `bun test` - 1893 pass, 1 skip
- `bun run test:package`

Generated by /flow-next:make-pr from fn-81-embedding-and-package-hardening against origin/main on 2026-05-26.
