### PR TITLE
fix(release): accept settled model-load recovery

### DIFF
--- a/scripts/package-smoke-resident-support.ts
+++ b/scripts/package-smoke-resident-support.ts
@@ -317,6 +317,43 @@ export function residentOwnershipState(status: ResidentStatus): object {
   };
 }
 
+/**
+ * Accept settled warm reuse even after a recovered prior load failure
+ * (e.g. loadAttempts=2, loadSuccesses=1, loadFailures=1, loadedModels=1).
+ * Reject unloaded/unsuccessful pre-state, inconsistent counters, new loads
+ * during reuse, unbalanced leases, or leftover active/inflight state.
+ */
+export function isValidPackedWarmModelReuse(
+  before: ResidentStatus["models"],
+  after: ResidentStatus["models"],
+  expectedLeaseCount: number
+): boolean {
+  const beforeSettled =
+    before.loadedModels === 1 &&
+    before.loadSuccesses >= 1 &&
+    before.loadAttempts === before.loadSuccesses + before.loadFailures &&
+    before.activeLeases === 0 &&
+    before.leaseAcquisitions === before.leaseReleases &&
+    before.inflightLoads === 0;
+  if (!beforeSettled) {
+    return false;
+  }
+
+  const acquired = after.leaseAcquisitions - before.leaseAcquisitions;
+  const released = after.leaseReleases - before.leaseReleases;
+  return (
+    after.loadedModels === before.loadedModels &&
+    after.loadAttempts === before.loadAttempts &&
+    after.loadSuccesses === before.loadSuccesses &&
+    after.loadFailures === before.loadFailures &&
+    acquired === expectedLeaseCount &&
+    released === acquired &&
+    after.activeLeases === 0 &&
+    after.leaseAcquisitions === after.leaseReleases &&
+    after.inflightLoads === 0
+  );
+}
+
 export async function proveResidentUnaffectedByDirectSetup(
   input: ResidentSmokeInput,
   baseUrl: string

--- a/scripts/package-smoke-resident.ts
+++ b/scripts/package-smoke-resident.ts
@@ -13,6 +13,7 @@ import {
   createHttpClient,
   freeLoopbackPort,
   isRecord,
+  isValidPackedWarmModelReuse,
   JSON_HEADERS,
   parseJsonObject,
   proveResidentUnaffectedByDirectSetup,
@@ -135,25 +136,12 @@ async function proveLoopbackGateway(input: ResidentSmokeInput): Promise<void> {
         "serve",
         [input.cwd, input.env.GNO_DATA_DIR ?? "", "package-smoke-secret"]
       );
-      const acquired =
-        semanticAfter.models.leaseAcquisitions -
-        semanticBefore.models.leaseAcquisitions;
-      const released =
-        semanticAfter.models.leaseReleases -
-        semanticBefore.models.leaseReleases;
       if (
-        semanticBefore.models.loadedModels !== 1 ||
-        semanticBefore.models.loadAttempts !== 1 ||
-        semanticBefore.models.loadSuccesses !== 1 ||
-        semanticAfter.models.loadedModels !==
-          semanticBefore.models.loadedModels ||
-        semanticAfter.models.loadAttempts !==
-          semanticBefore.models.loadAttempts ||
-        semanticAfter.models.loadSuccesses !==
-          semanticBefore.models.loadSuccesses ||
-        acquired !== semanticResults.length ||
-        released !== acquired ||
-        semanticAfter.models.activeLeases !== 0
+        !isValidPackedWarmModelReuse(
+          semanticBefore.models,
+          semanticAfter.models,
+          semanticResults.length
+        )
       ) {
         throw new Error(
           `Packed model-backed warm reuse failed: ${JSON.stringify({

--- a/test/scripts/package-smoke-resident-support.test.ts
+++ b/test/scripts/package-smoke-resident-support.test.ts
@@ -2,8 +2,26 @@ import { describe, expect, test } from "bun:test";
 
 import {
   isExpectedResidentShutdownExit,
+  isValidPackedWarmModelReuse,
+  type ResidentStatus,
   waitForStatus,
 } from "../../scripts/package-smoke-resident-support";
+
+type ModelStatus = ResidentStatus["models"];
+
+function models(overrides: Partial<ModelStatus> = {}): ModelStatus {
+  return {
+    activeLeases: 0,
+    leaseAcquisitions: 0,
+    leaseReleases: 0,
+    loadedModels: 1,
+    loadAttempts: 1,
+    loadSuccesses: 1,
+    loadFailures: 0,
+    inflightLoads: 0,
+    ...overrides,
+  };
+}
 
 describe("packed resident shutdown exits", () => {
   test("accepts the platform-specific signal status", () => {
@@ -46,4 +64,111 @@ describe("packed resident shutdown exits", () => {
     expect((startupError as Error).message).toContain("resident stderr");
     expect(performance.now() - startedAt).toBeLessThan(5000);
   });
+});
+
+describe("packed warm model reuse validation", () => {
+  test("accepts recovered prior load failure when settled", () => {
+    const before = models({
+      leaseAcquisitions: 2,
+      leaseReleases: 2,
+      loadAttempts: 2,
+      loadSuccesses: 1,
+      loadFailures: 1,
+      loadedModels: 1,
+    });
+    const after = models({
+      leaseAcquisitions: 6,
+      leaseReleases: 6,
+      loadAttempts: 2,
+      loadSuccesses: 1,
+      loadFailures: 1,
+      loadedModels: 1,
+    });
+    expect(isValidPackedWarmModelReuse(before, after, 4)).toBe(true);
+  });
+
+  const recoveredBefore = models({
+    leaseAcquisitions: 2,
+    leaseReleases: 2,
+    loadAttempts: 2,
+    loadSuccesses: 1,
+    loadFailures: 1,
+  });
+  const recoveredAfter = models({
+    leaseAcquisitions: 6,
+    leaseReleases: 6,
+    loadAttempts: 2,
+    loadSuccesses: 1,
+    loadFailures: 1,
+  });
+  const rejectedCases: {
+    name: string;
+    before: ModelStatus;
+    after: ModelStatus;
+  }[] = [
+    {
+      name: "no successful loaded model",
+      before: models({
+        loadedModels: 0,
+        loadAttempts: 1,
+        loadSuccesses: 0,
+        loadFailures: 1,
+      }),
+      after: recoveredAfter,
+    },
+    {
+      name: "inconsistent load accounting",
+      before: models({
+        loadAttempts: 3,
+        loadSuccesses: 1,
+        loadFailures: 1,
+      }),
+      after: recoveredAfter,
+    },
+    {
+      name: "unsettled or unbalanced pre-state",
+      before: models({
+        activeLeases: 1,
+        leaseAcquisitions: 2,
+        leaseReleases: 1,
+      }),
+      after: recoveredAfter,
+    },
+    {
+      name: "new load failure during reuse",
+      before: recoveredBefore,
+      after: {
+        ...recoveredAfter,
+        loadAttempts: 3,
+        loadFailures: 2,
+      },
+    },
+    {
+      name: "wrong request lease count",
+      before: recoveredBefore,
+      after: {
+        ...recoveredAfter,
+        leaseAcquisitions: 5,
+        leaseReleases: 5,
+      },
+    },
+    {
+      name: "unreleased request lease",
+      before: recoveredBefore,
+      after: { ...recoveredAfter, leaseReleases: 5 },
+    },
+    {
+      name: "leftover active or inflight work",
+      before: recoveredBefore,
+      after: { ...recoveredAfter, activeLeases: 1, inflightLoads: 1 },
+    },
+  ];
+
+  for (const rejectedCase of rejectedCases) {
+    test(`rejects ${rejectedCase.name}`, () => {
+      expect(
+        isValidPackedWarmModelReuse(rejectedCase.before, rejectedCase.after, 4)
+      ).toBe(false);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- accept a prior bounded model-load failure only after the resident has recovered to a settled, fully accounted state
- require warm probes to preserve model/load/failure counters and balance the exact lease delta
- add negative regressions for inconsistent counters, new loads/failures, leaked leases, and active/inflight work

## Evidence

- `bun test test/scripts/package-smoke-resident-support.test.ts` — 11 passed, 33 assertions
- `bun run lint:check` — clean
- reproduces the v1.25.0 pack-test recovery state: 2 attempts / 1 success / 1 prior failure / 1 loaded model

Closes the release-only assertion failure from workflow run 30100552039.