### PR TITLE
fix: filter watcher events by collection rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Filtered resident watcher events through the collection's live pattern,
+  include, exclude, and adapter-extension rules before sync, scheduling, or
+  Web event broadcast. Same-name collection root changes now restart their
+  watcher instead of retaining the stale path. Thanks @DanielKillenberger for
+  the report.
+
 ## [1.29.5] - 2026-07-25
 
 ### Changed

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -31,4 +31,4 @@ export type {
 } from "./types";
 export { collectionToWalkConfig, DEFAULT_CHUNK_PARAMS } from "./types";
 // Walker
-export { defaultWalker, FileWalker } from "./walker";
+export { defaultWalker, FileWalker, matchesWalkPath } from "./walker";

--- a/src/ingestion/walker.ts
+++ b/src/ingestion/walker.ts
@@ -174,6 +174,50 @@ function matchesInclude(
   });
 }
 
+type PathEligibilityConfig = Pick<
+  WalkConfig,
+  "additionalDefaultExtensions" | "exclude" | "include" | "pattern"
+>;
+
+/**
+ * Check collection-relative path eligibility without touching the filesystem.
+ * This intentionally remains usable for deleted paths so incremental sync can
+ * mark previously indexed documents inactive.
+ */
+export function matchesWalkPath(
+  relPath: string,
+  config: PathEligibilityConfig
+): boolean {
+  const normalizedPath = relPath.replaceAll("\\", "/");
+  if (
+    isAbsolute(normalizedPath) ||
+    DANGEROUS_PATTERN_REGEX.test(normalizedPath) ||
+    isRecordVirtualPath(normalizedPath)
+  ) {
+    return false;
+  }
+
+  let matchesPattern = false;
+  try {
+    matchesPattern = new Bun.Glob(config.pattern).match(normalizedPath);
+  } catch {
+    return false;
+  }
+  if (!matchesPattern) {
+    return false;
+  }
+
+  if (matchesCollectionExclusion(normalizedPath, config.exclude)) {
+    return false;
+  }
+
+  return matchesInclude(
+    normalizedPath,
+    config.include,
+    config.additionalDefaultExtensions ?? []
+  );
+}
+
 /**
  * File walker implementation using Bun.Glob.
  *
@@ -228,29 +272,7 @@ export class FileWalker implements WalkerPort {
       }
       const { absPath, relPath } = safePath;
 
-      if (isRecordVirtualPath(relPath)) {
-        skipped.push({ absPath, relPath, reason: "EXCLUDED" });
-        continue;
-      }
-
-      // Check exclude patterns
-      if (matchesCollectionExclusion(relPath, config.exclude)) {
-        skipped.push({
-          absPath,
-          relPath,
-          reason: "EXCLUDED",
-        });
-        continue;
-      }
-
-      // Check include extensions
-      if (
-        !matchesInclude(
-          relPath,
-          config.include,
-          config.additionalDefaultExtensions ?? []
-        )
-      ) {
+      if (!matchesWalkPath(relPath, config)) {
         skipped.push({
           absPath,
           relPath,

--- a/src/serve/watch-service.ts
+++ b/src/serve/watch-service.ts
@@ -7,7 +7,11 @@ import type { SqliteAdapter } from "../store/sqlite/adapter";
 import type { DocumentEvent, DocumentEventBus } from "./doc-events";
 import type { EmbedScheduler } from "./embed-scheduler";
 
-import { defaultSyncService } from "../ingestion";
+import {
+  collectionToWalkConfig,
+  defaultSyncService,
+  matchesWalkPath,
+} from "../ingestion";
 
 export interface CollectionWatchState {
   expectedCollections: string[];
@@ -45,6 +49,41 @@ interface CollectionWatchServiceOptions {
   watchFactory?: typeof watch;
 }
 
+function watcherCollectionFingerprint(
+  collection: Collection,
+  syncOptions: SyncOptions
+): string {
+  return JSON.stringify({
+    path: normalize(collection.path),
+    pattern: collection.pattern,
+    include: collection.include,
+    exclude: collection.exclude,
+    languageHint: collection.languageHint ?? null,
+    recordAdapters: collection.recordAdapters ?? null,
+    limits: syncOptions.limits ?? null,
+    concurrency: syncOptions.concurrency ?? null,
+    contentTypeRules: syncOptions.contentTypeRules ?? null,
+    contentTypeRulesFingerprint:
+      syncOptions.contentTypeRulesFingerprint ?? null,
+    projectTypedEdges: syncOptions.projectTypedEdges ?? null,
+  });
+}
+
+function changedPaths(
+  result: CollectionSyncResult,
+  fallbackPaths: string[] = []
+): string[] {
+  if (result.files) {
+    return result.files
+      .filter((file) => file.status === "added" || file.status === "updated")
+      .map((file) => file.relPath);
+  }
+  return result.filesAdded + result.filesUpdated + result.filesMarkedInactive >
+    0
+    ? fallbackPaths
+    : [];
+}
+
 export class CollectionWatchService {
   #collections: Collection[];
   readonly #store: SqliteAdapter;
@@ -53,12 +92,18 @@ export class CollectionWatchService {
   readonly #callbacks: CollectionWatchCallbacks | null;
   #syncOptions: SyncOptions;
   readonly #watchers = new Map<string, FSWatcher>();
+  readonly #watchRoots = new Map<string, string>();
+  readonly #collectionGenerations = new Map<string, number>();
+  readonly #collectionFingerprints = new Map<string, string>();
   readonly #pendingByCollection = new Map<string, Set<string>>();
   readonly #timers = new Map<string, ReturnType<typeof setTimeout>>();
   readonly #syncing = new Set<string>();
+  readonly #inFlightSyncs = new Set<Promise<void>>();
   readonly #suppressedPaths = new Map<string, number>();
   readonly #watchFactory: typeof watch;
   readonly #failedCollections = new Map<string, string>();
+  #nextCollectionGeneration = 0;
+  #disposed = false;
   #lastEventAt: string | null = null;
   #lastSyncAt: string | null = null;
 
@@ -73,6 +118,9 @@ export class CollectionWatchService {
   }
 
   start(): void {
+    if (this.#disposed) {
+      return;
+    }
     this.updateCollections(this.#collections);
   }
 
@@ -80,16 +128,28 @@ export class CollectionWatchService {
     collections: Collection[],
     syncOptions?: SyncOptions
   ): void {
-    this.#collections = collections;
+    if (this.#disposed) {
+      return;
+    }
     if (syncOptions) {
       this.#syncOptions = syncOptions;
     }
-    const nextNames = new Set(collections.map((collection) => collection.name));
+    const nextByName = new Map(
+      collections.map((collection) => [collection.name, collection])
+    );
 
     for (const [collectionName, watcher] of this.#watchers) {
-      if (!nextNames.has(collectionName)) {
+      const nextCollection = nextByName.get(collectionName);
+      const nextRoot = nextCollection
+        ? normalize(nextCollection.path)
+        : undefined;
+      if (
+        nextRoot === undefined ||
+        nextRoot !== this.#watchRoots.get(collectionName)
+      ) {
         watcher.close();
         this.#watchers.delete(collectionName);
+        this.#watchRoots.delete(collectionName);
         this.#failedCollections.delete(collectionName);
         this.#pendingByCollection.delete(collectionName);
         const timer = this.#timers.get(collectionName);
@@ -97,7 +157,31 @@ export class CollectionWatchService {
           clearTimeout(timer);
           this.#timers.delete(collectionName);
         }
-        this.#syncing.delete(collectionName);
+      }
+    }
+
+    for (const collectionName of this.#collectionFingerprints.keys()) {
+      if (!nextByName.has(collectionName)) {
+        this.#collectionFingerprints.delete(collectionName);
+        this.#collectionGenerations.set(
+          collectionName,
+          ++this.#nextCollectionGeneration
+        );
+      }
+    }
+
+    this.#collections = collections;
+    for (const collection of collections) {
+      const fingerprint = watcherCollectionFingerprint(
+        collection,
+        this.#syncOptions
+      );
+      if (this.#collectionFingerprints.get(collection.name) !== fingerprint) {
+        this.#collectionFingerprints.set(collection.name, fingerprint);
+        this.#collectionGenerations.set(
+          collection.name,
+          ++this.#nextCollectionGeneration
+        );
       }
     }
 
@@ -106,13 +190,27 @@ export class CollectionWatchService {
         continue;
       }
       try {
+        const watchedRoot = normalize(collection.path);
         const watcher = this.#watchFactory(
           collection.path,
           { recursive: true },
           (_eventType, filename) => {
-            if (!filename) return;
+            if (this.#disposed || !filename) return;
             const relPath = filename.toString().replaceAll("\\", "/");
-            const fullPath = normalize(join(collection.path, relPath));
+            const currentCollection = this.#collections.find(
+              (entry) => entry.name === collection.name
+            );
+            if (
+              !currentCollection ||
+              normalize(currentCollection.path) !== watchedRoot ||
+              !matchesWalkPath(
+                relPath,
+                collectionToWalkConfig(currentCollection, 0)
+              )
+            ) {
+              return;
+            }
+            const fullPath = normalize(join(watchedRoot, relPath));
             const suppressedUntil = this.#suppressedPaths.get(fullPath);
             if (suppressedUntil && suppressedUntil > Date.now()) {
               return;
@@ -122,6 +220,7 @@ export class CollectionWatchService {
           }
         );
         this.#watchers.set(collection.name, watcher);
+        this.#watchRoots.set(collection.name, watchedRoot);
         this.#failedCollections.delete(collection.name);
       } catch (error) {
         this.#failedCollections.set(
@@ -136,7 +235,11 @@ export class CollectionWatchService {
     this.#suppressedPaths.set(normalize(absPath), Date.now() + ms);
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
     for (const timer of this.#timers.values()) {
       clearTimeout(timer);
     }
@@ -145,7 +248,12 @@ export class CollectionWatchService {
     }
     this.#timers.clear();
     this.#watchers.clear();
+    this.#watchRoots.clear();
+    this.#collectionGenerations.clear();
+    this.#collectionFingerprints.clear();
+    this.#collections = [];
     this.#pendingByCollection.clear();
+    await Promise.allSettled(this.#inFlightSyncs);
     this.#syncing.clear();
   }
 
@@ -168,6 +276,9 @@ export class CollectionWatchService {
   }
 
   #queueChange(collectionName: string, relPath: string): void {
+    if (this.#disposed) {
+      return;
+    }
     const pending =
       this.#pendingByCollection.get(collectionName) ?? new Set<string>();
     pending.add(relPath);
@@ -180,12 +291,28 @@ export class CollectionWatchService {
     this.#timers.set(
       collectionName,
       setTimeout(() => {
-        void this.#flushCollection(collectionName);
+        this.#startFlush(collectionName);
       }, 300)
     );
   }
 
+  #startFlush(collectionName: string): void {
+    if (this.#disposed) {
+      return;
+    }
+    const sync = this.#flushCollection(collectionName);
+    this.#inFlightSyncs.add(sync);
+    void sync
+      .finally(() => {
+        this.#inFlightSyncs.delete(sync);
+      })
+      .catch(() => undefined);
+  }
+
   async #flushCollection(collectionName: string): Promise<void> {
+    if (this.#disposed) {
+      return;
+    }
     const pending = this.#pendingByCollection.get(collectionName);
     if (!pending || pending.size === 0) {
       return;
@@ -202,8 +329,15 @@ export class CollectionWatchService {
       return;
     }
 
-    const relPaths = [...pending];
+    const relPaths = [...pending].filter((relPath) =>
+      matchesWalkPath(relPath, collectionToWalkConfig(collection, 0))
+    );
+    let syncGeneration = this.#collectionGenerations.get(collectionName) ?? 0;
     this.#pendingByCollection.set(collectionName, new Set<string>());
+    if (relPaths.length === 0) {
+      this.#notifySettledIfIdle();
+      return;
+    }
     this.#syncing.add(collectionName);
 
     try {
@@ -211,7 +345,7 @@ export class CollectionWatchService {
         collection: collection.name,
         relPaths,
       });
-      const result = await defaultSyncService.syncPaths(
+      let result = await defaultSyncService.syncPaths(
         collection,
         this.#store,
         relPaths,
@@ -220,13 +354,67 @@ export class CollectionWatchService {
           runUpdateCmd: false,
         }
       );
+      if (this.#disposed) {
+        return;
+      }
       this.#callbacks?.onSyncComplete?.({
         collection: collection.name,
         relPaths,
         result,
       });
-      this.#afterSync(collection, relPaths);
+
+      let completionCollection = collection;
+      let completionPaths = changedPaths(result, relPaths);
+      while (true) {
+        const currentCollection = this.#collections.find(
+          (entry) => entry.name === collectionName
+        );
+        if (!currentCollection) {
+          break;
+        }
+        const currentGeneration =
+          this.#collectionGenerations.get(collectionName) ?? 0;
+        if (currentGeneration === syncGeneration) {
+          const currentRelPaths =
+            normalize(currentCollection.path) ===
+            normalize(completionCollection.path)
+              ? completionPaths.filter((relPath) =>
+                  matchesWalkPath(
+                    relPath,
+                    collectionToWalkConfig(currentCollection, 0)
+                  )
+                )
+              : [];
+          if (currentRelPaths.length > 0) {
+            this.#afterSync(currentCollection, currentRelPaths);
+          }
+          break;
+        }
+
+        result = await defaultSyncService.syncCollection(
+          currentCollection,
+          this.#store,
+          {
+            ...this.#syncOptions,
+            runUpdateCmd: false,
+          }
+        );
+        if (this.#disposed) {
+          return;
+        }
+        completionCollection = currentCollection;
+        completionPaths = changedPaths(result);
+        syncGeneration = currentGeneration;
+        this.#callbacks?.onSyncComplete?.({
+          collection: currentCollection.name,
+          relPaths: completionPaths,
+          result,
+        });
+      }
     } catch (error) {
+      if (this.#disposed) {
+        return;
+      }
       this.#callbacks?.onSyncError?.({
         collection: collection.name,
         relPaths,
@@ -235,22 +423,30 @@ export class CollectionWatchService {
       throw error;
     } finally {
       this.#syncing.delete(collectionName);
-      const remaining = this.#pendingByCollection.get(collectionName);
-      if (remaining && remaining.size > 0) {
-        void this.#flushCollection(collectionName);
-      } else if (
-        this.#syncing.size === 0 &&
-        ![...this.#pendingByCollection.values()].some(
-          (relPaths) => relPaths.size > 0
-        )
-      ) {
-        this.#callbacks?.onSettled?.();
+      if (!this.#disposed) {
+        const remaining = this.#pendingByCollection.get(collectionName);
+        if (remaining && remaining.size > 0) {
+          this.#startFlush(collectionName);
+        } else {
+          this.#notifySettledIfIdle();
+        }
       }
     }
   }
 
+  #notifySettledIfIdle(): void {
+    if (
+      this.#syncing.size === 0 &&
+      ![...this.#pendingByCollection.values()].some(
+        (relPaths) => relPaths.size > 0
+      )
+    ) {
+      this.#callbacks?.onSettled?.();
+    }
+  }
+
   #afterSync(collection: Collection, relPaths: string[]): void {
-    if (relPaths.length === 0) {
+    if (this.#disposed || relPaths.length === 0) {
       return;
     }
 

--- a/test/ingestion/walker.test.ts
+++ b/test/ingestion/walker.test.ts
@@ -12,13 +12,59 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { SUPPORTED_EXTENSIONS } from "../../src/converters/mime";
-import { FileWalker } from "../../src/ingestion/walker";
+import { FileWalker, matchesWalkPath } from "../../src/ingestion/walker";
 import { safeRm } from "../helpers/cleanup";
 
 const FIXTURES_ROOT = resolve(import.meta.dir, "../fixtures/walker");
 
 /** ISO date string prefix regex */
 const ISO_DATE_PREFIX_REGEX = /^\d{4}-\d{2}-\d{2}T/;
