### PR TITLE
fix: allow bounded resident shutdown in package smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+- Gave packed resident shutdown the same lifecycle headroom as the product's
+  admission-drain and model-disposal path, preventing Linux release smoke from
+  killing a healthy model-backed server at the old 10-second boundary.
+
 ## [1.30.3] - 2026-08-02
 
 ### Changed

--- a/scripts/package-smoke-resident-support.ts
+++ b/scripts/package-smoke-resident-support.ts
@@ -67,6 +67,10 @@ export const JSON_HEADERS = {
   "content-type": "application/json",
 };
 const START_TIMEOUT_MS = 60_000;
+// Resident disposal can spend up to two 5s admission-drain windows before
+// releasing model resources. Linux CI needs headroom beyond that product
+// deadline, especially after a model-backed smoke run.
+const STOP_TIMEOUT_MS = 30_000;
 
 export function isExpectedResidentShutdownExit(
   platform: NodeJS.Platform,
@@ -173,16 +177,17 @@ export async function waitForStatus(
 
 export async function stopResident(
   residentProcess: RunningProcess,
-  label: string
+  label: string,
+  timeoutMs = STOP_TIMEOUT_MS
 ): Promise<void> {
   if (residentProcess.child.exitCode === null) {
     residentProcess.child.kill("SIGTERM");
   }
   const exitCode = await Promise.race([
     residentProcess.child.exited,
-    Bun.sleep(10_000).then(() => {
+    Bun.sleep(timeoutMs).then(() => {
       residentProcess.child.kill("SIGKILL");
-      throw new Error(`${label} did not exit within 10 seconds`);
+      throw new Error(`${label} did not exit within ${timeoutMs}ms`);
     }),
   ]);
   const [stdout, stderr] = await Promise.all([

--- a/scripts/package-smoke-resident-support.ts
+++ b/scripts/package-smoke-resident-support.ts
@@ -70,7 +70,7 @@ const START_TIMEOUT_MS = 60_000;
 // Resident disposal can spend up to two 5s admission-drain windows before
 // releasing model resources. Linux CI needs headroom beyond that product
 // deadline, especially after a model-backed smoke run.
-const STOP_TIMEOUT_MS = 30_000;
+export const STOP_TIMEOUT_MS = 30_000;
 
 export function isExpectedResidentShutdownExit(
   platform: NodeJS.Platform,

--- a/test/scripts/package-smoke-resident-support.test.ts
+++ b/test/scripts/package-smoke-resident-support.test.ts
@@ -67,13 +67,23 @@ describe("packed resident shutdown exits", () => {
   });
 
   test("allows graceful shutdown beyond the old proportional deadline", async () => {
+    let markReady: (() => void) | undefined;
+    const ready = new Promise<void>((resolve) => {
+      markReady = resolve;
+    });
     const child = Bun.spawn(
       [
         process.execPath,
         "-e",
-        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 75)); setInterval(() => {}, 1000)",
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 75)); process.send?.('ready'); setInterval(() => {}, 1000)",
       ],
-      { stdout: "pipe", stderr: "pipe" }
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        ipc(message) {
+          if (message === "ready") markReady?.();
+        },
+      }
     );
     const running = {
       child,
@@ -81,7 +91,7 @@ describe("packed resident shutdown exits", () => {
       stderr: new Response(child.stderr).text(),
     };
 
-    await Bun.sleep(25);
+    await ready;
     await stopResident(running, "delayed resident", 500);
     expect(child.exitCode).toBe(0);
   });

--- a/test/scripts/package-smoke-resident-support.test.ts
+++ b/test/scripts/package-smoke-resident-support.test.ts
@@ -4,6 +4,7 @@ import {
   isExpectedResidentShutdownExit,
   isValidPackedWarmModelReuse,
   type ResidentStatus,
+  stopResident,
   waitForStatus,
 } from "../../scripts/package-smoke-resident-support";
 
@@ -63,6 +64,26 @@ describe("packed resident shutdown exits", () => {
     expect((startupError as Error).message).toContain("resident stdout");
     expect((startupError as Error).message).toContain("resident stderr");
     expect(performance.now() - startedAt).toBeLessThan(5000);
+  });
+
+  test("allows graceful shutdown beyond the old proportional deadline", async () => {
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "-e",
+        "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 75)); setInterval(() => {}, 1000)",
+      ],
+      { stdout: "pipe", stderr: "pipe" }
+    );
+    const running = {
+      child,
+      stdout: new Response(child.stdout).text(),
+      stderr: new Response(child.stderr).text(),
+    };
+
+    await Bun.sleep(25);
+    await stopResident(running, "delayed resident", 500);
+    expect(child.exitCode).toBe(0);
   });
 });
 

--- a/test/scripts/package-smoke-resident-support.test.ts
+++ b/test/scripts/package-smoke-resident-support.test.ts
@@ -4,6 +4,7 @@ import {
   isExpectedResidentShutdownExit,
   isValidPackedWarmModelReuse,
   type ResidentStatus,
+  STOP_TIMEOUT_MS,
   stopResident,
   waitForStatus,
 } from "../../scripts/package-smoke-resident-support";
@@ -66,7 +67,12 @@ describe("packed resident shutdown exits", () => {
     expect(performance.now() - startedAt).toBeLessThan(5000);
   });
 
-  test("allows graceful shutdown beyond the old proportional deadline", async () => {
+  test("keeps shutdown headroom beyond both admission-drain windows", () => {
+    expect(STOP_TIMEOUT_MS).toBe(30_000);
+    expect(STOP_TIMEOUT_MS).toBeGreaterThan(10_000);
+  });
+
+  test("allows graceful shutdown before a supplied deadline", async () => {
     let markReady: (() => void) | undefined;
     const ready = new Promise<void>((resolve) => {
       markReady = resolve;


### PR DESCRIPTION
## Summary

- align the packed-resident smoke timeout with the product's bounded shutdown lifecycle
- allow 30 seconds for two admission-drain windows plus model disposal while retaining SIGKILL and a hard failure
- add regression coverage for a resident that exits gracefully after the former proportional boundary

## Root cause

The v1.30.3 publish run reached a healthy model-backed packed server, verified PDF.js assets, then killed the Linux process after 10 seconds during shutdown. Product disposal can legitimately spend up to two 5-second admission-drain windows before releasing model resources, so the smoke harness had no scheduling/model-disposal headroom.

## Verification

- `bun test test/scripts/package-smoke-resident-support.test.ts`: 12 passed
- `bun run prerelease`: lint/typecheck/format clean; 3,609 passed, 2 expected skips; docs 15 passed; clipper reproducibility passed; packed-install smoke and real-data sentinel passed

Follow-up release: v1.30.4 after merge. The v1.30.3 tag exists, but its publish/release jobs were skipped after pack-test failed.