+
+describe("matchesWalkPath", () => {
+  const config = {
+    pattern: "**/*.md",
+    include: [],
+    exclude: [".obsidian"],
+    additionalDefaultExtensions: [],
+  };
+
+  test("matches pattern, include, and exclude rules without filesystem access", () => {
+    expect(matchesWalkPath("notes/decision.md", config)).toBe(true);
+    expect(matchesWalkPath("deleted.md", config)).toBe(true);
+    expect(matchesWalkPath(".obsidian/workspace.md", config)).toBe(false);
+    expect(matchesWalkPath(".obsidian/.sync.lock", config)).toBe(false);
+    expect(matchesWalkPath("cover.png", config)).toBe(false);
+    expect(matchesWalkPath("../outside.md", config)).toBe(false);
+  });
+
+  test("accepts adapter extensions only when include uses supported defaults", () => {
+    const transcriptConfig = {
+      ...config,
+      pattern: "**/*",
+      additionalDefaultExtensions: [".transcript"],
+    };
+    expect(matchesWalkPath("calls/demo.transcript", transcriptConfig)).toBe(
+      true
+    );
+    expect(
+      matchesWalkPath("calls/demo.transcript", {
+        ...transcriptConfig,
+        include: [".md"],
+      })
+    ).toBe(false);
+  });
+
+  test("supports whole-pattern unions and rejects virtual record paths", () => {
+    const unionConfig = {
+      ...config,
+      pattern: "{**/*.md,**/*.txt}",
+    };
+    expect(matchesWalkPath("notes/readme.txt", unionConfig)).toBe(true);
+    expect(
+      matchesWalkPath(".gno/records/deadbeef/collision.md", unionConfig)
+    ).toBe(false);
+  });
+});
 
 describe("FileWalker", () => {
   const walker = new FileWalker();

--- a/test/serve/watch-service.test.ts
+++ b/test/serve/watch-service.test.ts
@@ -3,6 +3,7 @@ import type { WatchListener } from "node:fs";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type { Collection } from "../../src/config/types";
+import type { CollectionSyncResult } from "../../src/ingestion";
 
 import { defaultSyncService } from "../../src/ingestion";
 import { CollectionWatchService } from "../../src/serve/watch-service";
@@ -17,10 +18,31 @@ function createCollection(name: string, path: string): Collection {
   };
 }
 
+function createSyncResult(
+  overrides: Partial<CollectionSyncResult> = {}
+): CollectionSyncResult {
+  return {
+    collection: "notes",
+    filesProcessed: 0,
+    filesAdded: 0,
+    filesUpdated: 0,
+    filesUnchanged: 0,
+    filesErrored: 0,
+    filesSkipped: 0,
+    filesMarkedInactive: 0,
+    durationMs: 1,
+    errors: [],
+    ...overrides,
+  };
+}
+
 const originalSyncPaths = defaultSyncService.syncPaths.bind(defaultSyncService);
+const originalSyncCollection =
+  defaultSyncService.syncCollection.bind(defaultSyncService);
 
 afterEach(() => {
   defaultSyncService.syncPaths = originalSyncPaths;
+  defaultSyncService.syncCollection = originalSyncCollection;
 });
 
 describe("CollectionWatchService", () => {
@@ -80,6 +102,498 @@ describe("CollectionWatchService", () => {
     ]);
   });
 
+  test("ignores paths excluded by collection rules before sync or broadcast", async () => {
+    let watcherCallback:
+      | ((eventType: string, filename: string) => void)
+      | undefined;
+    const emit = mock((_event: unknown) => undefined);
+    const notifySyncComplete = mock(() => undefined);
+    const onSyncStart = mock(() => undefined);
+    const syncPaths = mock(async () => createSyncResult());
+    defaultSyncService.syncPaths =
+      syncPaths as typeof defaultSyncService.syncPaths;
+
+    const collection = createCollection("notes", "/tmp/notes");
+    collection.exclude = [".obsidian"];
+    const service = new CollectionWatchService({
+      collections: [collection],
+      eventBus: { emit } as never,
+      scheduler: { notifySyncComplete } as never,
+      store: {} as never,
+      callbacks: { onSyncStart },
+      watchFactory: ((
+        _path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watcherCallback = callback as typeof watcherCallback;
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    watcherCallback?.("change", ".obsidian/.sync.lock");
+    watcherCallback?.("change", "cover.png");
+    await Bun.sleep(350);
+
+    expect(syncPaths).not.toHaveBeenCalled();
+    expect(onSyncStart).not.toHaveBeenCalled();
+    expect(notifySyncComplete).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+    expect(service.getState().lastEventAt).toBeNull();
+    expect(service.getState().lastSyncAt).toBeNull();
+    await service.dispose();
+  });
+
+  test("rechecks live collection rules when queued paths flush", async () => {
+    let watcherCallback:
+      | ((eventType: string, filename: string) => void)
+      | undefined;
+    const seenPaths: string[][] = [];
+    const onSettled = mock(() => undefined);
+
+    defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
+      seenPaths.push(relPaths);
+      return createSyncResult({
+        filesProcessed: relPaths.length,
+        filesUpdated: relPaths.length,
+      });
+    }) as typeof defaultSyncService.syncPaths;
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/notes")],
+      eventBus: null,
+      scheduler: null,
+      store: {} as never,
+      callbacks: { onSettled },
+      watchFactory: ((
+        _path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watcherCallback = callback as typeof watcherCallback;
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    watcherCallback?.("change", "drafts/private.md");
+    const updatedCollection = createCollection("notes", "/tmp/notes");
+    updatedCollection.exclude = ["drafts"];
+    service.updateCollections([updatedCollection]);
+    await Bun.sleep(350);
+
+    expect(seenPaths).toEqual([]);
+    expect(onSettled).toHaveBeenCalledTimes(1);
+
+    watcherCallback?.("change", "published.md");
+    await Bun.sleep(350);
+    expect(seenPaths).toEqual([["published.md"]]);
+    await service.dispose();
+  });
+
+  test("suppresses completion side effects when live rules exclude an in-flight path", async () => {
+    let watcherCallback:
+      | ((eventType: string, filename: string) => void)
+      | undefined;
+    const emit = mock((_event: unknown) => undefined);
+    const notifySyncComplete = mock(() => undefined);
+    const syncCollection = mock(async () =>
+      createSyncResult({ filesMarkedInactive: 1 })
+    );
+    let finishSync: (() => void) | undefined;
+    const syncGate = new Promise<void>((resolve) => {
+      finishSync = resolve;
+    });
+
+    defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
+      await syncGate;
+      return createSyncResult({
+        filesProcessed: relPaths.length,
+        filesUpdated: relPaths.length,
+      });
+    }) as typeof defaultSyncService.syncPaths;
+    defaultSyncService.syncCollection =
+      syncCollection as typeof defaultSyncService.syncCollection;
+
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/notes")],
+      eventBus: { emit } as never,
+      scheduler: { notifySyncComplete } as never,
+      store: {} as never,
+      watchFactory: ((
+        _path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watcherCallback = callback as typeof watcherCallback;
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    watcherCallback?.("change", "private/note.md");
+    await Bun.sleep(350);
+
+    const updatedCollection = createCollection("notes", "/tmp/notes");
+    updatedCollection.exclude = ["private"];
+    service.updateCollections([updatedCollection]);
+    finishSync?.();
+    await Bun.sleep(20);
+
+    expect(syncCollection).toHaveBeenCalledTimes(1);
+    expect(notifySyncComplete).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+    await service.dispose();
+  });
+
+  test("does not reconcile an in-flight sync for an equivalent config refresh", async () => {
+    let watcherCallback:
+      | ((eventType: string, filename: string) => void)
+      | undefined;
+    const emit = mock((_event: unknown) => undefined);
+    const syncCollection = mock(async () => createSyncResult());
+    let finishSync: (() => void) | undefined;
+    const syncGate = new Promise<void>((resolve) => {
+      finishSync = resolve;
+    });
+
+    defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
+      await syncGate;
+      return createSyncResult({
+        filesProcessed: relPaths.length,
+        filesUpdated: relPaths.length,
+      });
+    }) as typeof defaultSyncService.syncPaths;
+    defaultSyncService.syncCollection =
+      syncCollection as typeof defaultSyncService.syncCollection;
+
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/notes")],
+      eventBus: { emit } as never,
+      scheduler: null,
+      store: {} as never,
+      watchFactory: ((
+        _path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watcherCallback = callback as typeof watcherCallback;
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    watcherCallback?.("change", "note.md");
+    await Bun.sleep(350);
+
+    service.updateCollections([createCollection("notes", "/tmp/notes")]);
+    finishSync?.();
+    await Bun.sleep(20);
+
+    expect(syncCollection).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledTimes(1);
+    await service.dispose();
+  });
+
+  test("does not reconcile or emit after disposal during an in-flight sync", async () => {
+    let watcherCallback:
+      | ((eventType: string, filename: string) => void)
+      | undefined;
+    const emit = mock((_event: unknown) => undefined);
+    const notifySyncComplete = mock(() => undefined);
+    const onSyncComplete = mock(() => undefined);
+    const syncCollection = mock(async () => createSyncResult());
+    let finishSync: (() => void) | undefined;
+    const syncGate = new Promise<void>((resolve) => {
+      finishSync = resolve;
+    });
+
+    defaultSyncService.syncPaths = (async () => {
+      await syncGate;
+      return createSyncResult({ filesUpdated: 1 });
+    }) as typeof defaultSyncService.syncPaths;
+    defaultSyncService.syncCollection =
+      syncCollection as typeof defaultSyncService.syncCollection;
+
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/notes")],
+      eventBus: { emit } as never,
+      scheduler: { notifySyncComplete } as never,
+      store: {} as never,
+      callbacks: { onSyncComplete },
+      watchFactory: ((
+        _path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watcherCallback = callback as typeof watcherCallback;
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    watcherCallback?.("change", "note.md");
+    await Bun.sleep(350);
+
+    const disposal = service.dispose();
+    finishSync?.();
+    await disposal;
+
+    expect(syncCollection).not.toHaveBeenCalled();
+    expect(onSyncComplete).not.toHaveBeenCalled();
+    expect(notifySyncComplete).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  test("restarts a watcher when a collection root changes", async () => {
+    const watchedPaths: string[] = [];
+    const closedPaths: string[] = [];
+    const callbacks = new Map<
+      string,
+      (eventType: string, filename: string) => void
+    >();
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/old-notes")],
+      eventBus: null,
+      scheduler: null,
+      store: {} as never,
+      watchFactory: ((
+        path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watchedPaths.push(path);
+        callbacks.set(
+          path,
+          callback as (eventType: string, filename: string) => void
+        );
+        return {
+          close: () => {
+            closedPaths.push(path);
+          },
+        };
+      }) as never,
+    });
+
+    service.start();
+    service.updateCollections([
+      createCollection("notes", "/tmp/replacement-notes"),
+    ]);
+
+    expect(watchedPaths).toEqual(["/tmp/old-notes", "/tmp/replacement-notes"]);
+    expect(closedPaths).toEqual(["/tmp/old-notes"]);
+    expect(service.getState().activeCollections).toEqual(["notes"]);
+    expect(callbacks.size).toBe(2);
+    await service.dispose();
+  });
+
+  test("serializes remove and re-add behind an in-flight sync without an ABA collision", async () => {
+    const callbacks = new Map<
+      string,
+      (eventType: string, filename: string) => void
+    >();
+    const seenPaths: string[][] = [];
+    const emit = mock((_event: unknown) => undefined);
+    const notifySyncComplete = mock(() => undefined);
+    const syncCollection = mock(async () =>
+      createSyncResult({
+        filesProcessed: 1,
+        filesAdded: 1,
+        files: [{ relPath: "new.md", status: "added" }],
+      })
+    );
+    let finishFirstSync: (() => void) | undefined;
+    const firstSync = new Promise<void>((resolve) => {
+      finishFirstSync = resolve;
+    });
+
+    defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
+      seenPaths.push(relPaths);
+      if (seenPaths.length === 1) {
+        await firstSync;
+      }
+      const status = seenPaths.length === 1 ? "updated" : "unchanged";
+      return createSyncResult({
+        filesProcessed: relPaths.length,
+        filesUpdated: status === "updated" ? relPaths.length : 0,
+        filesUnchanged: status === "unchanged" ? relPaths.length : 0,
+        files: relPaths.map((relPath) => ({ relPath, status })),
+      });
+    }) as typeof defaultSyncService.syncPaths;
+    defaultSyncService.syncCollection =
+      syncCollection as typeof defaultSyncService.syncCollection;
+
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/old-notes")],
+      eventBus: { emit } as never,
+      scheduler: { notifySyncComplete } as never,
+      store: {} as never,
+      watchFactory: ((
+        path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        callbacks.set(
+          path,
+          callback as (eventType: string, filename: string) => void
+        );
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    callbacks.get("/tmp/old-notes")?.("change", "old.md");
+    await Bun.sleep(350);
+    expect(seenPaths).toEqual([["old.md"]]);
+
+    service.updateCollections([]);
+    service.updateCollections([
+      createCollection("notes", "/tmp/replacement-notes"),
+    ]);
+    callbacks.get("/tmp/replacement-notes")?.("change", "new.md");
+    await Bun.sleep(350);
+    expect(seenPaths).toEqual([["old.md"]]);
+
+    finishFirstSync?.();
+    await Bun.sleep(20);
+    expect(syncCollection).toHaveBeenCalledTimes(1);
+    expect(seenPaths).toEqual([["old.md"], ["new.md"]]);
+    expect(notifySyncComplete).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0]?.[0]).toMatchObject({
+      collection: "notes",
+      relPath: "new.md",
+      uri: "gno://notes/new.md",
+    });
+    await service.dispose();
+  });
+
+  test("reprocesses an edit queued after full reconciliation scanned its path", async () => {
+    const callbacks = new Map<
+      string,
+      (eventType: string, filename: string) => void
+    >();
+    const seenPaths: string[][] = [];
+    let finishFirstSync: (() => void) | undefined;
+    let finishFullSync: (() => void) | undefined;
+    let markFullSyncStarted: (() => void) | undefined;
+    const firstSync = new Promise<void>((resolve) => {
+      finishFirstSync = resolve;
+    });
+    const fullSyncGate = new Promise<void>((resolve) => {
+      finishFullSync = resolve;
+    });
+    const fullSyncStarted = new Promise<void>((resolve) => {
+      markFullSyncStarted = resolve;
+    });
+
+    defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
+      seenPaths.push(relPaths);
+      if (seenPaths.length === 1) {
+        await firstSync;
+      }
+      return createSyncResult({
+        filesProcessed: relPaths.length,
+        filesUpdated: relPaths.length,
+        files: relPaths.map((relPath) => ({
+          relPath,
+          status: "updated",
+        })),
+      });
+    }) as typeof defaultSyncService.syncPaths;
+    defaultSyncService.syncCollection = (async () => {
+      markFullSyncStarted?.();
+      await fullSyncGate;
+      return createSyncResult({
+        filesProcessed: 1,
+        filesAdded: 1,
+        files: [{ relPath: "new.md", status: "added" }],
+      });
+    }) as typeof defaultSyncService.syncCollection;
+
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/old-notes")],
+      eventBus: null,
+      scheduler: null,
+      store: {} as never,
+      watchFactory: ((
+        path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        callbacks.set(
+          path,
+          callback as (eventType: string, filename: string) => void
+        );
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    callbacks.get("/tmp/old-notes")?.("change", "old.md");
+    await Bun.sleep(350);
+    service.updateCollections([
+      createCollection("notes", "/tmp/replacement-notes"),
+    ]);
+
+    finishFirstSync?.();
+    await fullSyncStarted;
+    callbacks.get("/tmp/replacement-notes")?.("change", "new.md");
+    await Bun.sleep(350);
+    finishFullSync?.();
+    await Bun.sleep(20);
+
+    expect(seenPaths).toEqual([["old.md"], ["new.md"]]);
+    await service.dispose();
+  });
+
+  test("forwards eligible deletion paths for inactive sync and one notification", async () => {
+    let watcherCallback:
+      | ((eventType: string, filename: string) => void)
+      | undefined;
+    const seenPaths: string[][] = [];
+    const emit = mock((_event: unknown) => undefined);
+    const notifySyncComplete = mock(() => undefined);
+
+    defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
+      seenPaths.push(relPaths);
+      return createSyncResult({
+        filesProcessed: 1,
+        filesUpdated: 1,
+        filesMarkedInactive: 1,
+      });
+    }) as typeof defaultSyncService.syncPaths;
+
+    const service = new CollectionWatchService({
+      collections: [createCollection("notes", "/tmp/notes")],
+      eventBus: { emit } as never,
+      scheduler: { notifySyncComplete } as never,
+      store: {} as never,
+      watchFactory: ((
+        _path: string,
+        _options: { recursive: boolean },
+        callback: WatchListener<string>
+      ) => {
+        watcherCallback = callback as typeof watcherCallback;
+        return { close: () => undefined };
+      }) as never,
+    });
+
+    service.start();
+    watcherCallback?.("rename", "deleted.md");
+    await Bun.sleep(350);
+
+    expect(seenPaths).toEqual([["deleted.md"]]);
+    expect(notifySyncComplete).toHaveBeenCalledTimes(1);
+    expect(notifySyncComplete).toHaveBeenCalledWith(["deleted.md"]);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit.mock.calls[0]?.[0]).toMatchObject({
+      relPath: "deleted.md",
+      uri: "gno://notes/deleted.md",
+    });
+    await service.dispose();
+  });
+
   test("supports headless mode without event bus and emits sync callbacks", async () => {
     let watcherCallback:
       | ((eventType: string, filename: string) => void)
@@ -129,7 +643,7 @@ describe("CollectionWatchService", () => {
 
     expect(onSyncStart).toHaveBeenCalledTimes(1);
     expect(onSyncComplete).toHaveBeenCalledTimes(1);
-    service.dispose();
+    await service.dispose();
   });
 
   test("updateCollections refreshes sync options for later watcher syncs", async () => {
@@ -188,6 +702,6 @@ describe("CollectionWatchService", () => {
 
     expect(seenFingerprints).toEqual(["after"]);
     expect(seenPaths).toEqual([["doc.md"]]);
-    service.dispose();
+    await service.dispose();
   });
 });


### PR DESCRIPTION
## Summary

- apply the same collection pattern, include, exclude, and adapter-extension eligibility rules to resident filesystem watcher events as full walks
- re-evaluate queued and in-flight paths against live collection configuration, restart watchers when roots change, and reconcile safely across config races
- drain in-flight watcher work during shutdown and suppress unchanged duplicate notifications
- add regression coverage for excluded paths, deletions, config changes, root replacement, remove/re-add ABA races, post-scan edits, and disposal

Fixes #158.

Thanks @DanielKillenberger for the precise report and reproduction.

## Verification

- `bun run lint:check`
- `bun run docs:verify`
- `bun test` — 3,466 passed, 2 skipped
- `bun run test:package`
- independent final review: clean