### PR TITLE
Document structure navigation and section addressability

### DIFF
--- a/.claude/skills/gno/SKILL.md
+++ b/.claude/skills/gno/SKILL.md
@@ -329,6 +329,7 @@ When using GNO through MCP, prefer this retrieval order:
 5. Use graph/link expansion for relationship context: `gno_graph_query` for typed relationship traversal, `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors. Prefer explicit or typed edges over inferred, ambiguous, or similarity edges when confidence matters.
 6. Use `gno_query_diagnose` when a known target document should have appeared but did not; it reports BM25/vector/fusion/graph/rerank stage presence and filter state.
 7. Use `gno_get` with `fromLine`/`lineCount` for targeted reads, or `gno_multi_get` to batch top refs.
+8. Use `gno_section` only when you need a durable section locator or must re-resolve one after edits. Prefer search → `gno_get` for ordinary retrieval. `action=create` needs `ref` plus exactly one of `anchor`|`line`; `action=resolve` needs `ref` plus `target`. Cite or open content only for `exact`/`recovered` results, then follow the tool's ready-to-use `gno_get` guidance (`fromLine = lineStart`; `lineCount = lineEnd - lineStart + 1`). Never navigate or cite `ambiguous`/`stale`/`missing`.
 
 For a caller-owned canonical Capsule that should stay fresh locally:
 
@@ -370,6 +371,7 @@ Use narrower tools when the request tells you to:
 - `gno_graph_neighbors`: relationship/corpus-navigation questions around a known document
 - `gno_graph_path`: "how are X and Y connected?" questions
 - `gno_query_diagnose`: why a named target did or did not surface for a query
+- `gno_section`: create/resolve a durable section target when citation identity matters after edits; follow navigable citations with `gno_get`. Not the default retrieval path.
 
 For ambiguous terms, pass `intent` instead of bloating the query text. For typed retrieval, use `queryModes`: `term` for lexical anchors, `intent` for disambiguation, one `hyde` for a hypothetical answer/document.
 

--- a/.claude/skills/gno/mcp-reference.md
+++ b/.claude/skills/gno/mcp-reference.md
@@ -107,6 +107,12 @@ Check `gno_status` first when freshness or
 embeddings may be stale. Use `gno_query_diagnose` when a known target document
 should have appeared but did not.
 
+Use `gno_section` only when durable section identity matters (create/resolve a
+`SectionTargetV1`). Prefer ordinary `gno_query` → `gno_get` retrieval first.
+Exact/recovered results include citation lines and ready-to-use `gno_get`
+guidance (`fromLine = lineStart`; `lineCount = lineEnd - lineStart + 1`). Never
+cite or navigate ambiguous/stale/missing results.
+
 Use graph tools for relationship context: `gno_graph` for corpus report/stats,
 community summaries,
 `gno_graph_query` for bounded typed-edge traversal,

--- a/.codex/skills/gno/SKILL.md
+++ b/.codex/skills/gno/SKILL.md
@@ -329,6 +329,7 @@ When using GNO through MCP, prefer this retrieval order:
 5. Use graph/link expansion for relationship context: `gno_graph_query` for typed relationship traversal, `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors. Prefer explicit or typed edges over inferred, ambiguous, or similarity edges when confidence matters.
 6. Use `gno_query_diagnose` when a known target document should have appeared but did not; it reports BM25/vector/fusion/graph/rerank stage presence and filter state.
 7. Use `gno_get` with `fromLine`/`lineCount` for targeted reads, or `gno_multi_get` to batch top refs.
+8. Use `gno_section` only when you need a durable section locator or must re-resolve one after edits. Prefer search → `gno_get` for ordinary retrieval. `action=create` needs `ref` plus exactly one of `anchor`|`line`; `action=resolve` needs `ref` plus `target`. Cite or open content only for `exact`/`recovered` results, then follow the tool's ready-to-use `gno_get` guidance (`fromLine = lineStart`; `lineCount = lineEnd - lineStart + 1`). Never navigate or cite `ambiguous`/`stale`/`missing`.
 
 For a caller-owned canonical Capsule that should stay fresh locally:
 
@@ -370,6 +371,7 @@ Use narrower tools when the request tells you to:
 - `gno_graph_neighbors`: relationship/corpus-navigation questions around a known document
 - `gno_graph_path`: "how are X and Y connected?" questions
 - `gno_query_diagnose`: why a named target did or did not surface for a query
+- `gno_section`: create/resolve a durable section target when citation identity matters after edits; follow navigable citations with `gno_get`. Not the default retrieval path.
 
 For ambiguous terms, pass `intent` instead of bloating the query text. For typed retrieval, use `queryModes`: `term` for lexical anchors, `intent` for disambiguation, one `hyde` for a hypothetical answer/document.
 

--- a/.codex/skills/gno/mcp-reference.md
+++ b/.codex/skills/gno/mcp-reference.md
@@ -107,6 +107,12 @@ Check `gno_status` first when freshness or
 embeddings may be stale. Use `gno_query_diagnose` when a known target document
 should have appeared but did not.
 
+Use `gno_section` only when durable section identity matters (create/resolve a
+`SectionTargetV1`). Prefer ordinary `gno_query` → `gno_get` retrieval first.
+Exact/recovered results include citation lines and ready-to-use `gno_get`
+guidance (`fromLine = lineStart`; `lineCount = lineEnd - lineStart + 1`). Never
+cite or navigate ambiguous/stale/missing results.
+
 Use graph tools for relationship context: `gno_graph` for corpus report/stats,
 community summaries,
 `gno_graph_query` for bounded typed-edge traversal,

--- a/.flow/memory/bug/ui/mobile-user-sees-clipped-docview-960px-2026-08-03.md
+++ b/.flow/memory/bug/ui/mobile-user-sees-clipped-docview-960px-2026-08-03.md
@@ -1,0 +1,49 @@
+---
+title: Mobile user sees clipped DocView — 960px canvas overflows 375px viewport
+date: "2026-08-03"
+track: bug
+category: ui
+module: src/serve/public/pages/DocView.tsx
+tags: [qa, fn-61-document-structure-navigation-and-section-addressability, web-ui, mobile]
+problem_type: ui
+symptoms: "DocView reports 960px scroll width at a 375px viewport, clipping header actions and forcing 585px horizontal overflow."
+root_cause: (observed via live QA — unconfirmed)
+resolution_type: fix
+---
+
+## Problem
+
+A mobile-width user opening DocView sees a desktop-width canvas clipped behind horizontal scrolling; header actions extend off-screen.
+
+## Steps to reproduce (cold)
+
+1. Start `gno serve` with an indexed Markdown document and open `/doc?uri=<document>&view=rendered`.
+2. Set the browser viewport to 375 x 812.
+3. Wait for the document to render.
+4. Observe the horizontal scrollbar and measure `document.documentElement.scrollWidth`.
+5. Reload and repeat.
+
+## Expected
+
+The document view should remain usable at the QA mobile viewport without a desktop-width canvas forcing horizontal scrolling.
+
+## Actual
+
+Both runs reported `innerWidth: 375`, `scrollWidth: 960`, and `overflow: 585`; header actions are clipped. Document content and QuickSwitcher section navigation remain usable.
+
+## Evidence
+
+- console: `.flow/tmp/qa-fn-61-document-structure-navigation-and-section-addressability/S7-mobile-console.log`
+- screenshot: `.flow/tmp/qa-fn-61-document-structure-navigation-and-section-addressability/S7-mobile.png`
+- follow-up screenshot: `.flow/tmp/qa-fn-61-document-structure-navigation-and-section-addressability/S8-mobile-switcher.png`
+- URL: `http://127.0.0.1:3331/doc?uri=gno%3A%2F%2Ffn61qa%2Fguide.md&view=rendered`
+- repeated measurement: `innerWidth=375`, `scrollWidth=960`, `overflow=585`
+
+## Traceability
+
+- R-IDs: [R3, R6]
+- scenario: S14
+- driver_rung: agent-browser
+- viewport: 375x812
+- classification: pre_existing
+- severity: P2

--- a/.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json
+++ b/.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json
@@ -1,0 +1,64 @@
+{
+  "branch": "fn-61-document-structure-navigation-and-section-addressability",
+  "findings": {
+    "backend": "interactive",
+    "headSha": "2ffa6971d396ed447c1ea6f1d1793ac07e33696d",
+    "items": [
+      {
+        "body": "At the 375px QA viewport, DocView retains a 960px canvas and forces 585px horizontal overflow; document content and QuickSwitcher remain usable. (surface: src/serve/public/pages/DocView.tsx)",
+        "classification": "pre_existing",
+        "confidence": 100,
+        "firstSeenReceiptId": "review-6f104c464183b71b361c00284a9699c82a923fe08f1ce39a97df99f3b4bfdff8",
+        "id": "finding-b5b88188cc3bb7fffe8d76be85c8a85a",
+        "lastSeenReceiptId": "review-6f104c464183b71b361c00284a9699c82a923fe08f1ce39a97df99f3b4bfdff8",
+        "ordinal": 1,
+        "rIds": [],
+        "severity": "P2",
+        "status": "open",
+        "title": "S14-mobile-docview-overflow"
+      }
+    ],
+    "reviewKind": "qa",
+    "round": 1,
+    "schemaVersion": 1,
+    "sourceReceiptId": "review-6f104c464183b71b361c00284a9699c82a923fe08f1ce39a97df99f3b4bfdff8"
+  },
+  "head_sha": "2ffa6971d396ed447c1ea6f1d1793ac07e33696d",
+  "id": "fn-61-document-structure-navigation-and-section-addressability",
+  "mode": "interactive",
+  "open_p0p1": [],
+  "qa_outcome": "SHIP",
+  "rid_coverage": {
+    "covered": 6,
+    "rids": [
+      {
+        "coverage": "subtracted",
+        "id": "R1"
+      },
+      {
+        "coverage": "live",
+        "id": "R2"
+      },
+      {
+        "coverage": "live",
+        "id": "R3"
+      },
+      {
+        "coverage": "live",
+        "id": "R4"
+      },
+      {
+        "coverage": "live",
+        "id": "R5"
+      },
+      {
+        "coverage": "live",
+        "id": "R6"
+      }
+    ],
+    "total": 6
+  },
+  "timestamp": "2026-08-03T00:50:00Z",
+  "type": "qa_verdict",
+  "verdict": "SHIP"
+}

--- a/.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json
+++ b/.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json
@@ -2,7 +2,7 @@
   "branch": "fn-61-document-structure-navigation-and-section-addressability",
   "findings": {
     "backend": "interactive",
-    "headSha": "d8502ef7c1f080bfe555753cdf2fee76b6e38f5d",
+    "headSha": "3888a3dbdba544f2b226e7294e4992fdd358a27b",
     "items": [
       {
         "body": "At the 375px QA viewport, DocView retains a 960px canvas and forces 585px horizontal overflow; document content and QuickSwitcher remain usable. (surface: src/serve/public/pages/DocView.tsx)",
@@ -23,7 +23,7 @@
     "schemaVersion": 1,
     "sourceReceiptId": "review-6f104c464183b71b361c00284a9699c82a923fe08f1ce39a97df99f3b4bfdff8"
   },
-  "head_sha": "d8502ef7c1f080bfe555753cdf2fee76b6e38f5d",
+  "head_sha": "3888a3dbdba544f2b226e7294e4992fdd358a27b",
   "id": "fn-61-document-structure-navigation-and-section-addressability",
   "mode": "interactive",
   "open_p0p1": [],
@@ -58,7 +58,7 @@
     ],
     "total": 6
   },
-  "timestamp": "2026-08-03T00:50:00Z",
+  "timestamp": "2026-08-03T01:12:29Z",
   "type": "qa_verdict",
   "verdict": "SHIP"
 }

--- a/.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json
+++ b/.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json
@@ -2,7 +2,7 @@
   "branch": "fn-61-document-structure-navigation-and-section-addressability",
   "findings": {
     "backend": "interactive",
-    "headSha": "2ffa6971d396ed447c1ea6f1d1793ac07e33696d",
+    "headSha": "d8502ef7c1f080bfe555753cdf2fee76b6e38f5d",
     "items": [
       {
         "body": "At the 375px QA viewport, DocView retains a 960px canvas and forces 585px horizontal overflow; document content and QuickSwitcher remain usable. (surface: src/serve/public/pages/DocView.tsx)",
@@ -23,7 +23,7 @@
     "schemaVersion": 1,
     "sourceReceiptId": "review-6f104c464183b71b361c00284a9699c82a923fe08f1ce39a97df99f3b4bfdff8"
   },
-  "head_sha": "2ffa6971d396ed447c1ea6f1d1793ac07e33696d",
+  "head_sha": "d8502ef7c1f080bfe555753cdf2fee76b6e38f5d",
   "id": "fn-61-document-structure-navigation-and-section-addressability",
   "mode": "interactive",
   "open_p0p1": [],

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.json
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.json
@@ -8,7 +8,7 @@
   "priority": 1,
   "spec": "fn-61-document-structure-navigation-and-section-addressability",
   "spec_path": ".flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.md",
-  "status": "todo",
+  "status": "done",
   "title": "Add durable section target and conservative resolver",
-  "updated_at": "2026-08-02T20:48:07.834241Z"
+  "updated_at": "2026-08-02T23:07:56.805448Z"
 }

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.md
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.md
@@ -39,9 +39,8 @@ No persistent section table in v1. A fingerprint mismatch can still recover uniq
 
 
 ## Done summary
-TBD
-
+Added a bounded browser-safe SectionTargetV1, a deterministic fail-closed resolver, and schema-backed regressions for exact recovery, edits, ambiguity, stale/missing states, fences, Unicode, and hostile oversized identity fields.
 ## Evidence
 - Commits:
-- Tests:
+- Tests: bun test test/core/sections.test.ts test/spec/schemas/section-target.test.ts test/serve/public/lib/deep-links.test.ts (20 pass, 0 fail), bun test (3634 pass, 2 platform skips, 0 fail), bun run lint:check (clean)
 - PRs:

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.json
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.json
@@ -10,7 +10,7 @@
   "priority": 2,
   "spec": "fn-61-document-structure-navigation-and-section-addressability",
   "spec_path": ".flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.md",
-  "status": "todo",
+  "status": "done",
   "title": "Expose section target creation and resolution through REST and SDK",
-  "updated_at": "2026-08-02T20:57:43.369097Z"
+  "updated_at": "2026-08-02T23:33:28.572206Z"
 }

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.md
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.md
@@ -36,9 +36,8 @@ Existing `/api/doc/:id/sections` and SDK `getSections()` stay backward compatibl
 - [ ] Shared fixtures prove schema and semantic parity across REST/SDK.
 - [ ] Focused API/SDK tests, specs/docs, and lint pass.
 ## Done summary
-TBD
-
+Exposed bounded SectionTargetV1 creation and conservative resolution through versioned REST and SDK contracts while preserving the existing sections endpoint and getSections API. Added shared canonical citation projection, closed untrusted-input validation, fail-closed transport bounds, schemas, docs, and cross-surface parity regressions.
 ## Evidence
 - Commits:
-- Tests:
+- Tests: bun test focused section REST/SDK/core/schema matrix (47 pass, 0 fail), bun run lint:check (clean), bun scripts/docs-verify.ts (15 pass, 2 model-cache skips, 0 fail), bun test (3664 pass, 2 platform skips, 0 fail)
 - PRs:

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.json
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.json
@@ -1,7 +1,7 @@
 {
-  "assignee": null,
+  "assignee": "gordon.mickel@gmail.com",
   "claim_note": "",
-  "claimed_at": null,
+  "claimed_at": "2026-08-03T00:01:13.967149Z",
   "created_at": "2026-08-02T20:47:55.321344Z",
   "depends_on": [
     "fn-61-document-structure-navigation-and-section-addressability.6",
@@ -11,7 +11,7 @@
   "priority": 3,
   "spec": "fn-61-document-structure-navigation-and-section-addressability",
   "spec_path": ".flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.md",
-  "status": "todo",
+  "status": "done",
   "title": "Integrate citation-safe links and verify compatibility end to end",
-  "updated_at": "2026-08-02T20:57:43.856426Z"
+  "updated_at": "2026-08-03T00:57:17.808096Z"
 }

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.md
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.md
@@ -43,9 +43,8 @@ Do not leak full private section content in copied URLs, logs, or telemetry. Pro
 
 
 ## Done summary
-TBD
-
+Integrated citation-safe section links across the Web UI, REST API, SDK, and MCP. Added readable human links alongside bounded versioned durable targets, fail-closed exact/recovered/ambiguous/stale behavior, updated the installed skill guidance and hosted gno.sh reference documentation, and verified both product and documentation surfaces live.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 2ffa6971d396ed447c1ea6f1d1793ac07e33696d, b405e92e5b93376c9f25f19049ed25d3c5282efe
+- Tests: bun test: 3698 pass, 2 expected skips, 0 fail, bun run lint:check: 0 warnings, 0 errors, bun scripts/docs-verify.ts: 15 pass, 2 model-cache skips, gno skill autoresearch eval: 47/47, 100%, flow-next QA: SHIP, 6/6 R-IDs covered, no P0/P1, gno.sh bun run check: pass, gno.sh bun run typecheck: pass, gno.sh bun run build: pass, 92 pages prerendered, local live QA: Web UI, REST, Streamable HTTP MCP, and gno.sh docs verified
 - PRs:

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.json
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.json
@@ -10,7 +10,7 @@
   "priority": 2,
   "spec": "fn-61-document-structure-navigation-and-section-addressability",
   "spec_path": ".flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.md",
-  "status": "todo",
+  "status": "done",
   "title": "Add read-only MCP section resolution and citation evidence",
-  "updated_at": "2026-08-02T20:57:43.619475Z"
+  "updated_at": "2026-08-03T00:00:39.795900Z"
 }

--- a/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.md
+++ b/.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.md
@@ -39,9 +39,8 @@ No MCP write, target persistence, or parser fork. An ambiguous/stale target cann
 
 
 ## Done summary
-TBD
-
+Added the read-only gno_section MCP tool for durable section-target creation and conservative resolution, with closed schemas, stdio/HTTP parity, fail-closed citation behavior, documentation, and explicit egress classification.
 ## Evidence
 - Commits:
-- Tests:
+- Tests: bun test test/egress/enforcement.test.ts test/mcp/tools/sections.test.ts test/mcp/http-parity.test.ts (32 pass), bun run lint:check (clean), bun scripts/docs-verify.ts (15 pass, 2 model-cache skips), bun test (3682 pass, 2 platform/opt-in skips, 0 fail)
 - PRs:

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ Full-featured markdown editor with:
 
 ![GNO Document Viewer](./assets/screenshots/webui-doc-view.jpg)
 
-View documents with full context: outgoing links, backlinks, section outline, and AI-powered related notes sidebar.
+View documents with full context: outgoing links, backlinks, section outline, and AI-powered related notes sidebar. Outline copy-link stays human-readable (`#anchor`); an optional citation link adds a bounded durable selector for conservative recovery after edits.
 
 ### Browse Workspace
 

--- a/assets/skill/SKILL.md
+++ b/assets/skill/SKILL.md
@@ -329,6 +329,7 @@ When using GNO through MCP, prefer this retrieval order:
 5. Use graph/link expansion for relationship context: `gno_graph_query` for typed relationship traversal, `gno_graph_neighbors` for nearby documents, `gno_graph_path` for "how are X and Y connected?", `gno_links`/`gno_backlinks` for one-document link expansion, and `gno_similar` for semantic neighbors. Prefer explicit or typed edges over inferred, ambiguous, or similarity edges when confidence matters.
 6. Use `gno_query_diagnose` when a known target document should have appeared but did not; it reports BM25/vector/fusion/graph/rerank stage presence and filter state.
 7. Use `gno_get` with `fromLine`/`lineCount` for targeted reads, or `gno_multi_get` to batch top refs.
+8. Use `gno_section` only when you need a durable section locator or must re-resolve one after edits. Prefer search → `gno_get` for ordinary retrieval. `action=create` needs `ref` plus exactly one of `anchor`|`line`; `action=resolve` needs `ref` plus `target`. Cite or open content only for `exact`/`recovered` results, then follow the tool's ready-to-use `gno_get` guidance (`fromLine = lineStart`; `lineCount = lineEnd - lineStart + 1`). Never navigate or cite `ambiguous`/`stale`/`missing`.
 
 For a caller-owned canonical Capsule that should stay fresh locally:
 
@@ -370,6 +371,7 @@ Use narrower tools when the request tells you to:
 - `gno_graph_neighbors`: relationship/corpus-navigation questions around a known document
 - `gno_graph_path`: "how are X and Y connected?" questions
 - `gno_query_diagnose`: why a named target did or did not surface for a query
+- `gno_section`: create/resolve a durable section target when citation identity matters after edits; follow navigable citations with `gno_get`. Not the default retrieval path.
 
 For ambiguous terms, pass `intent` instead of bloating the query text. For typed retrieval, use `queryModes`: `term` for lexical anchors, `intent` for disambiguation, one `hyde` for a hypothetical answer/document.
 

--- a/assets/skill/mcp-reference.md
+++ b/assets/skill/mcp-reference.md
@@ -107,6 +107,12 @@ Check `gno_status` first when freshness or
 embeddings may be stale. Use `gno_query_diagnose` when a known target document
 should have appeared but did not.
 
+Use `gno_section` only when durable section identity matters (create/resolve a
+`SectionTargetV1`). Prefer ordinary `gno_query` → `gno_get` retrieval first.
+Exact/recovered results include citation lines and ready-to-use `gno_get`
+guidance (`fromLine = lineStart`; `lineCount = lineEnd - lineStart + 1`). Never
+cite or navigate ambiguous/stale/missing results.
+
 Use graph tools for relationship context: `gno_graph` for corpus report/stats,
 community summaries,
 `gno_graph_query` for bounded typed-edge traversal,

--- a/docs/API.md
+++ b/docs/API.md
@@ -48,38 +48,40 @@ CLI.
 
 ### Read Operations
 
-| Endpoint                 | Method | Description                                                 |
-| :----------------------- | :----- | :---------------------------------------------------------- |
-| `/api/health`            | GET    | Health check                                                |
-| `/api/status`            | GET    | Index statistics, onboarding, health, background, bootstrap |
-| `/api/resident/status`   | GET    | Redacted resident lifecycle and bounded counters            |
-| `/api/capabilities`      | GET    | Available features                                          |
-| `/api/collections`       | GET    | List collections                                            |
-| `/api/connectors`        | GET    | Detect in-app connector install state                       |
-| `/api/connectors/verify` | POST   | Explicit read-only connector retrieval proof                |
-| `/api/docs`              | GET    | List documents                                              |
-| `/api/docs/autocomplete` | GET    | Title/path suggestions for wiki-linking and quick switcher  |
-| `/api/note-presets`      | GET    | List note presets and scaffold previews                     |
-| `/api/doc`               | GET    | Get document content                                        |
-| `/api/doc-asset`         | GET    | Get the original source file bytes (Range-capable)          |
-| `/api/doc/:id/sections`  | GET    | Get extracted heading/section structure                     |
-| `/api/events`            | GET    | Server-sent document change events                          |
-| `/api/doc/:id/links`     | GET    | Get outgoing links from doc                                 |
-| `/api/doc/:id/backlinks` | GET    | Get docs linking to this                                    |
-| `/api/doc/:id/similar`   | GET    | Find semantically similar                                   |
-| `/api/graph`             | GET    | Knowledge graph of links                                    |
-| `/api/graph/query`       | POST   | Bounded typed-edge graph traversal                          |
-| `/api/tags`              | GET    | List tags with counts                                       |
-| `/api/search`            | POST   | BM25 keyword search                                         |
-| `/api/query`             | POST   | Hybrid search                                               |
-| `/api/query/diagnose`    | POST   | Diagnose why a target document does or does not retrieve    |
-| `/api/ask`               | POST   | AI-powered Q&A                                              |
-| `/api/context`           | POST   | Compile a deterministic, budgeted evidence Capsule          |
-| `/api/context/verify`    | POST   | Verify a saved Capsule against the active index             |
-| `/api/presets`           | GET    | List model presets                                          |
-| `/api/presets`           | POST   | Switch preset                                               |
-| `/api/models/status`     | GET    | Download status                                             |
-| `/api/models/pull`       | POST   | Start model download                                        |
+| Endpoint                               | Method | Description                                                 |
+| :------------------------------------- | :----- | :---------------------------------------------------------- |
+| `/api/health`                          | GET    | Health check                                                |
+| `/api/status`                          | GET    | Index statistics, onboarding, health, background, bootstrap |
+| `/api/resident/status`                 | GET    | Redacted resident lifecycle and bounded counters            |
+| `/api/capabilities`                    | GET    | Available features                                          |
+| `/api/collections`                     | GET    | List collections                                            |
+| `/api/connectors`                      | GET    | Detect in-app connector install state                       |
+| `/api/connectors/verify`               | POST   | Explicit read-only connector retrieval proof                |
+| `/api/docs`                            | GET    | List documents                                              |
+| `/api/docs/autocomplete`               | GET    | Title/path suggestions for wiki-linking and quick switcher  |
+| `/api/note-presets`                    | GET    | List note presets and scaffold previews                     |
+| `/api/doc`                             | GET    | Get document content                                        |
+| `/api/doc-asset`                       | GET    | Get the original source file bytes (Range-capable)          |
+| `/api/doc/:id/sections`                | GET    | Get extracted heading/section structure                     |
+| `/api/doc/:id/section-targets`         | POST   | Create a durable SectionTargetV1 for a heading              |
+| `/api/doc/:id/section-targets/resolve` | POST   | Conservatively resolve a SectionTargetV1                    |
+| `/api/events`                          | GET    | Server-sent document change events                          |
+| `/api/doc/:id/links`                   | GET    | Get outgoing links from doc                                 |
+| `/api/doc/:id/backlinks`               | GET    | Get docs linking to this                                    |
+| `/api/doc/:id/similar`                 | GET    | Find semantically similar                                   |
+| `/api/graph`                           | GET    | Knowledge graph of links                                    |
+| `/api/graph/query`                     | POST   | Bounded typed-edge graph traversal                          |
+| `/api/tags`                            | GET    | List tags with counts                                       |
+| `/api/search`                          | POST   | BM25 keyword search                                         |
+| `/api/query`                           | POST   | Hybrid search                                               |
+| `/api/query/diagnose`                  | POST   | Diagnose why a target document does or does not retrieve    |
+| `/api/ask`                             | POST   | AI-powered Q&A                                              |
+| `/api/context`                         | POST   | Compile a deterministic, budgeted evidence Capsule          |
+| `/api/context/verify`                  | POST   | Verify a saved Capsule against the active index             |
+| `/api/presets`                         | GET    | List model presets                                          |
+| `/api/presets`                         | POST   | Switch preset                                               |
+| `/api/models/status`                   | GET    | Download status                                             |
+| `/api/models/pull`                     | POST   | Start model download                                        |
 
 ### Write Operations
 
@@ -1479,6 +1481,104 @@ admitted when it connects. GNO rechecks that epoch before every document event
 and heartbeat. After policy rotation, the stream suppresses document URI,
 collection, and relative-path metadata, sends a content-free
 `EGRESS_POLICY_CHANGED` retry event, closes, and unsubscribes.
+
+---
+
+### Document Sections
+
+```http
+GET /api/doc/:id/sections
+```
+
+Returns the extracted heading/section structure for a document. Shape is
+unchanged: `{ "sections": [ { "anchor", "level", "line", "title" }, ... ] }`.
+
+### Create Section Target
+
+```http
+POST /api/doc/:id/section-targets
+Content-Type: application/json
+
+{ "anchor": "setup" }
+```
+
+Create a bounded, versioned `SectionTargetV1` for one heading. Provide exactly
+one selector: `anchor` **or** `line` (1-based heading line). The canonical
+document URI always comes from the resolved stored document — never from the
+caller.
+
+**Response** (`section-target-create-result.schema.json`):
+
+```json
+{
+  "uri": "gno://notes/pilot.md",
+  "target": {
+    "schemaVersion": "1",
+    "document": { "uri": "gno://notes/pilot.md" },
+    "anchor": "setup",
+    "headingPath": ["Guide", "Setup"],
+    "occurrence": 1,
+    "quote": {
+      "exact": "Install Bun first.",
+      "prefix": "\n\n",
+      "suffix": "\n"
+    },
+    "sourceFingerprint": "…64-char sha256…",
+    "hints": { "line": 3, "startOffset": 20, "endOffset": 38 }
+  }
+}
+```
+
+Validation failures (missing/both selectors, malformed JSON, oversized body)
+return `400`. Unknown section → `404`. Faithful target that cannot fit bounds →
+`422`. Stored canonical document URI that exceeds transport `uri` maxLength
+(`1024`) → `422` `VALIDATION` before target creation (never truncated).
+
+### Resolve Section Target
+
+```http
+POST /api/doc/:id/section-targets/resolve
+Content-Type: application/json
+
+{ "target": { "schemaVersion": "1", "...": "…" } }
+```
+
+Conservatively resolve a previously created target against the stored document.
+Statuses: `exact`, `recovered`, `ambiguous`, `stale`, `missing`. A URI mismatch
+between the target and the stored document yields `missing` with
+`diagnostics.reason: "document_uri_mismatch"`.
+
+Navigable (`exact` / `recovered`) responses include `citation` with canonical
+`uri`, current `anchor`/`title`, inclusive `lineStart`/`lineEnd`, and
+`sourceFingerprint`. Non-navigable responses omit `citation` and any navigation
+fields. If a navigable citation cannot fit transport bounds without truncating
+identity, the result becomes non-navigable `stale` with
+`diagnostics.reason: "citation_exceeds_transport_bounds"`. If the stored
+canonical document URI itself exceeds transport `uri` maxLength, resolve returns
+`422` `VALIDATION` before projection (top-level `uri` is not truncated; citation
+fail-closed does not repair it). Ambiguous/stale candidate lists are filtered to
+schema bounds (no identity truncation), capped at 32 items, and report
+`candidateCount` / `candidatesTruncated`.
+
+**Response** (`section-target-resolve-result.schema.json`):
+
+```json
+{
+  "uri": "gno://notes/pilot.md",
+  "status": "exact",
+  "currentFingerprint": "…",
+  "target": { "schemaVersion": "1" },
+  "diagnostics": {},
+  "citation": {
+    "uri": "gno://notes/pilot.md",
+    "anchor": "setup",
+    "title": "Setup",
+    "lineStart": 3,
+    "lineEnd": 6,
+    "sourceFingerprint": "…"
+  }
+}
+```
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1580,6 +1580,11 @@ schema bounds (no identity truncation), capped at 32 items, and report
 }
 ```
 
+Human Web UI copy-link uses readable `#anchor` fragments only. Optional UI
+citation links add a bounded versioned `st` query param for local recovery;
+they must not be treated as a public sharing format. Agents should prefer
+`gno_section` / REST create+resolve over scraping `st` from URLs.
+
 ---
 
 ### Get Document Links

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -26,10 +26,10 @@ diagnose can emit the closed, redacted `query-diagnose@1.1` affinity metadata.
 ## Overview
 
 MCP (Model Context Protocol) allows AI assistants to access external tools and
-resources. GNO registers 25 tools in default read-only mode and 40 when writes
+resources. GNO registers 26 tools in default read-only mode and 41 when writes
 are explicitly enabled:
 
-- **Tools (read)**: gno_context, gno_context_verify, gno_ask, gno_search, gno_vsearch, gno_query, gno_query_diagnose, gno_get, gno_multi_get, gno_status, gno_changes, gno_diff, gno_impact, gno_trace_list, gno_trace_show, gno_list_tags, gno_links, gno_backlinks, gno_similar, gno_graph, gno_graph_query, gno_graph_neighbors, gno_graph_path
+- **Tools (read)**: gno_context, gno_context_verify, gno_ask, gno_search, gno_vsearch, gno_query, gno_query_diagnose, gno_get, gno_section, gno_multi_get, gno_status, gno_changes, gno_diff, gno_impact, gno_trace_list, gno_trace_show, gno_list_tags, gno_links, gno_backlinks, gno_similar, gno_graph, gno_graph_query, gno_graph_neighbors, gno_graph_path
 - **Tools (write, opt-in)**: gno_trace_label, gno_trace_export, gno_trace_delete, gno_trace_purge, gno_capture, gno_add_collection, gno_sync, gno_embed, gno_index, gno_remove_collection, gno_clear_collection_embeddings, gno_create_folder, gno_rename_note, gno_move_note, gno_duplicate_note
 - **Tools (jobs)**: gno_job_status, gno_list_jobs
 - **Resources**: Access documents via `gno://collection/path`
@@ -106,6 +106,7 @@ Use the narrower tools when the request is explicit:
 | `gno_query`          | Default choice; mixed lexical + semantic + reranked retrieval                   | `gno_multi_get` for top URIs                        |
 | `gno_query_diagnose` | Important target doc is missing or you need stage-by-stage retrieval evidence   | Adjust filters/query mode, then retry `gno_query`   |
 | `gno_get`            | One known `gno://` URI, `#docid`, or `collection/path`                          | Use `fromLine` + `lineCount` first                  |
+| `gno_section`        | Create/resolve a durable section target; cite only exact/recovered              | Follow citation lines with `gno_get`                |
 | `gno_multi_get`      | Batch several top result refs or glob-matched docs                              | Keep `maxBytes` bounded                             |
 | `gno_status`         | Results look stale, vector search fails, or embeddings may be missing           | Run write-enabled `gno_index` or `gno_embed`        |
 
@@ -1214,6 +1215,29 @@ path separators, controls, and platform-invalid punctuation are rejected before
 filesystem access. Case and canonically equivalent Unicode spellings share one
 NFC/case-folded identity. Its 242-byte UTF-8 budget keeps the complete
 `index-<identity>.sqlite` filename within the portable 255-byte component limit.
+
+### gno_section
+
+Create or resolve a durable `SectionTargetV1` against one indexed document.
+
+```
+action: "create"
+ref: "gno://notes/pilot.md"
+anchor: "setup"   # or line: 3 — exactly one selector
+```
+
+```
+action: "resolve"
+ref: "gno://notes/pilot.md"
+target: { schemaVersion: "1", ... }
+```
+
+Always registered and read-only: no document writes and no target persistence.
+Uses the shared core create/resolve/transport contract. Exact/recovered results
+include citation evidence (canonical URI, current anchor/title, inclusive line
+range, fingerprint). Ambiguous/stale/missing omit citation and are not safe to
+navigate or cite. Model-visible text includes serialized JSON plus `gno_get`
+`fromLine`/`lineCount` follow-up guidance for navigable ranges.
 
 ### gno_multi_get
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -368,6 +368,10 @@ transport `uri` maxLength, create/resolve throw SDK `VALIDATION` before
 projection (never truncating `target.document.uri`). Diagnostics candidates are
 filtered/capped (32 max) with explicit `candidateCount` / `candidatesTruncated`.
 
+Readable Web UI `#anchor` links stay compatible and are the human default.
+Durable targets are for citation-safe create/resolve — not a replacement for
+`getSections()` navigation.
+
 ### Capture
 
 Capture a note with provenance and receive the shared capture receipt.

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -336,6 +336,38 @@ supplied. Case and canonically equivalent Unicode spellings share one
 NFC/case-folded identity. Its 242-byte UTF-8 budget keeps the complete
 `index-<identity>.sqlite` filename within the portable 255-byte component limit.
 
+### Sections / Section Targets
+
+```ts
+const sections = await client.getSections("notes/pilot.md");
+
+const created = await client.createSectionTarget("notes/pilot.md", {
+  anchor: "setup",
+});
+// or: { line: 3 } — exactly one selector
+
+const resolved = await client.resolveSectionTarget(
+  "notes/pilot.md",
+  created.target
+);
+if (resolved.status === "exact" || resolved.status === "recovered") {
+  console.log(resolved.citation?.anchor, resolved.citation?.lineStart);
+} else {
+  console.log(resolved.status, resolved.diagnostics.reason);
+}
+```
+
+`getSections()` stays backward compatible. `createSectionTarget` /
+`resolveSectionTarget` share the same projection as the REST endpoints
+(`section-target-create-result` / `section-target-resolve-result` schemas):
+canonical stored URI, conservative status, and citation only when navigable.
+Ambiguous, stale, and missing results never include citation/navigation fields.
+Oversized navigable citations fail closed to `stale` with
+`citation_exceeds_transport_bounds`. If the stored canonical document URI exceeds
+transport `uri` maxLength, create/resolve throw SDK `VALIDATION` before
+projection (never truncating `target.document.uri`). Diagnostics candidates are
+filtered/capped (32 max) with explicit `candidateCount` / `candidatesTruncated`.
+
 ### Capture
 
 Capture a note with provenance and receive the shared capture receipt.

--- a/docs/WEB-UI.md
+++ b/docs/WEB-UI.md
@@ -679,11 +679,21 @@ The document view includes a collapsible sidebar with link information:
 
 ### Document Outline
 
-Long notes now expose a heading-aware outline in the facts rail:
+Long notes expose a heading-aware outline in the facts rail:
 
 - jump to sections quickly
-- copy deep links to section anchors
+- copy readable deep links to section anchors (`/doc?uri=…#anchor`)
+- optionally copy a citation link that adds a bounded, versioned `st`
+  selector for durable recovery
 - keep a live sense of where you are in long notes
+
+Readable `#anchor` links remain the human default and stay compatible with
+older bookmarks. Citation links are for local/agent citation safety: they
+carry bounded quote/context evidence, never a full section body, and resolve
+conservatively. Exact and uniquely recovered targets navigate to the current
+anchor and show a short status; ambiguous, stale, missing, or invalid
+selectors never navigate and never silently cite a different section.
+Quick Switcher section jumps continue to use readable anchors only.
 
 ### Wiki Link Autocomplete
 

--- a/spec/mcp.md
+++ b/spec/mcp.md
@@ -166,6 +166,7 @@ Collection names are case-insensitive on input and normalized to lowercase in re
 - Use `gno_query_diagnose` when a specific important document is missing from results or when you need per-stage retrieval evidence before changing query strategy.
 - Use `gno_graph_query` for bounded typed-edge traversal over `doc_edges`; keep `gno_graph_neighbors`/`gno_graph_path` for the legacy graph projection.
 - After search/query returns a `line`, call `gno_get` with `fromLine` and `lineCount` before fetching whole documents.
+- Use `gno_section` to create or resolve durable section targets; only cite/navigate on exact/recovered citations, then follow with `gno_get` line ranges.
 - Use `gno_multi_get` to batch the top result refs. Keep `maxBytes` bounded to avoid flooding client context.
 - Check `gno_status` when results look stale, vector search is unavailable, or embedding backlog may explain missing results.
 
@@ -897,6 +898,67 @@ contain `..`. Invalid names are rejected before filesystem access. NFC/case-
 folded equivalents share one logical identity. The canonical identity is
 limited to 242 UTF-8 bytes so `index-<identity>.sqlite` stays within the portable
 255-byte filename-component limit.
+
+---
+
+### gno_section
+
+Read-only create/resolve for durable `SectionTargetV1` locators against one
+indexed document. Always registered (independent of `enableWrite`). Does not
+write documents, persist targets, or fork the shared parser/resolver.
+
+Uses the active indexed store content and the shared core
+create/resolve/transport projection (same bounds, closed validation, and
+fail-closed citation semantics as REST/SDK). Canonical document URI always
+comes from the stored document — never from the caller.
+
+**Annotations (descriptive only):**
+`readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`,
+`openWorldHint: false`. Authorization remains server-side; annotations do not
+grant or deny writes. `gno_section` is not in `MCP_WRITE_TOOL_NAMES`.
+
+**Input Schema (closed, action-discriminated):**
+
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["action", "ref"],
+  "properties": {
+    "action": { "enum": ["create", "resolve"] },
+    "ref": { "type": "string", "minLength": 1, "maxLength": 2048 },
+    "anchor": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "line": { "type": "integer", "minimum": 1 },
+    "target": { "$ref": "gno://schemas/section-target@1.0" }
+  }
+}
+```
+
+The published MCP discovery schema is one closed object because the SDK cannot
+reliably publish/validate Zod unions for tool schemas. Server-side refinements
+enforce the action branches: create requires exactly one of `anchor` or `line`
+(1-based heading line) and forbids `target`; resolve requires a closed
+`SectionTargetV1` and forbids `anchor`/`line`. Unknown fields, unknown actions,
+inverted offsets, and oversized values fail closed before core resolution or
+document reads.
+
+**Output Schema:** `gno://schemas/section@1.0`
+
+Action-discriminated structured output wrapping the shared create/resolve
+result semantics:
+
+- `action: "create"` → `{ schemaVersion:"1.0", action, uri, target }`
+- `action: "resolve"` + `exact`/`recovered` → includes `citation` with
+  canonical `uri`, current `anchor`/`title`, inclusive `lineStart`/`lineEnd`,
+  and `sourceFingerprint`
+- `action: "resolve"` + `ambiguous`/`stale`/`missing` → omits `citation`;
+  model-visible text states the result is not safe to navigate or cite
+
+Model-visible `content[0].text` includes the serialized structured JSON for
+MCP 2025-11-25 hosts that ignore `structuredContent`, plus concise `gno_get`
+`fromLine`/`lineCount` follow-up guidance when a navigable citation is present.
+
+Existing `gno_get` input/output and line-range behavior are unchanged.
 
 ---
 

--- a/spec/output-schemas/section-target-create-result.schema.json
+++ b/spec/output-schemas/section-target-create-result.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gno://schemas/section-target-create-result@1.0",
+  "title": "GNO Section Target Create Result",
+  "description": "Response from creating a durable SectionTargetV1 against a stored document. Canonical uri always comes from the resolved document.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["uri", "target"],
+  "properties": {
+    "uri": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "description": "Canonical stored document URI"
+    },
+    "target": {
+      "$ref": "gno://schemas/section-target@1.0"
+    }
+  }
+}

--- a/spec/output-schemas/section-target-resolve-result.schema.json
+++ b/spec/output-schemas/section-target-resolve-result.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gno://schemas/section-target-resolve-result@1.0",
+  "title": "GNO Section Target Resolve Result",
+  "description": "Conservative section-target resolution result shared by REST and SDK. Citation is present only for navigable exact/recovered statuses. Diagnostics candidates are filtered/capped without truncating identity strings.",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uri",
+        "status",
+        "currentFingerprint",
+        "target",
+        "diagnostics",
+        "citation"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "status": {
+          "type": "string",
+          "enum": ["exact", "recovered"]
+        },
+        "currentFingerprint": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "target": {
+          "$ref": "gno://schemas/section-target@1.0"
+        },
+        "diagnostics": {
+          "$ref": "#/definitions/diagnostics"
+        },
+        "citation": {
+          "$ref": "#/definitions/citation"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uri",
+        "status",
+        "currentFingerprint",
+        "target",
+        "diagnostics"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ambiguous", "stale", "missing"]
+        },
+        "currentFingerprint": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "target": {
+          "$ref": "gno://schemas/section-target@1.0"
+        },
+        "diagnostics": {
+          "$ref": "#/definitions/diagnostics"
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "safePositiveInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "safeNonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "candidates": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "anchor",
+              "line",
+              "title",
+              "headingPath",
+              "occurrence"
+            ],
+            "properties": {
+              "anchor": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512
+              },
+              "line": {
+                "$ref": "#/definitions/safePositiveInteger"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512
+              },
+              "headingPath": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 6,
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 512
+                }
+              },
+              "occurrence": {
+                "$ref": "#/definitions/safePositiveInteger"
+              }
+            }
+          }
+        },
+        "candidateCount": {
+          "$ref": "#/definitions/safeNonNegativeInteger",
+          "description": "Total candidate count before transport filtering/capping"
+        },
+        "candidatesTruncated": {
+          "type": "boolean",
+          "description": "True when any candidate was omitted by bounds filtering or the 32-item cap"
+        }
+      },
+      "dependencies": {
+        "candidates": ["candidateCount", "candidatesTruncated"],
+        "candidateCount": ["candidatesTruncated", "candidates"],
+        "candidatesTruncated": ["candidateCount", "candidates"]
+      }
+    },
+    "citation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uri",
+        "anchor",
+        "title",
+        "lineStart",
+        "lineEnd",
+        "sourceFingerprint"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "anchor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "lineStart": {
+          "$ref": "#/definitions/safePositiveInteger"
+        },
+        "lineEnd": {
+          "$ref": "#/definitions/safePositiveInteger"
+        },
+        "sourceFingerprint": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/spec/output-schemas/section-target.schema.json
+++ b/spec/output-schemas/section-target.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gno://schemas/section-target@1.0",
+  "title": "GNO Section Target V1",
+  "description": "Bounded, versioned, content-derived section locator for conservative citation recovery. Does not embed full section bodies.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "document",
+    "anchor",
+    "headingPath",
+    "occurrence",
+    "quote",
+    "sourceFingerprint",
+    "hints"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1",
+      "description": "Section target schema version"
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "Canonical document URI"
+        }
+      }
+    },
+    "anchor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "Human-readable heading anchor at capture time"
+    },
+    "headingPath": {
+      "type": "array",
+      "description": "NFC-normalized heading ancestry including the section title",
+      "minItems": 1,
+      "maxItems": 6,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512
+      }
+    },
+    "occurrence": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "1-based occurrence among sections with the same headingPath"
+    },
+    "quote": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exact", "prefix", "suffix"],
+      "properties": {
+        "exact": {
+          "type": "string",
+          "maxLength": 96,
+          "description": "Bounded exact quote (section body preferred, else heading title)"
+        },
+        "prefix": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "Bounded prefix context immediately before exact"
+        },
+        "suffix": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "Bounded suffix context immediately after exact"
+        }
+      }
+    },
+    "sourceFingerprint": {
+      "$ref": "#/definitions/sha256",
+      "description": "SHA-256 hex fingerprint of the full source document content at capture"
+    },
+    "hints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line", "startOffset", "endOffset"],
+      "description": "Line and code-unit offset hints only; never identity",
+      "properties": {
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based heading line at capture"
+        },
+        "startOffset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "UTF-16 code-unit start offset of the exact quote at capture"
+        },
+        "endOffset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "UTF-16 code-unit end offset of the exact quote at capture"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/spec/output-schemas/section-target.schema.json
+++ b/spec/output-schemas/section-target.schema.json
@@ -53,6 +53,7 @@
     "occurrence": {
       "type": "integer",
       "minimum": 1,
+      "maximum": 9007199254740991,
       "description": "1-based occurrence among sections with the same headingPath"
     },
     "quote": {
@@ -90,16 +91,19 @@
         "line": {
           "type": "integer",
           "minimum": 1,
+          "maximum": 9007199254740991,
           "description": "1-based heading line at capture"
         },
         "startOffset": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 9007199254740991,
           "description": "UTF-16 code-unit start offset of the exact quote at capture"
         },
         "endOffset": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 9007199254740991,
           "description": "UTF-16 code-unit end offset of the exact quote at capture"
         }
       }

--- a/spec/output-schemas/section.schema.json
+++ b/spec/output-schemas/section.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gno://schemas/section@1.0",
+  "title": "GNO MCP Section Tool Result",
+  "description": "Action-discriminated MCP gno_section structured output. Create returns the shared create-result semantics; resolve returns the shared resolve-result semantics (citation only for exact/recovered).",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "action", "uri", "target"],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0"
+        },
+        "action": {
+          "const": "create"
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "target": {
+          "$ref": "gno://schemas/section-target@1.0"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "action",
+        "uri",
+        "status",
+        "currentFingerprint",
+        "target",
+        "diagnostics",
+        "citation"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0"
+        },
+        "action": {
+          "const": "resolve"
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "status": {
+          "type": "string",
+          "enum": ["exact", "recovered"]
+        },
+        "currentFingerprint": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "target": {
+          "$ref": "gno://schemas/section-target@1.0"
+        },
+        "diagnostics": {
+          "$ref": "gno://schemas/section-target-resolve-result@1.0#/definitions/diagnostics"
+        },
+        "citation": {
+          "$ref": "gno://schemas/section-target-resolve-result@1.0#/definitions/citation"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "action",
+        "uri",
+        "status",
+        "currentFingerprint",
+        "target",
+        "diagnostics"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": "1.0"
+        },
+        "action": {
+          "const": "resolve"
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ambiguous", "stale", "missing"]
+        },
+        "currentFingerprint": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "target": {
+          "$ref": "gno://schemas/section-target@1.0"
+        },
+        "diagnostics": {
+          "$ref": "gno://schemas/section-target-resolve-result@1.0#/definitions/diagnostics"
+        }
+      }
+    }
+  ]
+}

--- a/src/core/section-parse.ts
+++ b/src/core/section-parse.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared Markdown section extraction (ATX headings + fence awareness).
+ * Private helper module — import public API from `./sections`.
+ *
+ * @module src/core/section-parse
+ */
+
+export interface DocumentSection {
+  anchor: string;
+  level: number;
+  line: number;
+  title: string;
+}
+
+/** Structural section record used by target create/resolve. */
+export interface SectionRecord {
+  section: DocumentSection;
+  headingPath: string[];
+  occurrence: number;
+  /** Inclusive start line through exclusive end line of section body. */
+  endLine: number;
+  titleStartOffset: number;
+  titleEndOffset: number;
+}
+
+const HEADING_REGEX = /^(#{1,6})\s+(.+?)\s*#*\s*$/u;
+const FENCE_REGEX = /^ {0,3}(`{3,}|~{3,})(.*)$/u;
+const FENCE_CLOSE_REGEX = /^ {0,3}(`{3,}|~{3,})[\t ]*$/u;
+
+interface OpenFence {
+  marker: "`" | "~";
+  length: number;
+}
+
+const fenceOpener = (line: string): OpenFence | null => {
+  const match = FENCE_REGEX.exec(line);
+  const run = match?.[1];
+  const suffix = match?.[2] ?? "";
+  if (!run || (run[0] === "`" && suffix.includes("`"))) return null;
+  return { marker: run[0] as OpenFence["marker"], length: run.length };
+};
+
+const closesFence = (line: string, fence: OpenFence): boolean => {
+  const run = FENCE_CLOSE_REGEX.exec(line)?.[1];
+  return Boolean(run && run[0] === fence.marker && run.length >= fence.length);
+};
+
+export const normalizeHeadingTitle = (title: string): string =>
+  title.normalize("NFC").trim();
+
+export const pathKey = (headingPath: readonly string[]): string =>
+  headingPath.join("\0");
+
+export function slugifySectionTitle(title: string): string {
+  return (
+    title
+      .normalize("NFC")
+      .toLowerCase()
+      .trim()
+      .replaceAll(/[^\p{L}\p{N}\s-]/gu, "")
+      .replaceAll(/\s+/g, "-")
+      .replaceAll(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "section"
+  );
+}
+
+export const lineStartOffsets = (content: string): number[] => {
+  const offsets = [0];
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === "\n") offsets.push(index + 1);
+  }
+  return offsets;
+};
+
+/** Extract structural section records (no quote evidence). */
+export function extractSectionRecords(content: string): SectionRecord[] {
+  const records: SectionRecord[] = [];
+  const counts = new Map<string, number>();
+  const pathCounts = new Map<string, number>();
+  const lines = content.split("\n");
+  const starts = lineStartOffsets(content);
+  let openFence: OpenFence | null = null;
+  const stack: { level: number; title: string }[] = [];
+
+  for (const [index, line] of lines.entries()) {
+    if (openFence) {
+      if (closesFence(line, openFence)) openFence = null;
+      continue;
+    }
+    const opener = fenceOpener(line);
+    if (opener) {
+      openFence = opener;
+      continue;
+    }
+    const match = HEADING_REGEX.exec(line);
+    if (!match) continue;
+
+    const level = match[1]?.length ?? 0;
+    const title = match[2]?.trim() ?? "";
+    if (!title) continue;
+
+    const normalizedTitle = normalizeHeadingTitle(title);
+    while (stack.length > 0 && (stack.at(-1)?.level ?? 0) >= level) {
+      stack.pop();
+    }
+    stack.push({ level, title: normalizedTitle });
+    const headingPath = stack.map((entry) => entry.title);
+    const occurrence = (pathCounts.get(pathKey(headingPath)) ?? 0) + 1;
+    pathCounts.set(pathKey(headingPath), occurrence);
+
+    const baseAnchor = slugifySectionTitle(title);
+    const count = (counts.get(baseAnchor) ?? 0) + 1;
+    counts.set(baseAnchor, count);
+    const anchor = count === 1 ? baseAnchor : `${baseAnchor}-${count}`;
+
+    const lineStart = starts[index] ?? 0;
+    const titleOffsetInLine = line.indexOf(title);
+    const titleStartOffset =
+      titleOffsetInLine >= 0 ? lineStart + titleOffsetInLine : lineStart;
+    const titleEndOffset = titleStartOffset + title.length;
+
+    records.push({
+      section: {
+        anchor,
+        level,
+        line: index + 1,
+        title,
+      },
+      headingPath,
+      occurrence,
+      endLine: lines.length,
+      titleStartOffset,
+      titleEndOffset,
+    });
+  }
+
+  for (const [recordIndex, record] of records.entries()) {
+    let endLine = lines.length;
+    for (let next = recordIndex + 1; next < records.length; next += 1) {
+      const candidate = records[next];
+      if (candidate && candidate.section.level <= record.section.level) {
+        endLine = candidate.section.line - 1;
+        break;
+      }
+    }
+    record.endLine = endLine;
+  }
+
+  return records;
+}
+
+export function extractSections(content: string): DocumentSection[] {
+  return extractSectionRecords(content).map((record) => record.section);
+}
+
+/** Extract one inclusive, 1-based line range without normalizing source bytes. */
+export function extractInclusiveLines(
+  content: string,
+  startLine: number,
+  endLine: number
+): string | null {
+  if (
+    content.includes("\r") ||
+    !Number.isSafeInteger(startLine) ||
+    !Number.isSafeInteger(endLine) ||
+    startLine < 1 ||
+    endLine < startLine
+  ) {
+    return null;
+  }
+  const lines = content.split("\n");
+  if (endLine > lines.length) return null;
+  return lines.slice(startLine - 1, endLine).join("\n");
+}
+
+/** Find the nearest Markdown heading governing a 1-based source line. */
+export function headingForLine(
+  sections: readonly DocumentSection[],
+  line: number
+): string | null {
+  let heading: string | null = null;
+  for (const section of sections) {
+    if (section.line > line) break;
+    heading = section.title;
+  }
+  return heading;
+}

--- a/src/core/section-target-link.ts
+++ b/src/core/section-target-link.ts
@@ -1,0 +1,154 @@
+/**
+ * Privacy-safe, bounded encoding of SectionTargetV1 for additive URL params.
+ * Private helper — import public API from `./sections`.
+ *
+ * Human-readable `#anchor` fragments stay unchanged. The optional `st`
+ * query param carries a versioned, size-bounded target for citation-safe
+ * recovery. It must never embed a full section body.
+ *
+ * @module src/core/section-target-link
+ */
+
+import {
+  isBoundedSectionTarget,
+  SECTION_TARGET_BOUNDS,
+  type SectionTargetV1,
+} from "./section-target";
+import { parseSectionTargetV1 } from "./section-target-transport";
+
+/** Query parameter name for the additive durable selector. */
+export const SECTION_TARGET_LINK_PARAM = "st" as const;
+
+/** Version prefix for the encoded selector payload. */
+export const SECTION_TARGET_LINK_VERSION = "1" as const;
+
+/**
+ * Hard cap on the encoded `st` value (version prefix + base64url payload).
+ * Keeps citation links shareable in local tooling without giant URLs.
+ */
+export const SECTION_TARGET_LINK_MAX_ENCODED_CHARS = 3072 as const;
+
+const UTF8 = new TextEncoder();
+const UTF8_DECODER = new TextDecoder();
+
+const bytesToBase64Url = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+};
+
+const base64UrlToBytes = (value: string): Uint8Array | null => {
+  if (!/^[A-Za-z0-9_-]*$/u.test(value)) {
+    return null;
+  }
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padLength = (4 - (padded.length % 4)) % 4;
+  const base64 = padded + "=".repeat(padLength);
+  try {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Encode a bounded SectionTargetV1 as `1.<base64url(json)>`.
+ * Returns null when the target is unbounded or the encoded form exceeds
+ * {@link SECTION_TARGET_LINK_MAX_ENCODED_CHARS}.
+ */
+export function encodeSectionTargetLinkParam(
+  target: SectionTargetV1
+): string | null {
+  if (!isBoundedSectionTarget(target)) {
+    return null;
+  }
+  const json = JSON.stringify(target);
+  if (UTF8.encode(json).byteLength > SECTION_TARGET_BOUNDS.maxSerializedBytes) {
+    return null;
+  }
+  const encoded = `${SECTION_TARGET_LINK_VERSION}.${bytesToBase64Url(UTF8.encode(json))}`;
+  if (encoded.length > SECTION_TARGET_LINK_MAX_ENCODED_CHARS) {
+    return null;
+  }
+  return encoded;
+}
+
+/**
+ * Decode an `st` query value into a validated SectionTargetV1.
+ * Fail-closed: malformed version, padding, JSON, or bounds → null.
+ * Error paths never echo quote/body text.
+ */
+export function decodeSectionTargetLinkParam(
+  value: string
+): SectionTargetV1 | null {
+  if (
+    value.length < 3 ||
+    value.length > SECTION_TARGET_LINK_MAX_ENCODED_CHARS
+  ) {
+    return null;
+  }
+  const dot = value.indexOf(".");
+  if (dot < 1) {
+    return null;
+  }
+  const version = value.slice(0, dot);
+  const payload = value.slice(dot + 1);
+  if (version !== SECTION_TARGET_LINK_VERSION || payload.length < 1) {
+    return null;
+  }
+  const bytes = base64UrlToBytes(payload);
+  if (!bytes || bytes.byteLength > SECTION_TARGET_BOUNDS.maxSerializedBytes) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(UTF8_DECODER.decode(bytes));
+  } catch {
+    return null;
+  }
+  const validated = parseSectionTargetV1(parsed);
+  if (!validated.ok) {
+    return null;
+  }
+  return validated.value;
+}
+
+/** Stable, content-free reason codes for link decode failures. */
+export type SectionTargetLinkDecodeFailure =
+  | "missing"
+  | "malformed"
+  | "unsupported_version"
+  | "oversized";
+
+/**
+ * Classify why an `st` value could not be decoded without inspecting body text.
+ */
+export function classifySectionTargetLinkDecodeFailure(
+  value: string | null | undefined
+): SectionTargetLinkDecodeFailure {
+  if (value === null || value === undefined || value.length < 1) {
+    return "missing";
+  }
+  if (value.length > SECTION_TARGET_LINK_MAX_ENCODED_CHARS) {
+    return "oversized";
+  }
+  const dot = value.indexOf(".");
+  if (dot < 1) {
+    return "malformed";
+  }
+  const version = value.slice(0, dot);
+  if (version !== SECTION_TARGET_LINK_VERSION) {
+    return "unsupported_version";
+  }
+  return "malformed";
+}

--- a/src/core/section-target-resolve.ts
+++ b/src/core/section-target-resolve.ts
@@ -1,0 +1,351 @@
+/**
+ * Conservative SectionTargetV1 resolution.
+ * Private helper module — import public API from `./sections`.
+ *
+ * @module src/core/section-target-resolve
+ */
+
+import {
+  extractSectionRecords,
+  lineStartOffsets,
+  normalizeHeadingTitle,
+  type DocumentSection,
+  type SectionRecord,
+} from "./section-parse";
+import {
+  fingerprintSourceContent,
+  withQuotes,
+  type QuotedSectionRecord,
+  type SectionTargetV1,
+} from "./section-target";
+
+export type SectionResolutionStatus =
+  | "exact"
+  | "recovered"
+  | "ambiguous"
+  | "stale"
+  | "missing";
+
+export interface SectionResolutionCandidate {
+  anchor: string;
+  line: number;
+  title: string;
+  headingPath: string[];
+  occurrence: number;
+}
+
+export interface SectionResolution {
+  status: SectionResolutionStatus;
+  target: SectionTargetV1;
+  currentFingerprint: string;
+  /** Present only when status is exact or recovered (navigable). */
+  section?: DocumentSection & { endLine: number };
+  /** Safe candidate list when status is ambiguous. */
+  candidates?: SectionResolutionCandidate[];
+  reason?: string;
+}
+
+const pathsEqual = (
+  left: readonly string[],
+  right: readonly string[]
+): boolean =>
+  left.length === right.length &&
+  left.every(
+    (value, index) => value === normalizeHeadingTitle(right[index] ?? "")
+  );
+
+const sectionSpan = (
+  content: string,
+  record: SectionRecord,
+  starts: readonly number[]
+): { start: number; end: number } => {
+  const start = record.titleStartOffset;
+  const end =
+    record.endLine >= starts.length
+      ? content.length
+      : (starts[record.endLine] ?? content.length);
+  return { start, end };
+};
+
+const quoteMatchesAt = (
+  content: string,
+  quote: SectionTargetV1["quote"]
+): number[] => {
+  if (!quote.exact) return [];
+  const hits: number[] = [];
+  let from = 0;
+  while (from <= content.length) {
+    const index = content.indexOf(quote.exact, from);
+    if (index < 0) break;
+    const prefixOk = content
+      .slice(Math.max(0, index - quote.prefix.length), index)
+      .endsWith(quote.prefix);
+    const suffixOk = content
+      .slice(index + quote.exact.length)
+      .startsWith(quote.suffix);
+    if (prefixOk && suffixOk) hits.push(index);
+    from = index + 1;
+  }
+  return hits;
+};
+
+const innermostRecordAt = (
+  records: readonly QuotedSectionRecord[],
+  offset: number,
+  content: string,
+  starts: readonly number[]
+): QuotedSectionRecord | null => {
+  let best: QuotedSectionRecord | null = null;
+  for (const record of records) {
+    const span = sectionSpan(content, record, starts);
+    if (offset < span.start || offset >= span.end) continue;
+    if (
+      !best ||
+      record.titleStartOffset > best.titleStartOffset ||
+      (record.titleStartOffset === best.titleStartOffset &&
+        record.section.level > best.section.level)
+    ) {
+      best = record;
+    }
+  }
+  return best;
+};
+
+const sectionContainsExact = (
+  content: string,
+  record: SectionRecord,
+  exact: string,
+  starts: readonly number[]
+): boolean => {
+  if (!exact) return false;
+  const span = sectionSpan(content, record, starts);
+  return content.slice(span.start, span.end).includes(exact);
+};
+
+const findQuoteMatches = (
+  content: string,
+  records: readonly QuotedSectionRecord[],
+  quote: SectionTargetV1["quote"]
+): QuotedSectionRecord[] => {
+  const starts = lineStartOffsets(content);
+  const matched = new Map<string, QuotedSectionRecord>();
+  for (const offset of quoteMatchesAt(content, quote)) {
+    const owner = innermostRecordAt(records, offset, content, starts);
+    if (owner) matched.set(owner.section.anchor, owner);
+  }
+  // Also accept exact structural quote equality for the record itself.
+  for (const record of records) {
+    if (
+      record.quote.exact === quote.exact &&
+      record.quote.prefix === quote.prefix &&
+      record.quote.suffix === quote.suffix
+    ) {
+      matched.set(record.section.anchor, record);
+    }
+  }
+  return [...matched.values()];
+};
+
+const toCandidate = (
+  record: QuotedSectionRecord
+): SectionResolutionCandidate => ({
+  anchor: record.section.anchor,
+  line: record.section.line,
+  title: record.section.title,
+  headingPath: [...record.headingPath],
+  occurrence: record.occurrence,
+});
+
+const navigable = (
+  status: "exact" | "recovered",
+  target: SectionTargetV1,
+  currentFingerprint: string,
+  record: QuotedSectionRecord
+): SectionResolution => ({
+  status,
+  target,
+  currentFingerprint,
+  section: {
+    ...record.section,
+    endLine: record.endLine,
+  },
+});
+
+export interface ResolveSectionTargetInput {
+  content: string;
+  target: SectionTargetV1;
+  /** When set, a URI mismatch yields missing (wrong document). */
+  uri?: string;
+}
+
+/**
+ * Conservatively resolve a SectionTargetV1 against current document content.
+ * Never silently navigates ambiguous or stale evidence.
+ */
+export async function resolveSectionTarget(
+  input: ResolveSectionTargetInput
+): Promise<SectionResolution> {
+  const { target } = input;
+  const currentFingerprint = await fingerprintSourceContent(input.content);
+
+  if (input.uri !== undefined && input.uri !== target.document.uri) {
+    return {
+      status: "missing",
+      target,
+      currentFingerprint,
+      reason: "document_uri_mismatch",
+    };
+  }
+
+  const records = withQuotes(
+    input.content,
+    extractSectionRecords(input.content)
+  );
+  const sameRevision = currentFingerprint === target.sourceFingerprint;
+
+  // Stage 1: same-revision structural match (anchor, else path+occurrence).
+  if (sameRevision) {
+    const byAnchor = records.filter(
+      (entry) => entry.section.anchor === target.anchor
+    );
+    if (byAnchor.length === 1 && byAnchor[0]) {
+      return navigable("exact", target, currentFingerprint, byAnchor[0]);
+    }
+    const byPath = records.filter(
+      (entry) =>
+        pathsEqual(entry.headingPath, target.headingPath) &&
+        entry.occurrence === target.occurrence
+    );
+    if (byPath.length === 1 && byPath[0]) {
+      return navigable("exact", target, currentFingerprint, byPath[0]);
+    }
+    if (byAnchor.length > 1 || byPath.length > 1) {
+      return {
+        status: "ambiguous",
+        target,
+        currentFingerprint,
+        candidates: [...byAnchor, ...byPath]
+          .filter(
+            (entry, index, all) =>
+              all.findIndex(
+                (candidate) => candidate.section.anchor === entry.section.anchor
+              ) === index
+          )
+          .map(toCandidate),
+        reason: "same_revision_multiple_matches",
+      };
+    }
+  }
+
+  // Quote matches are computed once; non-unique quotes fail closed as ambiguous.
+  const starts = lineStartOffsets(input.content);
+  const quoteMatches = findQuoteMatches(input.content, records, target.quote);
+  if (quoteMatches.length > 1) {
+    return {
+      status: "ambiguous",
+      target,
+      currentFingerprint,
+      candidates: quoteMatches.map(toCandidate),
+      reason: "quote_context_multiple_matches",
+    };
+  }
+
+  // Stage 2: exact heading path/occurrence with quote evidence in-span.
+  const pathMatches = records.filter(
+    (entry) =>
+      pathsEqual(entry.headingPath, target.headingPath) &&
+      entry.occurrence === target.occurrence
+  );
+  if (pathMatches.length === 1 && pathMatches[0]) {
+    const candidate = pathMatches[0];
+    const quoteOk =
+      sectionContainsExact(
+        input.content,
+        candidate,
+        target.quote.exact,
+        starts
+      ) ||
+      (quoteMatches.length === 1 &&
+        quoteMatches[0]?.section.anchor === candidate.section.anchor);
+    if (quoteOk) {
+      return navigable(
+        sameRevision ? "exact" : "recovered",
+        target,
+        currentFingerprint,
+        candidate
+      );
+    }
+  } else if (pathMatches.length > 1) {
+    return {
+      status: "ambiguous",
+      target,
+      currentFingerprint,
+      candidates: pathMatches.map(toCandidate),
+      reason: "path_occurrence_multiple_matches",
+    };
+  }
+
+  // Stage 3: unique quote + context recovery.
+  if (quoteMatches.length === 1 && quoteMatches[0]) {
+    return navigable(
+      sameRevision ? "exact" : "recovered",
+      target,
+      currentFingerprint,
+      quoteMatches[0]
+    );
+  }
+
+  // Fail closed: partial structural residue without unique recovery → stale;
+  // no residue → missing.
+  const pathResidue = records.some((entry) =>
+    pathsEqual(entry.headingPath, target.headingPath)
+  );
+  const titleResidue = records.some(
+    (entry) =>
+      normalizeHeadingTitle(entry.section.title) ===
+      normalizeHeadingTitle(target.headingPath.at(-1) ?? "")
+  );
+  const anchorResidue = records.some(
+    (entry) => entry.section.anchor === target.anchor
+  );
+
+  if (!sameRevision && (pathResidue || titleResidue || anchorResidue)) {
+    return {
+      status: "stale",
+      target,
+      currentFingerprint,
+      reason: "fingerprint_mismatch_without_unique_recovery",
+      candidates: records
+        .filter(
+          (entry) =>
+            pathsEqual(entry.headingPath, target.headingPath) ||
+            entry.section.anchor === target.anchor ||
+            normalizeHeadingTitle(entry.section.title) ===
+              normalizeHeadingTitle(target.headingPath.at(-1) ?? "")
+        )
+        .map(toCandidate),
+    };
+  }
+
+  return {
+    status: "missing",
+    target,
+    currentFingerprint,
+    reason: sameRevision
+      ? "section_not_found_same_revision"
+      : "section_not_found",
+  };
+}
+
+/** True when the resolution may safely navigate to `section`. */
+export function isNavigableSectionResolution(
+  resolution: SectionResolution
+): resolution is SectionResolution & {
+  status: "exact" | "recovered";
+  section: DocumentSection & { endLine: number };
+} {
+  return (
+    (resolution.status === "exact" || resolution.status === "recovered") &&
+    resolution.section !== undefined
+  );
+}

--- a/src/core/section-target-transport.ts
+++ b/src/core/section-target-transport.ts
@@ -1,0 +1,519 @@
+/**
+ * Closed validation and transport projection for section targets.
+ * Private helper — import public API from `./sections`.
+ *
+ * Shared by REST and SDK so response shapes stay identical without
+ * duplicating parser/resolver logic.
+ *
+ * @module src/core/section-target-transport
+ */
+
+import {
+  SECTION_TARGET_BOUNDS,
+  SECTION_TARGET_SCHEMA_VERSION,
+  isBoundedSectionTarget,
+  type SectionTargetV1,
+} from "./section-target";
+import {
+  isNavigableSectionResolution,
+  type SectionResolution,
+  type SectionResolutionCandidate,
+  type SectionResolutionStatus,
+} from "./section-target-resolve";
+
+export type TransportValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+export interface SectionTargetCreateSelector {
+  anchor?: string;
+  line?: number;
+}
+
+/** REST/SDK create response — canonical stored URI + target. */
+export interface SectionTargetCreateResult {
+  uri: string;
+  target: SectionTargetV1;
+}
+
+/** Citation evidence exposed only for navigable resolutions. */
+export interface SectionCitationV1 {
+  uri: string;
+  anchor: string;
+  title: string;
+  lineStart: number;
+  lineEnd: number;
+  sourceFingerprint: string;
+}
+
+/**
+ * Transport diagnostics. Candidates are filtered/projected to schema bounds
+ * without truncating identity strings; `candidateCount` is the pre-filter
+ * total and `candidatesTruncated` is true when any candidate was omitted.
+ */
+export interface SectionResolutionDiagnostics {
+  reason?: string;
+  candidates?: SectionResolutionCandidate[];
+  candidateCount?: number;
+  candidatesTruncated?: boolean;
+}
+
+/**
+ * REST/SDK resolve response. Non-navigable results omit citation and any
+ * navigation fields.
+ */
+export interface SectionTargetResolveResult {
+  uri: string;
+  status: SectionResolutionStatus;
+  currentFingerprint: string;
+  target: SectionTargetV1;
+  diagnostics: SectionResolutionDiagnostics;
+  citation?: SectionCitationV1;
+}
+
+/** Transport-only bounds for resolve diagnostics / citation projection. */
+export const SECTION_TARGET_TRANSPORT_BOUNDS = {
+  diagnosticsCandidatesMaxItems: 32,
+  reasonMaxChars: 256,
+  titleMaxChars: SECTION_TARGET_BOUNDS.anchorMaxChars,
+} as const;
+
+/** Stable reason when a navigable citation cannot fit transport bounds. */
+export const CITATION_EXCEEDS_TRANSPORT_BOUNDS =
+  "citation_exceeds_transport_bounds" as const;
+
+/** Stable VALIDATION message when a stored canonical URI cannot fit transport. */
+export const CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS =
+  `Canonical document URI exceeds the maximum length of ${SECTION_TARGET_BOUNDS.uriMaxChars}` as const;
+
+const FINGERPRINT_PATTERN = /^[a-f0-9]{64}$/;
+
+const invalid = <T>(error: string): TransportValidationResult<T> => ({
+  ok: false,
+  error,
+});
+/**
+ * Snapshot only own data properties. Accessors, exotic prototypes, symbols,
+ * proxy traps, arrays, and unknown keys are rejected without invoking getters.
+ */
+const closedRecord = (
+  value: unknown,
+  allowedKeys: readonly string[]
+): TransportValidationResult<Record<string, unknown>> => {
+  try {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return invalid("Expected a JSON object");
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return invalid("Expected a plain JSON object");
+    }
+    const keys = Reflect.ownKeys(value);
+    if (
+      keys.length > allowedKeys.length ||
+      keys.some((key) => typeof key !== "string" || !allowedKeys.includes(key))
+    ) {
+      return invalid("Object contains unknown fields");
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of keys) {
+      if (typeof key !== "string") return invalid("Invalid object field");
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !("value" in descriptor)) {
+        return invalid("Accessor fields are not allowed");
+      }
+      result[key] = descriptor.value;
+    }
+    return { ok: true, value: result };
+  } catch {
+    return invalid("Unreadable input object");
+  }
+};
+
+const parseNonEmptyString = (
+  value: unknown,
+  field: string,
+  maxChars: number
+): TransportValidationResult<string> => {
+  if (typeof value !== "string") {
+    return invalid(`${field} must be a string`);
+  }
+  if (value.length < 1) {
+    return invalid(`${field} must be a non-empty string`);
+  }
+  if (value.length > maxChars) {
+    return invalid(`${field} exceeds the maximum length of ${maxChars}`);
+  }
+  return { ok: true, value };
+};
+
+const parseBoundedString = (
+  value: unknown,
+  field: string,
+  maxChars: number
+): TransportValidationResult<string> => {
+  if (typeof value !== "string") {
+    return invalid(`${field} must be a string`);
+  }
+  if (value.length > maxChars) {
+    return invalid(`${field} exceeds the maximum length of ${maxChars}`);
+  }
+  return { ok: true, value };
+};
+
+const parsePositiveInt = (
+  value: unknown,
+  field: string
+): TransportValidationResult<number> => {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    return invalid(`${field} must be a positive safe integer`);
+  }
+  return { ok: true, value };
+};
+
+const parseNonNegativeInt = (
+  value: unknown,
+  field: string
+): TransportValidationResult<number> => {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    return invalid(`${field} must be a non-negative safe integer`);
+  }
+  return { ok: true, value };
+};
+/**
+ * Require exactly one selector: `anchor` XOR `line`.
+ * Rejects unknown fields and empty/oversized values.
+ */
+export const parseSectionTargetCreateSelector = (
+  value: unknown
+): TransportValidationResult<SectionTargetCreateSelector> => {
+  const record = closedRecord(value, ["anchor", "line"]);
+  if (!record.ok) return record;
+
+  const hasAnchor = Object.hasOwn(record.value, "anchor");
+  const hasLine = Object.hasOwn(record.value, "line");
+  if (hasAnchor === hasLine) {
+    return invalid("Provide exactly one of anchor or line");
+  }
+
+  if (hasAnchor) {
+    const anchor = parseNonEmptyString(
+      record.value.anchor,
+      "anchor",
+      SECTION_TARGET_BOUNDS.anchorMaxChars
+    );
+    if (!anchor.ok) return anchor;
+    return { ok: true, value: { anchor: anchor.value } };
+  }
+
+  const line = parsePositiveInt(record.value.line, "line");
+  if (!line.ok) return line;
+  return { ok: true, value: { line: line.value } };
+};
+
+/**
+ * Validate an untrusted SectionTargetV1 before core resolve.
+ * Enforces closed shape, bounds, fingerprint format, and serialized size.
+ */
+export const parseSectionTargetV1 = (
+  value: unknown
+): TransportValidationResult<SectionTargetV1> => {
+  const record = closedRecord(value, [
+    "schemaVersion",
+    "document",
+    "anchor",
+    "headingPath",
+    "occurrence",
+    "quote",
+    "sourceFingerprint",
+    "hints",
+  ]);
+  if (!record.ok) return record;
+
+  if (record.value.schemaVersion !== SECTION_TARGET_SCHEMA_VERSION) {
+    return invalid('schemaVersion must be "1"');
+  }
+
+  const document = closedRecord(record.value.document, ["uri"]);
+  if (!document.ok) return invalid(`document: ${document.error}`);
+  const uri = parseNonEmptyString(
+    document.value.uri,
+    "document.uri",
+    SECTION_TARGET_BOUNDS.uriMaxChars
+  );
+  if (!uri.ok) return uri;
+
+  const anchor = parseNonEmptyString(
+    record.value.anchor,
+    "anchor",
+    SECTION_TARGET_BOUNDS.anchorMaxChars
+  );
+  if (!anchor.ok) return anchor;
+
+  if (!Array.isArray(record.value.headingPath)) {
+    return invalid("headingPath must be an array");
+  }
+  if (
+    record.value.headingPath.length < 1 ||
+    record.value.headingPath.length > SECTION_TARGET_BOUNDS.headingPathMaxItems
+  ) {
+    return invalid(
+      `headingPath must contain 1 to ${SECTION_TARGET_BOUNDS.headingPathMaxItems} items`
+    );
+  }
+  const headingPath: string[] = [];
+  for (const [index, item] of record.value.headingPath.entries()) {
+    const parsed = parseNonEmptyString(
+      item,
+      `headingPath[${index}]`,
+      SECTION_TARGET_BOUNDS.headingPathItemMaxChars
+    );
+    if (!parsed.ok) return parsed;
+    headingPath.push(parsed.value);
+  }
+
+  const occurrence = parsePositiveInt(record.value.occurrence, "occurrence");
+  if (!occurrence.ok) return occurrence;
+
+  const quoteRecord = closedRecord(record.value.quote, [
+    "exact",
+    "prefix",
+    "suffix",
+  ]);
+  if (!quoteRecord.ok) return invalid(`quote: ${quoteRecord.error}`);
+  const exact = parseBoundedString(
+    quoteRecord.value.exact,
+    "quote.exact",
+    SECTION_TARGET_BOUNDS.exactMaxChars
+  );
+  if (!exact.ok) return exact;
+  const prefix = parseBoundedString(
+    quoteRecord.value.prefix,
+    "quote.prefix",
+    SECTION_TARGET_BOUNDS.prefixMaxChars
+  );
+  if (!prefix.ok) return prefix;
+  const suffix = parseBoundedString(
+    quoteRecord.value.suffix,
+    "quote.suffix",
+    SECTION_TARGET_BOUNDS.suffixMaxChars
+  );
+  if (!suffix.ok) return suffix;
+
+  if (
+    typeof record.value.sourceFingerprint !== "string" ||
+    !FINGERPRINT_PATTERN.test(record.value.sourceFingerprint)
+  ) {
+    return invalid("sourceFingerprint must be a lowercase SHA-256 hex digest");
+  }
+
+  const hintsRecord = closedRecord(record.value.hints, [
+    "line",
+    "startOffset",
+    "endOffset",
+  ]);
+  if (!hintsRecord.ok) return invalid(`hints: ${hintsRecord.error}`);
+  const hintsLine = parsePositiveInt(hintsRecord.value.line, "hints.line");
+  if (!hintsLine.ok) return hintsLine;
+  const startOffset = parseNonNegativeInt(
+    hintsRecord.value.startOffset,
+    "hints.startOffset"
+  );
+  if (!startOffset.ok) return startOffset;
+  const endOffset = parseNonNegativeInt(
+    hintsRecord.value.endOffset,
+    "hints.endOffset"
+  );
+  if (!endOffset.ok) return endOffset;
+  if (endOffset.value < startOffset.value) {
+    return invalid("hints.endOffset must be >= hints.startOffset");
+  }
+
+  const target: SectionTargetV1 = {
+    schemaVersion: SECTION_TARGET_SCHEMA_VERSION,
+    document: { uri: uri.value },
+    anchor: anchor.value,
+    headingPath,
+    occurrence: occurrence.value,
+    quote: {
+      exact: exact.value,
+      prefix: prefix.value,
+      suffix: suffix.value,
+    },
+    sourceFingerprint: record.value.sourceFingerprint,
+    hints: {
+      line: hintsLine.value,
+      startOffset: startOffset.value,
+      endOffset: endOffset.value,
+    },
+  };
+
+  // Serialized-byte budget is owned by isBoundedSectionTarget — no recheck.
+  if (!isBoundedSectionTarget(target)) {
+    return invalid("Section target exceeds size bounds");
+  }
+
+  return { ok: true, value: target };
+};
+/** Resolve-body wrapper: `{ target: SectionTargetV1 }` only. */
+export const parseSectionTargetResolveBody = (
+  value: unknown
+): TransportValidationResult<{ target: SectionTargetV1 }> => {
+  const record = closedRecord(value, ["target"]);
+  if (!record.ok) return record;
+  if (!Object.hasOwn(record.value, "target")) {
+    return invalid("target is required");
+  }
+  const target = parseSectionTargetV1(record.value.target);
+  if (!target.ok) return target;
+  return { ok: true, value: { target: target.value } };
+};
+
+export const projectSectionTargetCreateResult = (
+  uri: string,
+  target: SectionTargetV1
+): SectionTargetCreateResult => ({
+  uri,
+  target,
+});
+
+const isBoundedTransportString = (
+  value: string,
+  minChars: number,
+  maxChars: number
+): boolean => value.length >= minChars && value.length <= maxChars;
+
+const isBoundedPositiveSafeInt = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 1;
+
+/**
+ * True when a canonical document URI fits top-level transport `uri` bounds.
+ * Adapters must reject before create/projection — never truncate or rewrite.
+ */
+export const isTransportBoundedCanonicalUri = (uri: string): boolean =>
+  isBoundedTransportString(uri, 1, SECTION_TARGET_BOUNDS.uriMaxChars);
+
+/** True when a candidate fits transport schema bounds without truncation. */
+export const isTransportBoundedCandidate = (
+  candidate: SectionResolutionCandidate
+): boolean =>
+  isBoundedTransportString(
+    candidate.anchor,
+    1,
+    SECTION_TARGET_BOUNDS.anchorMaxChars
+  ) &&
+  isBoundedTransportString(
+    candidate.title,
+    1,
+    SECTION_TARGET_TRANSPORT_BOUNDS.titleMaxChars
+  ) &&
+  isBoundedPositiveSafeInt(candidate.line) &&
+  isBoundedPositiveSafeInt(candidate.occurrence) &&
+  candidate.headingPath.length >= 1 &&
+  candidate.headingPath.length <= SECTION_TARGET_BOUNDS.headingPathMaxItems &&
+  candidate.headingPath.every((item) =>
+    isBoundedTransportString(
+      item,
+      1,
+      SECTION_TARGET_BOUNDS.headingPathItemMaxChars
+    )
+  );
+
+/** True when a citation fits transport schema bounds without truncation. */
+export const isTransportBoundedCitation = (
+  citation: SectionCitationV1
+): boolean =>
+  isBoundedTransportString(
+    citation.uri,
+    1,
+    SECTION_TARGET_BOUNDS.uriMaxChars
+  ) &&
+  isBoundedTransportString(
+    citation.anchor,
+    1,
+    SECTION_TARGET_BOUNDS.anchorMaxChars
+  ) &&
+  isBoundedTransportString(
+    citation.title,
+    1,
+    SECTION_TARGET_TRANSPORT_BOUNDS.titleMaxChars
+  ) &&
+  isBoundedPositiveSafeInt(citation.lineStart) &&
+  isBoundedPositiveSafeInt(citation.lineEnd) &&
+  citation.lineEnd >= citation.lineStart &&
+  FINGERPRINT_PATTERN.test(citation.sourceFingerprint);
+
+const projectDiagnostics = (
+  resolution: SectionResolution
+): SectionResolutionDiagnostics => {
+  const diagnostics: SectionResolutionDiagnostics = {};
+  if (
+    resolution.reason !== undefined &&
+    resolution.reason.length >= 1 &&
+    resolution.reason.length <= SECTION_TARGET_TRANSPORT_BOUNDS.reasonMaxChars
+  ) {
+    diagnostics.reason = resolution.reason;
+  }
+
+  if (resolution.candidates === undefined) {
+    return diagnostics;
+  }
+
+  const candidateCount = resolution.candidates.length;
+  const fitting = resolution.candidates.filter(isTransportBoundedCandidate);
+  const emitted = fitting.slice(
+    0,
+    SECTION_TARGET_TRANSPORT_BOUNDS.diagnosticsCandidatesMaxItems
+  );
+  diagnostics.candidates = emitted;
+  diagnostics.candidateCount = candidateCount;
+  diagnostics.candidatesTruncated = emitted.length < candidateCount;
+  return diagnostics;
+};
+
+export const projectSectionTargetResolveResult = (
+  uri: string,
+  resolution: SectionResolution
+): SectionTargetResolveResult => {
+  const diagnostics = projectDiagnostics(resolution);
+
+  if (isNavigableSectionResolution(resolution)) {
+    const citation: SectionCitationV1 = {
+      uri,
+      anchor: resolution.section.anchor,
+      title: resolution.section.title,
+      lineStart: resolution.section.line,
+      lineEnd: resolution.section.endLine,
+      sourceFingerprint: resolution.currentFingerprint,
+    };
+    if (isTransportBoundedCitation(citation)) {
+      return {
+        uri,
+        status: resolution.status,
+        currentFingerprint: resolution.currentFingerprint,
+        target: resolution.target,
+        diagnostics,
+        citation,
+      };
+    }
+    // Fail closed: never truncate identity or emit an unbound citation.
+    return {
+      uri,
+      status: "stale",
+      currentFingerprint: resolution.currentFingerprint,
+      target: resolution.target,
+      diagnostics: {
+        ...diagnostics,
+        reason: CITATION_EXCEEDS_TRANSPORT_BOUNDS,
+      },
+    };
+  }
+
+  return {
+    uri,
+    status: resolution.status,
+    currentFingerprint: resolution.currentFingerprint,
+    target: resolution.target,
+    diagnostics,
+  };
+};

--- a/src/core/section-target.ts
+++ b/src/core/section-target.ts
@@ -1,0 +1,263 @@
+/**
+ * Durable SectionTargetV1 types, bounds, and creation.
+ * Private helper module — import public API from `./sections`.
+ *
+ * @module src/core/section-target
+ */
+
+import {
+  extractSectionRecords,
+  lineStartOffsets,
+  type SectionRecord,
+} from "./section-parse";
+
+/** Versioned, bounded, content-derived section locator (v1). */
+export interface SectionTargetV1 {
+  schemaVersion: "1";
+  document: {
+    uri: string;
+  };
+  /** Human-readable heading anchor at capture time. */
+  anchor: string;
+  /** NFC-normalized heading ancestry including the section title. */
+  headingPath: string[];
+  /** 1-based occurrence among sections with the same headingPath. */
+  occurrence: number;
+  quote: {
+    exact: string;
+    prefix: string;
+    suffix: string;
+  };
+  /** SHA-256 hex fingerprint of the full source document content. */
+  sourceFingerprint: string;
+  /** Line/offset hints only — never identity. */
+  hints: {
+    line: number;
+    startOffset: number;
+    endOffset: number;
+  };
+}
+
+export const SECTION_TARGET_SCHEMA_VERSION = "1" as const;
+
+/**
+ * Hard bounds so targets never embed full section bodies and remain
+ * schema-faithful. Identity fields (uri/anchor/headingPath) are never
+ * truncated — creation fails closed when they cannot fit.
+ */
+export const SECTION_TARGET_BOUNDS = {
+  exactMaxChars: 96,
+  prefixMaxChars: 32,
+  suffixMaxChars: 32,
+  uriMaxChars: 1024,
+  anchorMaxChars: 512,
+  headingPathItemMaxChars: 512,
+  headingPathMaxItems: 6,
+  maxSerializedBytes: 2048,
+} as const;
+
+const UTF8 = new TextEncoder();
+
+/** Structural section record with bounded quote evidence. */
+export interface QuotedSectionRecord extends SectionRecord {
+  quote: {
+    exact: string;
+    prefix: string;
+    suffix: string;
+  };
+  quoteStartOffset: number;
+  quoteEndOffset: number;
+}
+
+const clipStart = (value: string, maxChars: number): string =>
+  value.length <= maxChars ? value : value.slice(0, maxChars);
+
+const clipEnd = (value: string, maxChars: number): string =>
+  value.length <= maxChars ? value : value.slice(value.length - maxChars);
+
+const bytesOf = (value: string): number => UTF8.encode(value).byteLength;
+
+/** SHA-256 hex digest via Web Crypto (browser- and Bun-safe). */
+export async function fingerprintSourceContent(
+  content: string
+): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", UTF8.encode(content))
+  );
+  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+const chooseQuoteRange = (
+  content: string,
+  recordTitleStart: number,
+  recordTitleEnd: number,
+  bodyStartOffset: number,
+  bodyEndOffset: number
+): { start: number; end: number } => {
+  const body = content.slice(bodyStartOffset, bodyEndOffset);
+  const trimmedLead = body.match(/^\s*/)?.[0]?.length ?? 0;
+  const trimmedTrail = body.match(/\s*$/)?.[0]?.length ?? 0;
+  const bodyContentStart = bodyStartOffset + trimmedLead;
+  const bodyContentEnd = Math.max(
+    bodyContentStart,
+    bodyEndOffset - trimmedTrail
+  );
+  if (bodyContentStart < bodyContentEnd) {
+    const exact = clipStart(
+      content.slice(bodyContentStart, bodyContentEnd),
+      SECTION_TARGET_BOUNDS.exactMaxChars
+    );
+    if (exact.length > 0) {
+      return {
+        start: bodyContentStart,
+        end: bodyContentStart + exact.length,
+      };
+    }
+  }
+  return { start: recordTitleStart, end: recordTitleEnd };
+};
+
+/**
+ * Prefer local context so heading renames / insertions do not poison prefix
+ * evidence. Falls back to a short global clip only when local context is empty.
+ */
+const buildBoundedQuote = (
+  content: string,
+  exactStart: number,
+  exactEnd: number,
+  localPrefixFloor: number
+): { exact: string; prefix: string; suffix: string } => {
+  const exact = clipStart(
+    content.slice(exactStart, exactEnd),
+    SECTION_TARGET_BOUNDS.exactMaxChars
+  );
+  const boundedEnd = exactStart + exact.length;
+  const localPrefix = content.slice(localPrefixFloor, exactStart);
+  const prefixSource =
+    localPrefix.length > 0 ? localPrefix : content.slice(0, exactStart);
+  return {
+    exact,
+    prefix: clipEnd(prefixSource, SECTION_TARGET_BOUNDS.prefixMaxChars),
+    suffix: clipStart(
+      content.slice(boundedEnd),
+      SECTION_TARGET_BOUNDS.suffixMaxChars
+    ),
+  };
+};
+
+/** Attach bounded quote evidence to structural section records. */
+export const withQuotes = (
+  content: string,
+  records: readonly SectionRecord[]
+): QuotedSectionRecord[] => {
+  const starts = lineStartOffsets(content);
+  return records.map((record) => {
+    const bodyStartOffset = starts[record.section.line] ?? content.length;
+    const bodyEndOffset =
+      record.endLine >= starts.length
+        ? content.length
+        : (starts[record.endLine] ?? content.length);
+    const quoteRange = chooseQuoteRange(
+      content,
+      record.titleStartOffset,
+      record.titleEndOffset,
+      bodyStartOffset,
+      bodyEndOffset
+    );
+    // Keep prefix local to the gap after the heading title (or markers before
+    // a title-only quote) so renames do not poison quote recovery.
+    const prefixFloor =
+      quoteRange.start >= record.titleEndOffset
+        ? record.titleEndOffset
+        : (starts[record.section.line - 1] ?? record.titleStartOffset);
+    return {
+      ...record,
+      quoteStartOffset: quoteRange.start,
+      quoteEndOffset: quoteRange.end,
+      quote: buildBoundedQuote(
+        content,
+        quoteRange.start,
+        quoteRange.end,
+        prefixFloor
+      ),
+    };
+  });
+};
+
+/**
+ * True when every identity/quote field and the UTF-8 JSON encoding satisfy
+ * runtime bounds. Identity fields must be present faithfully — never truncated.
+ */
+export const isBoundedSectionTarget = (target: SectionTargetV1): boolean => {
+  const { uri } = target.document;
+  if (
+    uri.length < 1 ||
+    uri.length > SECTION_TARGET_BOUNDS.uriMaxChars ||
+    target.anchor.length < 1 ||
+    target.anchor.length > SECTION_TARGET_BOUNDS.anchorMaxChars ||
+    target.headingPath.length < 1 ||
+    target.headingPath.length > SECTION_TARGET_BOUNDS.headingPathMaxItems ||
+    target.headingPath.some(
+      (item) =>
+        item.length < 1 ||
+        item.length > SECTION_TARGET_BOUNDS.headingPathItemMaxChars
+    ) ||
+    target.quote.exact.length > SECTION_TARGET_BOUNDS.exactMaxChars ||
+    target.quote.prefix.length > SECTION_TARGET_BOUNDS.prefixMaxChars ||
+    target.quote.suffix.length > SECTION_TARGET_BOUNDS.suffixMaxChars
+  ) {
+    return false;
+  }
+  return (
+    bytesOf(JSON.stringify(target)) <= SECTION_TARGET_BOUNDS.maxSerializedBytes
+  );
+};
+
+export interface CreateSectionTargetInput {
+  content: string;
+  uri: string;
+  /** Capture by current readable anchor, or by 1-based heading line. */
+  anchor?: string;
+  line?: number;
+}
+
+/**
+ * Create a bounded SectionTargetV1 for a heading in `content`.
+ * Returns null when the section cannot be found, or when a faithful
+ * bounded target cannot be produced (oversized uri/anchor/path/serialized).
+ */
+export async function createSectionTarget(
+  input: CreateSectionTargetInput
+): Promise<SectionTargetV1 | null> {
+  const records = withQuotes(
+    input.content,
+    extractSectionRecords(input.content)
+  );
+  const record =
+    input.anchor !== undefined
+      ? records.find((entry) => entry.section.anchor === input.anchor)
+      : input.line !== undefined
+        ? records.find((entry) => entry.section.line === input.line)
+        : undefined;
+  if (!record) return null;
+
+  const sourceFingerprint = await fingerprintSourceContent(input.content);
+  const target: SectionTargetV1 = {
+    schemaVersion: SECTION_TARGET_SCHEMA_VERSION,
+    document: { uri: input.uri },
+    anchor: record.section.anchor,
+    headingPath: [...record.headingPath],
+    occurrence: record.occurrence,
+    quote: { ...record.quote },
+    sourceFingerprint,
+    hints: {
+      line: record.section.line,
+      startOffset: record.quoteStartOffset,
+      endOffset: record.quoteEndOffset,
+    },
+  };
+
+  // Fail closed: never truncate identity-bearing uri/anchor/path.
+  if (!isBoundedSectionTarget(target)) return null;
+  return target;
+}

--- a/src/core/sections.ts
+++ b/src/core/sections.ts
@@ -1,125 +1,38 @@
 /**
- * Shared section extraction and anchor helpers.
+ * Shared section extraction, anchors, and durable section targets.
  *
- * Browser-safe.
+ * Browser-safe (Web Crypto + standard string APIs only).
  *
  * @module src/core/sections
  */
 
-export interface DocumentSection {
-  anchor: string;
-  level: number;
-  line: number;
-  title: string;
-}
+export type { DocumentSection } from "./section-parse";
+export {
+  extractInclusiveLines,
+  extractSections,
+  headingForLine,
+  slugifySectionTitle,
+} from "./section-parse";
 
-const HEADING_REGEX = /^(#{1,6})\s+(.+?)\s*#*\s*$/u;
-const FENCE_REGEX = /^ {0,3}(`{3,}|~{3,})(.*)$/u;
-const FENCE_CLOSE_REGEX = /^ {0,3}(`{3,}|~{3,})[\t ]*$/u;
+export type {
+  CreateSectionTargetInput,
+  SectionTargetV1,
+} from "./section-target";
+export {
+  SECTION_TARGET_BOUNDS,
+  SECTION_TARGET_SCHEMA_VERSION,
+  createSectionTarget,
+  fingerprintSourceContent,
+  isBoundedSectionTarget,
+} from "./section-target";
 
-interface OpenFence {
-  marker: "`" | "~";
-  length: number;
-}
-
-const fenceOpener = (line: string): OpenFence | null => {
-  const match = FENCE_REGEX.exec(line);
-  const run = match?.[1];
-  const suffix = match?.[2] ?? "";
-  if (!run || (run[0] === "`" && suffix.includes("`"))) return null;
-  return { marker: run[0] as OpenFence["marker"], length: run.length };
-};
-
-const closesFence = (line: string, fence: OpenFence): boolean => {
-  const run = FENCE_CLOSE_REGEX.exec(line)?.[1];
-  return Boolean(run && run[0] === fence.marker && run.length >= fence.length);
-};
-
-export function slugifySectionTitle(title: string): string {
-  return (
-    title
-      .normalize("NFC")
-      .toLowerCase()
-      .trim()
-      .replaceAll(/[^\p{L}\p{N}\s-]/gu, "")
-      .replaceAll(/\s+/g, "-")
-      .replaceAll(/-+/g, "-")
-      .replace(/^-|-$/g, "") || "section"
-  );
-}
-
-export function extractSections(content: string): DocumentSection[] {
-  const sections: DocumentSection[] = [];
-  const counts = new Map<string, number>();
-  const lines = content.split("\n");
-  let openFence: OpenFence | null = null;
-
-  for (const [index, line] of lines.entries()) {
-    if (openFence) {
-      if (closesFence(line, openFence)) openFence = null;
-      continue;
-    }
-    const opener = fenceOpener(line);
-    if (opener) {
-      openFence = opener;
-      continue;
-    }
-    const match = HEADING_REGEX.exec(line);
-    if (!match) {
-      continue;
-    }
-
-    const level = match[1]?.length ?? 0;
-    const title = match[2]?.trim() ?? "";
-    if (!title) {
-      continue;
-    }
-
-    const baseAnchor = slugifySectionTitle(title);
-    const count = (counts.get(baseAnchor) ?? 0) + 1;
-    counts.set(baseAnchor, count);
-    const anchor = count === 1 ? baseAnchor : `${baseAnchor}-${count}`;
-
-    sections.push({
-      anchor,
-      level,
-      line: index + 1,
-      title,
-    });
-  }
-
-  return sections;
-}
-
-/** Extract one inclusive, 1-based line range without normalizing source bytes. */
-export function extractInclusiveLines(
-  content: string,
-  startLine: number,
-  endLine: number
-): string | null {
-  if (
-    content.includes("\r") ||
-    !Number.isSafeInteger(startLine) ||
-    !Number.isSafeInteger(endLine) ||
-    startLine < 1 ||
-    endLine < startLine
-  ) {
-    return null;
-  }
-  const lines = content.split("\n");
-  if (endLine > lines.length) return null;
-  return lines.slice(startLine - 1, endLine).join("\n");
-}
-
-/** Find the nearest Markdown heading governing a 1-based source line. */
-export function headingForLine(
-  sections: readonly DocumentSection[],
-  line: number
-): string | null {
-  let heading: string | null = null;
-  for (const section of sections) {
-    if (section.line > line) break;
-    heading = section.title;
-  }
-  return heading;
-}
+export type {
+  ResolveSectionTargetInput,
+  SectionResolution,
+  SectionResolutionCandidate,
+  SectionResolutionStatus,
+} from "./section-target-resolve";
+export {
+  isNavigableSectionResolution,
+  resolveSectionTarget,
+} from "./section-target-resolve";

--- a/src/core/sections.ts
+++ b/src/core/sections.ts
@@ -58,3 +58,13 @@ export {
   projectSectionTargetCreateResult,
   projectSectionTargetResolveResult,
 } from "./section-target-transport";
+
+export type { SectionTargetLinkDecodeFailure } from "./section-target-link";
+export {
+  SECTION_TARGET_LINK_MAX_ENCODED_CHARS,
+  SECTION_TARGET_LINK_PARAM,
+  SECTION_TARGET_LINK_VERSION,
+  classifySectionTargetLinkDecodeFailure,
+  decodeSectionTargetLinkParam,
+  encodeSectionTargetLinkParam,
+} from "./section-target-link";

--- a/src/core/sections.ts
+++ b/src/core/sections.ts
@@ -36,3 +36,25 @@ export {
   isNavigableSectionResolution,
   resolveSectionTarget,
 } from "./section-target-resolve";
+
+export type {
+  SectionCitationV1,
+  SectionResolutionDiagnostics,
+  SectionTargetCreateResult,
+  SectionTargetCreateSelector,
+  SectionTargetResolveResult,
+  TransportValidationResult,
+} from "./section-target-transport";
+export {
+  CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+  CITATION_EXCEEDS_TRANSPORT_BOUNDS,
+  SECTION_TARGET_TRANSPORT_BOUNDS,
+  isTransportBoundedCandidate,
+  isTransportBoundedCanonicalUri,
+  isTransportBoundedCitation,
+  parseSectionTargetCreateSelector,
+  parseSectionTargetResolveBody,
+  parseSectionTargetV1,
+  projectSectionTargetCreateResult,
+  projectSectionTargetResolveResult,
+} from "./section-target-transport";

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -13,6 +13,7 @@ src/mcp/
 │   ├── vsearch.ts     # gno_vsearch (vector)
 │   ├── query.ts       # gno_query (hybrid)
 │   ├── get.ts         # gno_get (single doc)
+│   ├── sections.ts    # gno_section (section target create/resolve)
 │   ├── multi-get.ts   # gno_multi_get (batch)
 │   └── status.ts      # gno_status
 └── resources/         # Resource implementations

--- a/src/mcp/CLAUDE.md
+++ b/src/mcp/CLAUDE.md
@@ -13,6 +13,7 @@ src/mcp/
 │   ├── vsearch.ts     # gno_vsearch (vector)
 │   ├── query.ts       # gno_query (hybrid)
 │   ├── get.ts         # gno_get (single doc)
+│   ├── sections.ts    # gno_section (section target create/resolve)
 │   ├── multi-get.ts   # gno_multi_get (batch)
 │   └── status.ts      # gno_status
 └── resources/         # Resource implementations

--- a/src/mcp/http-egress.ts
+++ b/src/mcp/http-egress.ts
@@ -53,6 +53,7 @@ export const MCP_HTTP_EGRESS_TOOLS = {
   gno_remove_collection: "metadata",
   gno_rename_note: "metadata",
   gno_search: "snippet",
+  gno_section: "metadata",
   gno_similar: "snippet",
   gno_status: "metadata",
   gno_sync: "metadata",

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -67,6 +67,12 @@ import { handleMultiGet } from "./multi-get";
 import { handleQuery, handleQueryDiagnose } from "./query";
 import { handleRemoveCollection } from "./remove-collection";
 import { handleSearch } from "./search";
+import {
+  handleSection,
+  SECTION_MCP_ANNOTATIONS,
+  sectionInputSchema,
+  sectionOutputSchema,
+} from "./sections";
 import { handleStatus } from "./status";
 import { handleSync } from "./sync";
 import {
@@ -116,6 +122,8 @@ export const MCP_TOOL_DESCRIPTIONS = {
   get: "Retrieve one document by gno:// URI, docid (#abc123), or collection/path. After search results include line, pass fromLine and lineCount to fetch only the relevant range before expanding to the full document.",
   multiGet:
     "Retrieve multiple documents by refs array or glob pattern. Use after gno_search/gno_query to batch top result URIs/docids; set maxBytes and lineNumbers to control context size.",
+  section:
+    "Create or resolve a durable SectionTargetV1 against one indexed document. action=create needs ref plus exactly one of anchor|line; action=resolve needs ref plus target. Exact/recovered include citation (uri, anchor, title, inclusive lines, fingerprint); ambiguous/stale/missing omit citation and are not safe to navigate or cite. Read-only — does not write or persist targets. Follow navigable ranges with gno_get fromLine/lineCount.",
   status:
     "Get index health: collection count, document count, chunk count, embedding backlog, and per-collection stats. Check first when vector/hybrid results look stale or unavailable.",
   context:
@@ -1062,6 +1070,17 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
     MCP_TOOL_DESCRIPTIONS.get,
     getInputSchema.shape,
     (args) => handleGet(args, ctx)
+  );
+
+  server.registerTool(
+    "gno_section",
+    {
+      description: MCP_TOOL_DESCRIPTIONS.section,
+      inputSchema: sectionInputSchema,
+      outputSchema: sectionOutputSchema,
+      annotations: SECTION_MCP_ANNOTATIONS,
+    },
+    (args) => handleSection(args, ctx)
   );
 
   server.tool(

--- a/src/mcp/tools/sections.ts
+++ b/src/mcp/tools/sections.ts
@@ -1,0 +1,512 @@
+/**
+ * MCP gno_section — read-only section target create/resolve.
+ *
+ * Always registered. No writes, no target persistence, no parser fork.
+ * Consumes shared core create/resolve + transport projection (fn-61.6).
+ *
+ * @module src/mcp/tools/sections
+ */
+
+import { z } from "zod";
+
+import type { DocumentRow } from "../../store/types";
+import type { ToolContext } from "../server";
+
+import { MCP_ERRORS } from "../../core/errors";
+import { parseRef } from "../../core/ref-parser";
+import {
+  CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+  createSectionTarget,
+  extractSections,
+  isBoundedSectionTarget,
+  isTransportBoundedCanonicalUri,
+  parseSectionTargetCreateSelector,
+  parseSectionTargetV1,
+  projectSectionTargetCreateResult,
+  projectSectionTargetResolveResult,
+  resolveSectionTarget,
+  SECTION_TARGET_BOUNDS,
+  type SectionCitationV1,
+  type SectionResolutionDiagnostics,
+  type SectionResolutionStatus,
+  type SectionTargetV1,
+} from "../../core/sections";
+import { runTool, type ToolResult } from "./index";
+
+export const SECTION_MCP_SCHEMA_VERSION = "1.0" as const;
+
+const FINGERPRINT_PATTERN = /^[a-f0-9]{64}$/;
+const REF_MAX_CHARS = 2048;
+
+const positiveSafeInt = z.number().int().min(1).max(Number.MAX_SAFE_INTEGER);
+
+const boundedNonEmpty = (max: number) => z.string().min(1).max(max);
+
+/**
+ * Closed SectionTargetV1 Zod mirror for MCP SDK validation.
+ * Object (not union) so McpServer can publish/normalize JSON Schema.
+ * Field bounds stay JSON-schema-compatible; cross-field rules via superRefine.
+ */
+export const sectionTargetInputSchema = z
+  .object({
+    schemaVersion: z.literal("1"),
+    document: z
+      .object({
+        uri: boundedNonEmpty(SECTION_TARGET_BOUNDS.uriMaxChars),
+      })
+      .strict(),
+    anchor: boundedNonEmpty(SECTION_TARGET_BOUNDS.anchorMaxChars),
+    headingPath: z
+      .array(boundedNonEmpty(SECTION_TARGET_BOUNDS.headingPathItemMaxChars))
+      .min(1)
+      .max(SECTION_TARGET_BOUNDS.headingPathMaxItems),
+    occurrence: positiveSafeInt,
+    quote: z
+      .object({
+        exact: z.string().max(SECTION_TARGET_BOUNDS.exactMaxChars),
+        prefix: z.string().max(SECTION_TARGET_BOUNDS.prefixMaxChars),
+        suffix: z.string().max(SECTION_TARGET_BOUNDS.suffixMaxChars),
+      })
+      .strict(),
+    sourceFingerprint: z.string().regex(FINGERPRINT_PATTERN),
+    hints: z
+      .object({
+        line: positiveSafeInt,
+        startOffset: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+        endOffset: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((target, ctx) => {
+    if (target.hints.endOffset < target.hints.startOffset) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["hints", "endOffset"],
+        message: "hints.endOffset must be >= hints.startOffset",
+      });
+    }
+    if (!isBoundedSectionTarget(target as SectionTargetV1)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Section target exceeds size bounds",
+      });
+    }
+  });
+
+const refSchema = boundedNonEmpty(REF_MAX_CHARS).describe(
+  "Document reference: gno:// URI, collection/path, or #docid"
+);
+
+/**
+ * Closed create/resolve input. Single object schema (MCP SDK cannot list/validate
+ * Zod unions as tool inputSchema/outputSchema).
+ */
+export const sectionInputSchema = z
+  .object({
+    action: z.enum(["create", "resolve"]),
+    ref: refSchema,
+    anchor: boundedNonEmpty(SECTION_TARGET_BOUNDS.anchorMaxChars).optional(),
+    line: positiveSafeInt.optional(),
+    target: sectionTargetInputSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.action === "create") {
+      const hasAnchor = value.anchor !== undefined;
+      const hasLine = value.line !== undefined;
+      if (hasAnchor === hasLine) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "create requires exactly one of anchor|line",
+        });
+      }
+      if (value.target !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["target"],
+          message: "create forbids target",
+        });
+      }
+      return;
+    }
+    if (value.target === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["target"],
+        message: "resolve requires target",
+      });
+    }
+    if (value.anchor !== undefined || value.line !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "resolve forbids anchor|line",
+      });
+    }
+  });
+
+export type SectionInput = z.infer<typeof sectionInputSchema>;
+
+const citationSchema = z
+  .object({
+    uri: boundedNonEmpty(SECTION_TARGET_BOUNDS.uriMaxChars),
+    anchor: boundedNonEmpty(SECTION_TARGET_BOUNDS.anchorMaxChars),
+    title: boundedNonEmpty(SECTION_TARGET_BOUNDS.anchorMaxChars),
+    lineStart: positiveSafeInt,
+    lineEnd: positiveSafeInt,
+    sourceFingerprint: z.string().regex(FINGERPRINT_PATTERN),
+  })
+  .strict()
+  .superRefine((citation, ctx) => {
+    if (citation.lineEnd < citation.lineStart) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["lineEnd"],
+        message: "citation.lineEnd must be >= citation.lineStart",
+      });
+    }
+  });
+
+const diagnosticsSchema = z
+  .object({
+    reason: z.string().min(1).max(256).optional(),
+    candidates: z
+      .array(
+        z
+          .object({
+            anchor: boundedNonEmpty(SECTION_TARGET_BOUNDS.anchorMaxChars),
+            line: positiveSafeInt,
+            title: boundedNonEmpty(SECTION_TARGET_BOUNDS.anchorMaxChars),
+            headingPath: z
+              .array(
+                boundedNonEmpty(SECTION_TARGET_BOUNDS.headingPathItemMaxChars)
+              )
+              .min(1)
+              .max(SECTION_TARGET_BOUNDS.headingPathMaxItems),
+            occurrence: positiveSafeInt,
+          })
+          .strict()
+      )
+      .max(32)
+      .optional(),
+    candidateCount: z
+      .number()
+      .int()
+      .min(0)
+      .max(Number.MAX_SAFE_INTEGER)
+      .optional(),
+    candidatesTruncated: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((diagnostics, ctx) => {
+    const hasCandidates = diagnostics.candidates !== undefined;
+    const hasCount = diagnostics.candidateCount !== undefined;
+    const hasTruncated = diagnostics.candidatesTruncated !== undefined;
+    if (hasCandidates || hasCount || hasTruncated) {
+      if (!(hasCandidates && hasCount && hasTruncated)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "diagnostics candidates, candidateCount, and candidatesTruncated are co-required",
+        });
+      }
+    }
+  });
+
+/**
+ * SDK-validated structured output for gno_section.
+ * Single object (not union) so McpServer can publish/validate outputSchema.
+ */
+export const sectionOutputSchema = z
+  .object({
+    schemaVersion: z.literal(SECTION_MCP_SCHEMA_VERSION),
+    action: z.enum(["create", "resolve"]),
+    uri: boundedNonEmpty(SECTION_TARGET_BOUNDS.uriMaxChars),
+    target: sectionTargetInputSchema,
+    status: z
+      .enum(["exact", "recovered", "ambiguous", "stale", "missing"])
+      .optional(),
+    currentFingerprint: z.string().regex(FINGERPRINT_PATTERN).optional(),
+    diagnostics: diagnosticsSchema.optional(),
+    citation: citationSchema.optional(),
+  })
+  .strict()
+  .superRefine((result, ctx) => {
+    if (result.action === "create") {
+      if (
+        result.status !== undefined ||
+        result.currentFingerprint !== undefined ||
+        result.diagnostics !== undefined ||
+        result.citation !== undefined
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "create result forbids resolve-only fields",
+        });
+      }
+      return;
+    }
+    if (
+      result.status === undefined ||
+      result.currentFingerprint === undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "resolve requires status and currentFingerprint",
+      });
+      return;
+    }
+    if (result.diagnostics === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["diagnostics"],
+        message: "resolve requires diagnostics",
+      });
+    }
+    const navigable =
+      result.status === "exact" || result.status === "recovered";
+    if (navigable && result.citation === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["citation"],
+        message: "exact/recovered require citation",
+      });
+    }
+    if (!navigable && result.citation !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["citation"],
+        message: "ambiguous/stale/missing forbid citation",
+      });
+    }
+  });
+
+export type SectionMcpResult = z.infer<typeof sectionOutputSchema>;
+
+export const SECTION_MCP_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
+
+async function lookupDocument(
+  ctx: ToolContext,
+  ref: string
+): Promise<
+  { ok: true; doc: DocumentRow } | { ok: false; code: string; message: string }
+> {
+  const parsed = parseRef(ref);
+  if ("error" in parsed) {
+    return {
+      ok: false,
+      code: MCP_ERRORS.INVALID_INPUT.code,
+      message: `Invalid ref format: ${parsed.error}`,
+    };
+  }
+
+  let doc: DocumentRow | null = null;
+  switch (parsed.type) {
+    case "docid": {
+      const result = await ctx.store.getDocumentByDocid(parsed.value);
+      doc = result.ok ? result.value : null;
+      break;
+    }
+    case "uri": {
+      const result = await ctx.store.getDocumentByUri(parsed.value);
+      doc = result.ok ? result.value : null;
+      break;
+    }
+    case "collPath": {
+      if (!(parsed.collection && parsed.relPath)) {
+        return {
+          ok: false,
+          code: MCP_ERRORS.INVALID_INPUT.code,
+          message: "Invalid collection/path format",
+        };
+      }
+      const canonical = ctx.collections.find(
+        (c) => c.name.toLowerCase() === parsed.collection!.toLowerCase()
+      );
+      const collectionName = canonical?.name ?? parsed.collection;
+      const result = await ctx.store.getDocument(
+        collectionName,
+        parsed.relPath
+      );
+      doc = result.ok ? result.value : null;
+      break;
+    }
+  }
+
+  if (!doc) {
+    return {
+      ok: false,
+      code: MCP_ERRORS.NOT_FOUND.code,
+      message: `Document not found: ${ref}`,
+    };
+  }
+  return { ok: true, doc };
+}
+
+async function loadIndexedContent(
+  ctx: ToolContext,
+  ref: string
+): Promise<{ doc: DocumentRow; content: string }> {
+  const lookup = await lookupDocument(ctx, ref);
+  if (!lookup.ok) {
+    throw new Error(`${lookup.code}: ${lookup.message}`);
+  }
+  const { doc } = lookup;
+  if (!doc.mirrorHash) {
+    throw new Error(
+      `${MCP_ERRORS.NOT_FOUND.code}: Document content unavailable`
+    );
+  }
+  const contentResult = await ctx.store.getContent(doc.mirrorHash);
+  if (!contentResult.ok || contentResult.value === null) {
+    throw new Error("RUNTIME: Mirror content unavailable");
+  }
+  if (!isTransportBoundedCanonicalUri(doc.uri)) {
+    throw new Error(`VALIDATION: ${CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS}`);
+  }
+  return { doc, content: contentResult.value };
+}
+
+function formatSectionResult(data: SectionMcpResult): string {
+  const json = JSON.stringify(data, null, 2);
+  if (data.action === "create") {
+    return [
+      `Created section target for ${data.uri} (anchor=${data.target.anchor}, line=${data.target.hints.line}).`,
+      "",
+      json,
+    ].join("\n");
+  }
+
+  if (data.citation) {
+    const citation: SectionCitationV1 = data.citation;
+    const lineCount = citation.lineEnd - citation.lineStart + 1;
+    return [
+      `Resolved section (${data.status}) in ${citation.uri}: ${citation.title} (#${citation.anchor}), lines ${citation.lineStart}-${citation.lineEnd}.`,
+      `Follow up with gno_get: {"ref":${JSON.stringify(citation.uri)},"fromLine":${citation.lineStart},"lineCount":${lineCount}}`,
+      "",
+      json,
+    ].join("\n");
+  }
+
+  const status = data.status as SectionResolutionStatus;
+  return [
+    `Section resolution status is ${status}; this result is not safe to navigate or cite.`,
+    "",
+    json,
+  ].join("\n");
+}
+
+async function handleCreate(
+  ctx: ToolContext,
+  ref: string,
+  selectorRaw: { anchor?: string; line?: number }
+): Promise<SectionMcpResult> {
+  const selector = parseSectionTargetCreateSelector(selectorRaw);
+  if (!selector.ok) {
+    throw new Error(`VALIDATION: ${selector.error}`);
+  }
+
+  const { doc, content } = await loadIndexedContent(ctx, ref);
+  const target = await createSectionTarget({
+    content,
+    uri: doc.uri,
+    ...selector.value,
+  });
+
+  if (!target) {
+    const sections = extractSections(content);
+    const matched =
+      selector.value.anchor !== undefined
+        ? sections.some((section) => section.anchor === selector.value.anchor)
+        : sections.some((section) => section.line === selector.value.line);
+    if (!matched) {
+      throw new Error(`${MCP_ERRORS.NOT_FOUND.code}: Section not found`);
+    }
+    throw new Error("VALIDATION: Section target exceeds size bounds");
+  }
+
+  const projected = projectSectionTargetCreateResult(doc.uri, target);
+  return {
+    schemaVersion: SECTION_MCP_SCHEMA_VERSION,
+    action: "create",
+    ...projected,
+  };
+}
+
+async function handleResolve(
+  ctx: ToolContext,
+  ref: string,
+  targetRaw: unknown
+): Promise<SectionMcpResult> {
+  const parsed = parseSectionTargetV1(targetRaw);
+  if (!parsed.ok) {
+    throw new Error(`VALIDATION: ${parsed.error}`);
+  }
+
+  const { doc, content } = await loadIndexedContent(ctx, ref);
+  const resolution = await resolveSectionTarget({
+    content,
+    target: parsed.value,
+    uri: doc.uri,
+  });
+  const projected = projectSectionTargetResolveResult(doc.uri, resolution);
+
+  if (projected.citation) {
+    return {
+      schemaVersion: SECTION_MCP_SCHEMA_VERSION,
+      action: "resolve",
+      uri: projected.uri,
+      status: projected.status as "exact" | "recovered",
+      currentFingerprint: projected.currentFingerprint,
+      target: projected.target,
+      diagnostics: projected.diagnostics as SectionResolutionDiagnostics,
+      citation: projected.citation,
+    };
+  }
+
+  return {
+    schemaVersion: SECTION_MCP_SCHEMA_VERSION,
+    action: "resolve",
+    uri: projected.uri,
+    status: projected.status as "ambiguous" | "stale" | "missing",
+    currentFingerprint: projected.currentFingerprint,
+    target: projected.target,
+    diagnostics: projected.diagnostics as SectionResolutionDiagnostics,
+  };
+}
+
+/**
+ * Handle gno_section tool call. Read-only — never mutates store or disk.
+ */
+export function handleSection(
+  args: SectionInput,
+  ctx: ToolContext
+): Promise<ToolResult> {
+  return runTool(
+    ctx,
+    "gno_section",
+    async () => {
+      if (args.action === "create") {
+        if (args.anchor !== undefined) {
+          return handleCreate(ctx, args.ref, { anchor: args.anchor });
+        }
+        if (args.line !== undefined) {
+          return handleCreate(ctx, args.ref, { line: args.line });
+        }
+        throw new Error(
+          "VALIDATION: create requires exactly one of anchor|line"
+        );
+      }
+      if (args.target === undefined) {
+        throw new Error("VALIDATION: resolve requires target");
+      }
+      return handleResolve(ctx, args.ref, args.target);
+    },
+    formatSectionResult
+  );
+}

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -47,6 +47,10 @@ import type {
   KnowledgeImpactInput,
   KnowledgeImpactResult,
   ListKnowledgeChangesInput,
+  SectionTargetCreateResult,
+  SectionTargetCreateSelector,
+  SectionTargetResolveResult,
+  SectionTargetV1,
 } from "./types";
 
 import {
@@ -122,7 +126,17 @@ import {
   RETRIEVAL_TRACE_METADATA,
   type RetrievalTraceSession,
 } from "../core/retrieval-trace-session";
-import { extractSections } from "../core/sections";
+import {
+  CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+  createSectionTarget as createSectionTargetCore,
+  extractSections,
+  isTransportBoundedCanonicalUri,
+  parseSectionTargetCreateSelector,
+  parseSectionTargetV1,
+  projectSectionTargetCreateResult,
+  projectSectionTargetResolveResult,
+  resolveSectionTarget as resolveSectionTargetCore,
+} from "../core/sections";
 import { normalizeStructuredQueryInput } from "../core/structured-query";
 import { parseAndValidateTagFilter } from "../core/tags";
 import {
@@ -1833,6 +1847,62 @@ class GnoClientImpl implements GnoClient {
     this.assertOpen();
     const document = await getDocumentByRef(this.store, this.config, ref, {});
     return extractSections(document.content);
+  }
+
+  async createSectionTarget(
+    ref: string,
+    selector: SectionTargetCreateSelector
+  ): Promise<SectionTargetCreateResult> {
+    this.assertOpen();
+    const parsed = parseSectionTargetCreateSelector(selector);
+    if (!parsed.ok) {
+      throw sdkError("VALIDATION", parsed.error);
+    }
+    const document = await getDocumentByRef(this.store, this.config, ref, {});
+    // Top-level response uri shares schema maxLength — reject before create.
+    if (!isTransportBoundedCanonicalUri(document.uri)) {
+      throw sdkError("VALIDATION", CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS);
+    }
+    // Canonical identity from stored document — never from caller.
+    const target = await createSectionTargetCore({
+      content: document.content,
+      uri: document.uri,
+      ...parsed.value,
+    });
+    if (!target) {
+      const sections = extractSections(document.content);
+      const matched =
+        parsed.value.anchor !== undefined
+          ? sections.some((section) => section.anchor === parsed.value.anchor)
+          : sections.some((section) => section.line === parsed.value.line);
+      if (!matched) {
+        throw sdkError("NOT_FOUND", "Section not found");
+      }
+      throw sdkError("VALIDATION", "Section target exceeds size bounds");
+    }
+    return projectSectionTargetCreateResult(document.uri, target);
+  }
+
+  async resolveSectionTarget(
+    ref: string,
+    target: SectionTargetV1
+  ): Promise<SectionTargetResolveResult> {
+    this.assertOpen();
+    const parsed = parseSectionTargetV1(target);
+    if (!parsed.ok) {
+      throw sdkError("VALIDATION", parsed.error);
+    }
+    const document = await getDocumentByRef(this.store, this.config, ref, {});
+    // Top-level uri must fit schema — citation fail-closed does not repair it.
+    if (!isTransportBoundedCanonicalUri(document.uri)) {
+      throw sdkError("VALIDATION", CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS);
+    }
+    const resolution = await resolveSectionTargetCore({
+      content: document.content,
+      target: parsed.value,
+      uri: document.uri,
+    });
+    return projectSectionTargetResolveResult(document.uri, resolution);
   }
 
   async close(): Promise<void> {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -28,6 +28,7 @@ export type { IndexStatus } from "../store/types";
 export { GnoSdkError, sdkError } from "./errors";
 export { createGnoClient } from "./client";
 export type {
+  DocumentSection,
   GnoAskOptions,
   GnoCaptureOptions,
   GnoCaptureResult,
@@ -64,6 +65,10 @@ export type {
   KnowledgeImpactInput,
   KnowledgeImpactResult,
   ListKnowledgeChangesInput,
+  SectionTargetCreateResult,
+  SectionTargetCreateSelector,
+  SectionTargetResolveResult,
+  SectionTargetV1,
 } from "./types";
 export {
   ContextCapsuleContractError,

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -52,7 +52,13 @@ import type {
   RetrievalTraceListResult,
   RetrievalTracePurgeResult as RetrievalTraceManagementPurgeResult,
 } from "../core/retrieval-trace-management";
-import type { DocumentSection } from "../core/sections";
+import type {
+  DocumentSection,
+  SectionTargetCreateResult,
+  SectionTargetCreateSelector,
+  SectionTargetResolveResult,
+  SectionTargetV1,
+} from "../core/sections";
 import type { SyncResult } from "../ingestion";
 import type { DownloadPolicy } from "../llm/policy";
 import type {
@@ -67,10 +73,15 @@ import type { IndexStatus } from "../store/types";
 export type {
   AskResult,
   Config,
+  DocumentSection,
   DownloadPolicy,
   IndexStatus,
   SearchOptions,
   SearchResults,
+  SectionTargetCreateResult,
+  SectionTargetCreateSelector,
+  SectionTargetResolveResult,
+  SectionTargetV1,
   SyncResult,
 };
 export type { AskOptions, HybridSearchOptions } from "../pipeline/types";
@@ -345,5 +356,22 @@ export interface GnoClient {
     options: GnoDuplicateNoteOptions
   ): Promise<GnoRefactorNoteResult>;
   getSections(ref: string): Promise<DocumentSection[]>;
+  /**
+   * Create a durable SectionTargetV1 for a heading in a stored document.
+   * Provide exactly one of `anchor` or `line`. Canonical URI comes from the
+   * resolved stored document, never from the caller.
+   */
+  createSectionTarget(
+    ref: string,
+    selector: SectionTargetCreateSelector
+  ): Promise<SectionTargetCreateResult>;
+  /**
+   * Conservatively resolve a SectionTargetV1 against a stored document.
+   * Navigable results include citation evidence; ambiguous/stale/missing do not.
+   */
+  resolveSectionTarget(
+    ref: string,
+    target: SectionTargetV1
+  ): Promise<SectionTargetResolveResult>;
   close(): Promise<void>;
 }

--- a/src/serve/public/lib/section-links.ts
+++ b/src/serve/public/lib/section-links.ts
@@ -1,0 +1,189 @@
+/**
+ * Readable section deep links and optional citation-safe selectors.
+ *
+ * Copy-link stays human-readable (`#anchor` only). Citation links add a
+ * bounded, versioned `st` query param for conservative recovery.
+ *
+ * @module src/serve/public/lib/section-links
+ */
+
+import {
+  createSectionTarget,
+  decodeSectionTargetLinkParam,
+  encodeSectionTargetLinkParam,
+  isNavigableSectionResolution,
+  resolveSectionTarget,
+  SECTION_TARGET_LINK_PARAM,
+  type SectionResolutionStatus,
+  type SectionTargetV1,
+} from "../../../core/sections";
+import { buildDocDeepLink, type DocumentDeepLinkTarget } from "./deep-links";
+
+export interface SectionLinkTarget extends DocumentDeepLinkTarget {
+  /** Readable heading anchor (HTML id). */
+  anchor: string;
+}
+
+export type SectionLinkNoticeKind =
+  | "copied_link"
+  | "copied_citation"
+  | "citation_unavailable"
+  | "clipboard_unavailable"
+  | SectionResolutionStatus
+  | "invalid_citation";
+
+/** Ephemeral, content-free status copy for outline/rail feedback. */
+export const SECTION_LINK_NOTICE_COPY: Record<SectionLinkNoticeKind, string> = {
+  copied_link: "Copied section link",
+  copied_citation: "Copied citation link",
+  citation_unavailable: "Citation unavailable for this section",
+  clipboard_unavailable: "Could not copy link",
+  exact: "Exact section match",
+  recovered: "Section recovered",
+  ambiguous: "Ambiguous section link — not navigating",
+  stale: "Stale section link — not navigating",
+  missing: "Section link not found — not navigating",
+  invalid_citation: "Invalid section citation — not navigating",
+};
+
+/** Absolute readable section URL for human sharing (no durable selector). */
+export function buildReadableSectionUrl(
+  origin: string,
+  target: SectionLinkTarget
+): string {
+  const path = `${buildDocDeepLink({
+    uri: target.uri,
+    view: target.view ?? "rendered",
+  })}#${target.anchor}`;
+  return `${origin}${path}`;
+}
+
+/**
+ * Absolute citation URL: readable `#anchor` plus bounded `st` selector.
+ * Returns null when a faithful bounded encoding cannot be produced.
+ */
+export function buildCitationSectionUrl(
+  origin: string,
+  target: SectionLinkTarget,
+  sectionTarget: SectionTargetV1
+): string | null {
+  const encoded = encodeSectionTargetLinkParam(sectionTarget);
+  if (!encoded) {
+    return null;
+  }
+  const params = new URLSearchParams({ uri: target.uri });
+  params.set("view", target.view ?? "rendered");
+  params.set(SECTION_TARGET_LINK_PARAM, encoded);
+  return `${origin}/doc?${params.toString()}#${target.anchor}`;
+}
+
+/** Read the raw `st` query value from a location search string. */
+export function readSectionTargetLinkParam(search: string): string | null {
+  const value = new URLSearchParams(search).get(SECTION_TARGET_LINK_PARAM);
+  return value && value.length > 0 ? value : null;
+}
+
+/** Strip the additive `st` param while preserving other query fields. */
+export function stripSectionTargetLinkParam(search: string): string {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search.slice(1) : search
+  );
+  params.delete(SECTION_TARGET_LINK_PARAM);
+  const serialized = params.toString();
+  return serialized.length > 0 ? `?${serialized}` : "";
+}
+
+export interface ResolveSectionLinkInput {
+  content: string;
+  uri: string;
+  /** Raw `st` query value. */
+  encodedTarget: string | null;
+  /** Readable hash without leading `#`. */
+  hashAnchor: string;
+}
+
+export interface ResolveSectionLinkResult {
+  /** When true, hash-only scroll must not run. */
+  blockHashNavigation: boolean;
+  /** Anchor to scroll to when navigable. */
+  navigateAnchor: string | null;
+  notice: SectionLinkNoticeKind | null;
+  /** Drop `st` from the address bar after a successful recovery. */
+  cleanCitationParam: boolean;
+}
+
+/**
+ * Resolve an optional durable selector against current document content.
+ * Readable `#anchor`-only links keep legacy behavior (no block).
+ */
+export async function resolveSectionLinkNavigation(
+  input: ResolveSectionLinkInput
+): Promise<ResolveSectionLinkResult> {
+  if (!input.encodedTarget) {
+    return {
+      blockHashNavigation: false,
+      navigateAnchor: input.hashAnchor || null,
+      notice: null,
+      cleanCitationParam: false,
+    };
+  }
+
+  const target = decodeSectionTargetLinkParam(input.encodedTarget);
+  if (!target) {
+    return {
+      blockHashNavigation: true,
+      navigateAnchor: null,
+      notice: "invalid_citation",
+      cleanCitationParam: false,
+    };
+  }
+
+  const resolution = await resolveSectionTarget({
+    content: input.content,
+    target,
+    uri: input.uri,
+  });
+
+  if (isNavigableSectionResolution(resolution)) {
+    return {
+      blockHashNavigation: false,
+      navigateAnchor: resolution.section.anchor,
+      notice: resolution.status,
+      cleanCitationParam: true,
+    };
+  }
+
+  return {
+    blockHashNavigation: true,
+    navigateAnchor: null,
+    notice: resolution.status,
+    cleanCitationParam: false,
+  };
+}
+
+/** Create a citation URL for an outline section using shared core create. */
+export async function createCitationSectionUrl(input: {
+  origin: string;
+  uri: string;
+  content: string;
+  anchor: string;
+  view?: "rendered" | "source";
+}): Promise<string | null> {
+  const target = await createSectionTarget({
+    content: input.content,
+    uri: input.uri,
+    anchor: input.anchor,
+  });
+  if (!target) {
+    return null;
+  }
+  return buildCitationSectionUrl(
+    input.origin,
+    {
+      uri: input.uri,
+      view: input.view ?? "rendered",
+      anchor: input.anchor,
+    },
+    target
+  );
+}

--- a/src/serve/public/pages/DocView.tsx
+++ b/src/serve/public/pages/DocView.tsx
@@ -13,6 +13,7 @@ import {
   LinkIcon,
   Loader2Icon,
   PencilIcon,
+  QuoteIcon,
   Share2Icon,
   SquareArrowOutUpRightIcon,
   TextIcon,
@@ -83,6 +84,15 @@ import {
   downloadPublishArtifactFile,
   type PublishExportResponse,
 } from "../lib/publish-export";
+import {
+  buildReadableSectionUrl,
+  createCitationSectionUrl,
+  readSectionTargetLinkParam,
+  resolveSectionLinkNavigation,
+  SECTION_LINK_NOTICE_COPY,
+  stripSectionTargetLinkParam,
+  type SectionLinkNoticeKind,
+} from "../lib/section-links";
 import { subscribeWorkspaceActionRequest } from "../lib/workspace-events";
 
 /** Lazy so pdfjs is never pulled for non-PDF documents. */
@@ -389,9 +399,13 @@ export default function DocView({ navigate }: PageProps) {
   const [activeSectionAnchor, setActiveSectionAnchor] = useState<string | null>(
     null
   );
+  const [sectionLinkNotice, setSectionLinkNotice] =
+    useState<SectionLinkNoticeKind | null>(null);
+  const [blockHashNavigation, setBlockHashNavigation] = useState(false);
 
   // Request sequencing - ignore stale responses on rapid navigation
   const requestIdRef = useRef(0);
+  const sectionResolveRequestRef = useRef(0);
   const latestDocEvent = useDocEvents();
 
   // App remounts page on route/query changes, so URI is stable per render.
@@ -402,6 +416,10 @@ export default function DocView({ navigate }: PageProps) {
   const currentUri = currentTarget.uri;
   const currentHash = useMemo(
     () => window.location.hash.replace(/^#/u, ""),
+    []
+  );
+  const encodedSectionTarget = useMemo(
+    () => readSectionTargetLinkParam(window.location.search),
     []
   );
   const highlightedLines = useMemo(() => {
@@ -564,7 +582,78 @@ export default function DocView({ navigate }: PageProps) {
   }, []);
 
   useEffect(() => {
-    if (!currentHash || showRawView || loading) {
+    if (!sectionLinkNotice) {
+      return;
+    }
+    const timer = window.setTimeout(() => setSectionLinkNotice(null), 3200);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [sectionLinkNotice]);
+
+  useEffect(() => {
+    if (!doc?.content || loading || !encodedSectionTarget) {
+      return;
+    }
+
+    const requestId = ++sectionResolveRequestRef.current;
+    const content = doc.content;
+    void resolveSectionLinkNavigation({
+      content,
+      uri: doc.uri,
+      encodedTarget: encodedSectionTarget,
+      hashAnchor: currentHash,
+    }).then((result) => {
+      if (requestId !== sectionResolveRequestRef.current) {
+        return;
+      }
+      setBlockHashNavigation(result.blockHashNavigation);
+      if (result.notice) {
+        setSectionLinkNotice(result.notice);
+      }
+      if (result.cleanCitationParam) {
+        const cleanedSearch = stripSectionTargetLinkParam(
+          window.location.search
+        );
+        const nextHash = result.navigateAnchor
+          ? `#${result.navigateAnchor}`
+          : window.location.hash;
+        window.history.replaceState(
+          {},
+          "",
+          `${window.location.pathname}${cleanedSearch}${nextHash}`
+        );
+      }
+      if (result.blockHashNavigation || !result.navigateAnchor) {
+        return;
+      }
+      if (showRawView) {
+        return;
+      }
+      requestAnimationFrame(() => {
+        document
+          .getElementById(result.navigateAnchor ?? "")
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        setActiveSectionAnchor(result.navigateAnchor);
+      });
+    });
+  }, [
+    currentHash,
+    doc?.content,
+    doc?.uri,
+    encodedSectionTarget,
+    loading,
+    showRawView,
+  ]);
+
+  useEffect(() => {
+    if (
+      blockHashNavigation ||
+      encodedSectionTarget ||
+      !currentHash ||
+      showRawView ||
+      loading
+    ) {
       return;
     }
 
@@ -574,12 +663,91 @@ export default function DocView({ navigate }: PageProps) {
         ?.scrollIntoView({ behavior: "smooth", block: "start" });
       setActiveSectionAnchor(currentHash);
     });
-  }, [currentHash, loading, showRawView]);
+  }, [
+    blockHashNavigation,
+    currentHash,
+    encodedSectionTarget,
+    loading,
+    showRawView,
+  ]);
 
   const breadcrumbs = doc ? parseBreadcrumbs(doc.collection, doc.relPath) : [];
   const sections = useMemo(
     () => extractSections(parsedContent.body),
     [parsedContent.body]
+  );
+
+  const copyReadableSectionLink = useCallback(
+    (anchor: string) => {
+      if (!doc) {
+        return;
+      }
+      void navigator.clipboard
+        .writeText(
+          buildReadableSectionUrl(window.location.origin, {
+            uri: doc.uri,
+            view: "rendered",
+            anchor,
+          })
+        )
+        .then(() => {
+          setSectionLinkNotice("copied_link");
+        })
+        .catch(() => {
+          setSectionLinkNotice("clipboard_unavailable");
+        });
+    },
+    [doc]
+  );
+
+  const copyCitationSectionLink = useCallback(
+    async (anchor: string) => {
+      const content = doc?.content;
+      if (!doc || !content) {
+        return;
+      }
+      const citationUrl = await createCitationSectionUrl({
+        origin: window.location.origin,
+        uri: doc.uri,
+        content,
+        anchor,
+        view: "rendered",
+      });
+      if (!citationUrl) {
+        setSectionLinkNotice("citation_unavailable");
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(citationUrl);
+        setSectionLinkNotice("copied_citation");
+      } catch {
+        setSectionLinkNotice("clipboard_unavailable");
+      }
+    },
+    [doc]
+  );
+
+  const jumpToSection = useCallback(
+    (anchor: string) => {
+      setShowRawView(false);
+      setBlockHashNavigation(false);
+      requestAnimationFrame(() => {
+        document.getElementById(anchor)?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+        window.history.replaceState(
+          {},
+          "",
+          `${buildDocDeepLink({
+            uri: doc?.uri ?? "",
+            view: "rendered",
+          })}#${anchor}`
+        );
+        setActiveSectionAnchor(anchor);
+      });
+    },
+    [doc?.uri]
   );
 
   useEffect(() => {
@@ -1170,8 +1338,19 @@ export default function DocView({ navigate }: PageProps) {
         <>
           <div className="mx-3 border-border/20 border-t" />
           <div className="px-3 py-3">
-            <div className="mb-2 font-mono text-[10px] text-muted-foreground/50 uppercase tracking-[0.15em]">
-              Outline
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="font-mono text-[10px] text-muted-foreground/50 uppercase tracking-[0.15em]">
+                Outline
+              </div>
+              {sectionLinkNotice && (
+                <div
+                  aria-live="polite"
+                  className="min-w-0 truncate font-mono text-[10px] text-muted-foreground/70"
+                  role="status"
+                >
+                  {SECTION_LINK_NOTICE_COPY[sectionLinkNotice]}
+                </div>
+              )}
             </div>
             <div className="w-full min-w-0 max-w-full space-y-0.5 overflow-x-hidden">
               {sections.map((section) => (
@@ -1185,25 +1364,9 @@ export default function DocView({ navigate }: PageProps) {
                   style={{ paddingLeft: `${section.level * 7}px` }}
                 >
                   <button
-                    className="flex w-full min-w-0 max-w-full cursor-pointer items-start gap-2 overflow-hidden rounded px-1 py-0.5 pr-7 text-left text-xs transition-colors hover:bg-muted/20 hover:text-foreground"
+                    className="flex w-full min-w-0 max-w-full cursor-pointer items-start gap-2 overflow-hidden rounded px-1 py-0.5 pr-12 text-left text-xs transition-colors hover:bg-muted/20 hover:text-foreground"
                     onClick={() => {
-                      setShowRawView(false);
-                      requestAnimationFrame(() => {
-                        document
-                          .getElementById(section.anchor)
-                          ?.scrollIntoView({
-                            behavior: "smooth",
-                            block: "start",
-                          });
-                        window.history.replaceState(
-                          {},
-                          "",
-                          `${buildDocDeepLink({
-                            uri: doc?.uri ?? "",
-                            view: "rendered",
-                          })}#${section.anchor}`
-                        );
-                      });
+                      jumpToSection(section.anchor);
                     }}
                     type="button"
                   >
@@ -1221,20 +1384,40 @@ export default function DocView({ navigate }: PageProps) {
                       </TooltipContent>
                     </Tooltip>
                   </button>
-                  <button
-                    className="absolute top-1 right-1 cursor-pointer rounded p-1 opacity-0 transition-all hover:bg-muted/20 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-                    onClick={() => {
-                      void navigator.clipboard.writeText(
-                        `${window.location.origin}${buildDocDeepLink({
-                          uri: doc?.uri ?? "",
-                          view: "rendered",
-                        })}#${section.anchor}`
-                      );
-                    }}
-                    type="button"
-                  >
-                    <CopyIcon className="size-3" />
-                  </button>
+                  <div className="absolute top-1 right-1 flex items-center gap-0.5 opacity-0 transition-all focus-within:opacity-100 group-hover:opacity-100">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          aria-label={`Copy link to ${section.title}`}
+                          className="cursor-pointer rounded p-1 hover:bg-muted/20 hover:text-foreground"
+                          onClick={() => {
+                            copyReadableSectionLink(section.anchor);
+                          }}
+                          type="button"
+                        >
+                          <CopyIcon className="size-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">Copy link</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          aria-label={`Copy local citation link to ${section.title}`}
+                          className="cursor-pointer rounded p-1 hover:bg-muted/20 hover:text-foreground"
+                          onClick={() => {
+                            void copyCitationSectionLink(section.anchor);
+                          }}
+                          type="button"
+                        >
+                          <QuoteIcon className="size-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left">
+                        Copy local citation link
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/serve/routes/section-targets.ts
+++ b/src/serve/routes/section-targets.ts
@@ -1,0 +1,221 @@
+/**
+ * REST handlers for section target create/resolve.
+ *
+ * Consumes shared core create/resolve + transport projection.
+ * Does not change GET /api/doc/:id/sections.
+ *
+ * @module src/serve/routes/section-targets
+ */
+
+import type { SqliteAdapter } from "../../store/sqlite/adapter";
+import type { DocumentRow } from "../../store/types";
+
+import {
+  CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+  SECTION_TARGET_BOUNDS,
+  createSectionTarget,
+  extractSections,
+  isTransportBoundedCanonicalUri,
+  parseSectionTargetCreateSelector,
+  parseSectionTargetResolveBody,
+  projectSectionTargetCreateResult,
+  projectSectionTargetResolveResult,
+  resolveSectionTarget,
+} from "../../core/sections";
+import { parseClosedJson } from "../closed-json";
+
+/** Create body is tiny; resolve wraps a ≤2048-byte target. */
+const CREATE_BODY_MAX_BYTES = 1024;
+const RESOLVE_BODY_MAX_BYTES = SECTION_TARGET_BOUNDS.maxSerializedBytes + 1024;
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return Response.json(data, { status });
+}
+
+function errorResponse(code: string, message: string, status = 400): Response {
+  return jsonResponse({ error: { code, message } }, status);
+}
+
+function readRequestedUriFromUrl(req: Request): string | undefined {
+  const value = new URL(req.url).searchParams.get("uri");
+  return value?.trim() ? value : undefined;
+}
+
+async function resolveDocumentReference(
+  store: Pick<SqliteAdapter, "getDocumentByDocid" | "getDocumentByUri">,
+  docId: string,
+  requestedUri?: string
+): Promise<
+  | { ok: true; value: DocumentRow | null }
+  | { ok: false; error: { message: string } }
+> {
+  if (requestedUri) {
+    const byUri = await store.getDocumentByUri(requestedUri);
+    if (!byUri.ok) {
+      return { ok: false, error: byUri.error };
+    }
+    return { ok: true, value: byUri.value };
+  }
+
+  const byDocid = await store.getDocumentByDocid(docId);
+  if (!byDocid.ok) {
+    return { ok: false, error: byDocid.error };
+  }
+  return { ok: true, value: byDocid.value };
+}
+
+async function loadDocumentContent(
+  store: Pick<
+    SqliteAdapter,
+    "getDocumentByDocid" | "getDocumentByUri" | "getContent"
+  >,
+  docId: string,
+  req: Request
+): Promise<
+  | { ok: true; doc: DocumentRow; content: string }
+  | { ok: false; response: Response }
+> {
+  const docResult = await resolveDocumentReference(
+    store,
+    docId,
+    readRequestedUriFromUrl(req)
+  );
+  if (!docResult.ok) {
+    return {
+      ok: false,
+      response: errorResponse("RUNTIME", docResult.error.message, 500),
+    };
+  }
+  if (!docResult.value) {
+    return {
+      ok: false,
+      response: errorResponse("NOT_FOUND", "Document not found", 404),
+    };
+  }
+
+  const doc = docResult.value;
+  if (!doc.mirrorHash) {
+    return {
+      ok: false,
+      response: errorResponse("NOT_FOUND", "Document content unavailable", 404),
+    };
+  }
+
+  const contentResult = await store.getContent(doc.mirrorHash);
+  if (!contentResult.ok || contentResult.value === null) {
+    return {
+      ok: false,
+      response: errorResponse("RUNTIME", "Mirror content unavailable", 409),
+    };
+  }
+
+  return { ok: true, doc, content: contentResult.value };
+}
+
+/**
+ * POST /api/doc/:id/section-targets
+ * Body: { anchor?: string, line?: number } — exactly one selector.
+ * Canonical document URI always comes from the resolved stored document.
+ */
+export async function handleCreateSectionTarget(
+  store: Pick<
+    SqliteAdapter,
+    "getDocumentByDocid" | "getDocumentByUri" | "getContent"
+  >,
+  docId: string,
+  req: Request
+): Promise<Response> {
+  const parsed = await parseClosedJson(req, CREATE_BODY_MAX_BYTES);
+  if (!parsed.ok) {
+    return errorResponse("VALIDATION", parsed.error, 400);
+  }
+
+  const selector = parseSectionTargetCreateSelector(parsed.value);
+  if (!selector.ok) {
+    return errorResponse("VALIDATION", selector.error, 400);
+  }
+
+  const loaded = await loadDocumentContent(store, docId, req);
+  if (!loaded.ok) return loaded.response;
+
+  // Top-level response uri shares schema maxLength — reject before create.
+  if (!isTransportBoundedCanonicalUri(loaded.doc.uri)) {
+    return errorResponse(
+      "VALIDATION",
+      CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+      422
+    );
+  }
+
+  // Canonical identity from stored doc — never from caller.
+  const target = await createSectionTarget({
+    content: loaded.content,
+    uri: loaded.doc.uri,
+    ...selector.value,
+  });
+
+  if (!target) {
+    const sections = extractSections(loaded.content);
+    const matched =
+      selector.value.anchor !== undefined
+        ? sections.some((section) => section.anchor === selector.value.anchor)
+        : sections.some((section) => section.line === selector.value.line);
+    if (!matched) {
+      return errorResponse("NOT_FOUND", "Section not found", 404);
+    }
+    return errorResponse(
+      "VALIDATION",
+      "Section target exceeds size bounds",
+      422
+    );
+  }
+
+  return jsonResponse(projectSectionTargetCreateResult(loaded.doc.uri, target));
+}
+
+/**
+ * POST /api/doc/:id/section-targets/resolve
+ * Body: { target: SectionTargetV1 }
+ * Resolves against the stored document; URI mismatch yields status missing.
+ */
+export async function handleResolveSectionTarget(
+  store: Pick<
+    SqliteAdapter,
+    "getDocumentByDocid" | "getDocumentByUri" | "getContent"
+  >,
+  docId: string,
+  req: Request
+): Promise<Response> {
+  const parsed = await parseClosedJson(req, RESOLVE_BODY_MAX_BYTES);
+  if (!parsed.ok) {
+    return errorResponse("VALIDATION", parsed.error, 400);
+  }
+
+  const body = parseSectionTargetResolveBody(parsed.value);
+  if (!body.ok) {
+    return errorResponse("VALIDATION", body.error, 400);
+  }
+
+  const loaded = await loadDocumentContent(store, docId, req);
+  if (!loaded.ok) return loaded.response;
+
+  // Top-level (and citation) uri must fit schema — reject before projection.
+  // Citation fail-closed does not repair an unbound top-level uri.
+  if (!isTransportBoundedCanonicalUri(loaded.doc.uri)) {
+    return errorResponse(
+      "VALIDATION",
+      CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+      422
+    );
+  }
+
+  const resolution = await resolveSectionTarget({
+    content: loaded.content,
+    target: body.value.target,
+    uri: loaded.doc.uri,
+  });
+
+  return jsonResponse(
+    projectSectionTargetResolveResult(loaded.doc.uri, resolution)
+  );
+}

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -94,6 +94,10 @@ import {
 } from "./routes/links";
 import { createMcpHttpGateway } from "./routes/mcp";
 import {
+  handleCreateSectionTarget,
+  handleResolveSectionTarget,
+} from "./routes/section-targets";
+import {
   handleTraceDelete,
   handleTraceExport,
   handleTraceLabel,
@@ -1167,6 +1171,36 @@ export async function startServer(
             return withSecurityHeaders(
               await handleResidentRead(runtime as ResidentRuntime, req, () =>
                 handleDocSections(store, id, req)
+              ),
+              isDev
+            );
+          },
+        },
+        "/api/doc/:id/section-targets": {
+          POST: async (req: Request) => {
+            if (!isRequestAllowed(req, port)) {
+              return withSecurityHeaders(forbiddenResponse(), isDev);
+            }
+            const parts = new URL(req.url).pathname.split("/");
+            const id = decodeURIComponent(parts[3] || "");
+            return withSecurityHeaders(
+              await handleResidentRead(runtime as ResidentRuntime, req, () =>
+                handleCreateSectionTarget(store, id, req)
+              ),
+              isDev
+            );
+          },
+        },
+        "/api/doc/:id/section-targets/resolve": {
+          POST: async (req: Request) => {
+            if (!isRequestAllowed(req, port)) {
+              return withSecurityHeaders(forbiddenResponse(), isDev);
+            }
+            const parts = new URL(req.url).pathname.split("/");
+            const id = decodeURIComponent(parts[3] || "");
+            return withSecurityHeaders(
+              await handleResidentRead(runtime as ResidentRuntime, req, () =>
+                handleResolveSectionTarget(store, id, req)
               ),
               isDev
             );

--- a/test/core/section-target-link.test.ts
+++ b/test/core/section-target-link.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Adversarial coverage for bounded section-target link encoding.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifySectionTargetLinkDecodeFailure,
+  createSectionTarget,
+  decodeSectionTargetLinkParam,
+  encodeSectionTargetLinkParam,
+  extractSections,
+  isNavigableSectionResolution,
+  resolveSectionTarget,
+  SECTION_TARGET_LINK_MAX_ENCODED_CHARS,
+  SECTION_TARGET_LINK_PARAM,
+  SECTION_TARGET_LINK_VERSION,
+  type SectionTargetV1,
+} from "../../src/core/sections";
+import {
+  SECTION_AMBIGUOUS_CONTENT,
+  SECTION_FIXTURE_CONTENT,
+  SECTION_FIXTURE_URI,
+  SECTION_MISSING_CONTENT,
+  SECTION_RECOVERED_CONTENT,
+  SECTION_STALE_CONTENT,
+  captureFixtureTarget,
+} from "../helpers/section-target-fixtures";
+
+const SECRET_BODY = "PRIVATE_SECTION_BODY_SHOULD_NEVER_LEAK_IN_ERRORS";
+
+describe("section target link encoding", () => {
+  test("round-trips a bounded target under the versioned st param", async () => {
+    const target = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const encoded = encodeSectionTargetLinkParam(target);
+    expect(encoded).not.toBeNull();
+    expect(encoded?.startsWith(`${SECTION_TARGET_LINK_VERSION}.`)).toBe(true);
+    expect(encoded!.length).toBeLessThanOrEqual(
+      SECTION_TARGET_LINK_MAX_ENCODED_CHARS
+    );
+    expect(decodeSectionTargetLinkParam(encoded!)).toEqual(target);
+    expect(SECTION_TARGET_LINK_PARAM).toBe("st");
+  });
+
+  test("rejects oversized and malformed selectors without leaking bodies", () => {
+    const oversized = `${SECTION_TARGET_LINK_VERSION}.${"a".repeat(SECTION_TARGET_LINK_MAX_ENCODED_CHARS)}`;
+    expect(decodeSectionTargetLinkParam(oversized)).toBeNull();
+    expect(classifySectionTargetLinkDecodeFailure(oversized)).toBe("oversized");
+
+    const malformed = `${SECTION_TARGET_LINK_VERSION}.!!!${SECRET_BODY}`;
+    expect(decodeSectionTargetLinkParam(malformed)).toBeNull();
+    expect(classifySectionTargetLinkDecodeFailure(malformed)).toBe("malformed");
+    expect(classifySectionTargetLinkDecodeFailure("2.abc")).toBe(
+      "unsupported_version"
+    );
+    expect(classifySectionTargetLinkDecodeFailure("")).toBe("missing");
+
+    // Failure classifiers stay content-free even when the input embeds secrets.
+    expect(classifySectionTargetLinkDecodeFailure(malformed)).not.toContain(
+      SECRET_BODY
+    );
+  });
+
+  test("encode refuses unbounded identity fields", async () => {
+    const target = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const hostile: SectionTargetV1 = {
+      ...target,
+      document: { uri: `gno://${"x".repeat(2000)}/doc.md` },
+    };
+    expect(encodeSectionTargetLinkParam(hostile)).toBeNull();
+  });
+});
+
+describe("section target link recovery matrix", () => {
+  test("exact and unique recovery stay navigable via encoded selectors", async () => {
+    const exactTarget = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const exactEncoded = encodeSectionTargetLinkParam(exactTarget);
+    expect(decodeSectionTargetLinkParam(exactEncoded!)).toEqual(exactTarget);
+
+    const recoveredTarget = await captureFixtureTarget(
+      SECTION_FIXTURE_CONTENT,
+      {
+        anchor: "setup",
+      }
+    );
+    const recoveredEncoded = encodeSectionTargetLinkParam(recoveredTarget);
+    const decoded = decodeSectionTargetLinkParam(recoveredEncoded!);
+    expect(decoded).not.toBeNull();
+
+    const recovered = await resolveSectionTarget({
+      content: SECTION_RECOVERED_CONTENT,
+      target: decoded!,
+      uri: SECTION_FIXTURE_URI,
+    });
+    expect(isNavigableSectionResolution(recovered)).toBe(true);
+    expect(recovered.status).toBe("recovered");
+  });
+
+  test("ambiguous stale and missing stay non-navigable", async () => {
+    const twin = await createSectionTarget({
+      content: SECTION_AMBIGUOUS_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      anchor: "twin",
+    });
+    expect(twin).not.toBeNull();
+
+    // Same-revision structural match uses distinct anchors → exact.
+    const sameRevision = await resolveSectionTarget({
+      content: SECTION_AMBIGUOUS_CONTENT,
+      target: twin!,
+      uri: SECTION_FIXTURE_URI,
+    });
+    expect(sameRevision.status).toBe("exact");
+    expect(isNavigableSectionResolution(sameRevision)).toBe(true);
+
+    // Add a third identical twin so quote evidence is no longer unique.
+    const moreIdentical = [
+      SECTION_AMBIGUOUS_CONTENT,
+      "",
+      "## Twin",
+      "",
+      "Identical twin body text.",
+    ].join("\n");
+    const ambiguousAfterEdit = await resolveSectionTarget({
+      content: moreIdentical,
+      target: twin!,
+      uri: SECTION_FIXTURE_URI,
+    });
+    expect(isNavigableSectionResolution(ambiguousAfterEdit)).toBe(false);
+    expect(ambiguousAfterEdit.status).toBe("ambiguous");
+
+    const setup = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const stale = await resolveSectionTarget({
+      content: SECTION_STALE_CONTENT,
+      target: setup,
+      uri: SECTION_FIXTURE_URI,
+    });
+    expect(isNavigableSectionResolution(stale)).toBe(false);
+    expect(stale.status).toBe("stale");
+
+    const missing = await resolveSectionTarget({
+      content: SECTION_MISSING_CONTENT,
+      target: setup,
+      uri: SECTION_FIXTURE_URI,
+    });
+    expect(isNavigableSectionResolution(missing)).toBe(false);
+    expect(missing.status).toBe("missing");
+  });
+
+  test("duplicate headings keep distinct anchors in readable links", () => {
+    const sections = extractSections(SECTION_AMBIGUOUS_CONTENT);
+    expect(sections.map((section) => section.anchor)).toEqual([
+      "guide",
+      "twin",
+      "twin-2",
+    ]);
+  });
+});

--- a/test/core/sections.test.ts
+++ b/test/core/sections.test.ts
@@ -1,6 +1,34 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import { describe, expect, test } from "bun:test";
 
-import { extractSections } from "../../src/core/sections";
+import sectionTargetSchema from "../../spec/output-schemas/section-target.schema.json";
+import {
+  SECTION_TARGET_BOUNDS,
+  createSectionTarget,
+  extractSections,
+  isNavigableSectionResolution,
+  resolveSectionTarget,
+  type SectionTargetV1,
+} from "../../src/core/sections";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+const validateTarget = ajv.compile(sectionTargetSchema);
+
+const DOC_URI = "gno://work/notes/pilot.md";
+
+const assertTargetSchema = (target: SectionTargetV1): void => {
+  const valid = validateTarget(target);
+  if (!valid) {
+    throw new Error(
+      `Section target schema validation failed:\n${JSON.stringify(validateTarget.errors, null, 2)}`
+    );
+  }
+};
+
+const bytesOf = (value: string): number =>
+  new TextEncoder().encode(value).byteLength;
 
 describe("sections", () => {
   test("extracts headings with stable duplicate anchors", () => {
@@ -38,5 +66,441 @@ describe("sections", () => {
       { anchor: "between", level: 2, line: 7, title: "Between" },
       { anchor: "after", level: 3, line: 13, title: "After" },
     ]);
+  });
+
+  test("supports ATX headings with optional closing markers", () => {
+    const sections = extractSections(
+      `# Open\n\n## Closed ##\n\n### Spaced close   ###`
+    );
+    expect(sections.map((section) => section.title)).toEqual([
+      "Open",
+      "Closed",
+      "Spaced close",
+    ]);
+    expect(sections.map((section) => section.anchor)).toEqual([
+      "open",
+      "closed",
+      "spaced-close",
+    ]);
+  });
+});
+
+describe("section targets", () => {
+  test("creates a bounded versioned target that preserves the human anchor", async () => {
+    const content = [
+      "# Guide",
+      "",
+      "## Setup",
+      "",
+      "Install Bun first.",
+      "Then run tests.",
+      "",
+      "## Usage",
+      "",
+      "Call createSectionTarget.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content,
+      uri: DOC_URI,
+      anchor: "setup",
+    });
+
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    expect(target.schemaVersion).toBe("1");
+    expect(target.document.uri).toBe(DOC_URI);
+    expect(target.anchor).toBe("setup");
+    expect(target.headingPath).toEqual(["Guide", "Setup"]);
+    expect(target.occurrence).toBe(1);
+    expect(target.quote.exact).toContain("Install Bun first.");
+    expect(target.quote.exact.length).toBeLessThanOrEqual(
+      SECTION_TARGET_BOUNDS.exactMaxChars
+    );
+    expect(target.quote.prefix.length).toBeLessThanOrEqual(
+      SECTION_TARGET_BOUNDS.prefixMaxChars
+    );
+    expect(target.quote.suffix.length).toBeLessThanOrEqual(
+      SECTION_TARGET_BOUNDS.suffixMaxChars
+    );
+    expect(target.sourceFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(target.hints.line).toBe(3);
+    expect(bytesOf(JSON.stringify(target))).toBeLessThanOrEqual(
+      SECTION_TARGET_BOUNDS.maxSerializedBytes
+    );
+    assertTargetSchema(target);
+
+    const exact = await resolveSectionTarget({ content, target, uri: DOC_URI });
+    expect(exact.status).toBe("exact");
+    expect(isNavigableSectionResolution(exact)).toBe(true);
+    if (exact.section) {
+      expect(exact.section.anchor).toBe("setup");
+      expect(exact.section.line).toBe(3);
+    }
+  });
+
+  test("recovers after duplicate heading insertion via quote context", async () => {
+    const original = [
+      "# Alpha",
+      "",
+      "## Beta",
+      "",
+      "Original beta body with unique marker ONE.",
+      "",
+      "## Gamma",
+      "",
+      "Tail.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content: original,
+      uri: DOC_URI,
+      anchor: "beta",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const edited = [
+      "# Alpha",
+      "",
+      "## Beta",
+      "",
+      "Inserted decoy body with marker TWO.",
+      "",
+      "## Beta",
+      "",
+      "Original beta body with unique marker ONE.",
+      "",
+      "## Gamma",
+      "",
+      "Tail.",
+    ].join("\n");
+
+    const resolution = await resolveSectionTarget({
+      content: edited,
+      target,
+      uri: DOC_URI,
+    });
+
+    expect(resolution.status).toBe("recovered");
+    expect(isNavigableSectionResolution(resolution)).toBe(true);
+    expect(resolution.section?.anchor).toBe("beta-2");
+    expect(resolution.section?.line).toBe(7);
+    expect(resolution.currentFingerprint).not.toBe(target.sourceFingerprint);
+  });
+
+  test("recovers after heading rename when body quote remains unique", async () => {
+    const original = [
+      "# Doc",
+      "",
+      "## Old Name",
+      "",
+      "Rename-stable paragraph about widgets.",
+      "",
+      "## Other",
+      "",
+      "Unrelated.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content: original,
+      uri: DOC_URI,
+      anchor: "old-name",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const renamed = [
+      "# Doc",
+      "",
+      "## New Name",
+      "",
+      "Rename-stable paragraph about widgets.",
+      "",
+      "## Other",
+      "",
+      "Unrelated.",
+    ].join("\n");
+
+    const resolution = await resolveSectionTarget({
+      content: renamed,
+      target,
+      uri: DOC_URI,
+    });
+
+    expect(resolution.status).toBe("recovered");
+    expect(resolution.section?.anchor).toBe("new-name");
+    expect(resolution.section?.title).toBe("New Name");
+  });
+
+  test("recovers after section reorder when quote context is unique", async () => {
+    const original = [
+      "# Doc",
+      "",
+      "## First",
+      "",
+      "First body alpha.",
+      "",
+      "## Second",
+      "",
+      "Second body bravo.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content: original,
+      uri: DOC_URI,
+      anchor: "second",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const reordered = [
+      "# Doc",
+      "",
+      "## Second",
+      "",
+      "Second body bravo.",
+      "",
+      "## First",
+      "",
+      "First body alpha.",
+    ].join("\n");
+
+    const resolution = await resolveSectionTarget({
+      content: reordered,
+      target,
+      uri: DOC_URI,
+    });
+
+    expect(resolution.status).toBe("recovered");
+    expect(resolution.section?.anchor).toBe("second");
+    expect(resolution.section?.line).toBe(3);
+  });
+
+  test("returns missing after section deletion", async () => {
+    const original = [
+      "# Doc",
+      "",
+      "## Keep",
+      "",
+      "Keep body.",
+      "",
+      "## Delete Me",
+      "",
+      "Gone soon.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content: original,
+      uri: DOC_URI,
+      anchor: "delete-me",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const deleted = ["# Doc", "", "## Keep", "", "Keep body."].join("\n");
+    const resolution = await resolveSectionTarget({
+      content: deleted,
+      target,
+      uri: DOC_URI,
+    });
+
+    expect(resolution.status).toBe("missing");
+    expect(isNavigableSectionResolution(resolution)).toBe(false);
+    expect(resolution.section).toBeUndefined();
+  });
+
+  test("returns ambiguous for indistinguishable identical sections", async () => {
+    const identical = [
+      "# Doc",
+      "",
+      "## Twin",
+      "",
+      "Same body text.",
+      "",
+      "## Twin",
+      "",
+      "Same body text.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content: identical,
+      uri: DOC_URI,
+      anchor: "twin",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    // Fingerprint-changing no-op whitespace outside sections is insufficient;
+    // swap in a third identical twin so quote evidence is no longer unique.
+    const moreIdentical = [
+      identical,
+      "",
+      "## Twin",
+      "",
+      "Same body text.",
+    ].join("\n");
+
+    const resolution = await resolveSectionTarget({
+      content: moreIdentical,
+      target,
+      uri: DOC_URI,
+    });
+
+    expect(resolution.status).toBe("ambiguous");
+    expect(isNavigableSectionResolution(resolution)).toBe(false);
+    expect(resolution.section).toBeUndefined();
+    expect(resolution.candidates?.length).toBeGreaterThan(1);
+  });
+
+  test("returns stale when fingerprint drifts without unique recovery", async () => {
+    const original = [
+      "# Doc",
+      "",
+      "## Topic",
+      "",
+      "Unique original wording.",
+      "",
+      "## Other",
+      "",
+      "Other body.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content: original,
+      uri: DOC_URI,
+      anchor: "topic",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const drifted = [
+      "# Doc",
+      "",
+      "## Topic",
+      "",
+      "Completely rewritten body with no shared quote.",
+      "",
+      "## Other",
+      "",
+      "Other body.",
+    ].join("\n");
+
+    const resolution = await resolveSectionTarget({
+      content: drifted,
+      target,
+      uri: DOC_URI,
+    });
+
+    expect(resolution.status).toBe("stale");
+    expect(isNavigableSectionResolution(resolution)).toBe(false);
+    expect(resolution.section).toBeUndefined();
+  });
+
+  test("does not treat fenced decoy headings as resolvable sections", async () => {
+    const content = [
+      "# Real",
+      "",
+      "```md",
+      "## Fake",
+      "fenced decoy body",
+      "```",
+      "",
+      "## Fake",
+      "",
+      "Real fake section body.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content,
+      uri: DOC_URI,
+      anchor: "fake",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    expect(target.headingPath).toEqual(["Real", "Fake"]);
+    expect(target.quote.exact).toContain("Real fake section body.");
+
+    const resolution = await resolveSectionTarget({
+      content,
+      target,
+      uri: DOC_URI,
+    });
+    expect(resolution.status).toBe("exact");
+    expect(resolution.section?.line).toBe(8);
+  });
+
+  test("never navigates ambiguous or stale targets", async () => {
+    const content = ["# A", "", "## B", "", "Body."].join("\n");
+    const target = await createSectionTarget({
+      content,
+      uri: DOC_URI,
+      anchor: "b",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const stale = await resolveSectionTarget({
+      content: ["# A", "", "## B", "", "Changed."].join("\n"),
+      target,
+      uri: DOC_URI,
+    });
+    expect(["stale", "missing", "ambiguous"]).toContain(stale.status);
+    expect(isNavigableSectionResolution(stale)).toBe(false);
+  });
+
+  test("fails closed on oversized heading path without truncating identity", async () => {
+    const content = `# ${"x".repeat(3000)}\n`;
+    const target = await createSectionTarget({
+      content,
+      uri: "gno://x",
+      line: 1,
+    });
+    expect(target).toBeNull();
+  });
+
+  test("fails closed on oversized document URI without truncating identity", async () => {
+    const content = "# Short\n\nBody.\n";
+    const target = await createSectionTarget({
+      content,
+      uri: `gno://${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars)}`,
+      line: 1,
+    });
+    expect(target).toBeNull();
+  });
+
+  test("preserves ordinary Unicode in heading path and quote evidence", async () => {
+    const content = [
+      "# Café résumé",
+      "",
+      "## 日本語ガイド",
+      "",
+      "本文 with naïve résumé notes.",
+    ].join("\n");
+
+    const target = await createSectionTarget({
+      content,
+      uri: DOC_URI,
+      line: 3,
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    expect(target.headingPath).toEqual(["Café résumé", "日本語ガイド"]);
+    expect(target.quote.exact).toContain("naïve");
+    expect(bytesOf(JSON.stringify(target))).toBeLessThanOrEqual(
+      SECTION_TARGET_BOUNDS.maxSerializedBytes
+    );
+    assertTargetSchema(target);
+
+    const resolution = await resolveSectionTarget({
+      content,
+      target,
+      uri: DOC_URI,
+    });
+    expect(resolution.status).toBe("exact");
+    expect(resolution.section?.title).toBe("日本語ガイド");
   });
 });

--- a/test/helpers/section-target-fixtures.ts
+++ b/test/helpers/section-target-fixtures.ts
@@ -1,0 +1,165 @@
+/**
+ * Shared semantic fixture matrix for section-target REST/SDK tests.
+ *
+ * @module test/helpers/section-target-fixtures
+ */
+
+import type { SectionTargetV1 } from "../../src/core/sections";
+
+import {
+  createSectionTarget,
+  fingerprintSourceContent,
+} from "../../src/core/sections";
+
+export const SECTION_FIXTURE_URI = "gno://work/notes/pilot.md";
+
+export const SECTION_FIXTURE_CONTENT = [
+  "# Guide",
+  "",
+  "## Setup",
+  "",
+  "Install Bun first.",
+  "Then run tests.",
+  "",
+  "## Usage",
+  "",
+  "Call createSectionTarget.",
+].join("\n");
+
+export const SECTION_RECOVERED_CONTENT = [
+  "# Guide",
+  "",
+  "## Getting Started",
+  "",
+  "Install Bun first.",
+  "Then run tests.",
+  "",
+  "## Usage",
+  "",
+  "Call createSectionTarget.",
+].join("\n");
+
+export const SECTION_AMBIGUOUS_CONTENT = [
+  "# Guide",
+  "",
+  "## Twin",
+  "",
+  "Identical twin body text.",
+  "",
+  "## Twin",
+  "",
+  "Identical twin body text.",
+].join("\n");
+
+export const SECTION_STALE_CONTENT = [
+  "# Guide",
+  "",
+  "## Setup",
+  "",
+  "Completely different body with no recoverable quote.",
+].join("\n");
+
+export const SECTION_MISSING_CONTENT = ["# Guide", "", "No setup here."].join(
+  "\n"
+);
+
+export type SectionSemanticCase =
+  | "exact"
+  | "recovered"
+  | "ambiguous"
+  | "stale"
+  | "missing";
+
+export interface SectionSemanticFixture {
+  id: SectionSemanticCase;
+  captureContent: string;
+  resolveContent: string;
+  selector: { anchor: string } | { line: number };
+  expectedStatus: SectionSemanticCase;
+  navigable: boolean;
+}
+
+/** One semantic matrix reused across REST and SDK tests. */
+export const SECTION_SEMANTIC_CASES: readonly SectionSemanticFixture[] = [
+  {
+    id: "exact",
+    captureContent: SECTION_FIXTURE_CONTENT,
+    resolveContent: SECTION_FIXTURE_CONTENT,
+    selector: { anchor: "setup" },
+    expectedStatus: "exact",
+    navigable: true,
+  },
+  {
+    id: "recovered",
+    captureContent: SECTION_FIXTURE_CONTENT,
+    resolveContent: SECTION_RECOVERED_CONTENT,
+    selector: { anchor: "setup" },
+    expectedStatus: "recovered",
+    navigable: true,
+  },
+  {
+    id: "ambiguous",
+    captureContent: SECTION_AMBIGUOUS_CONTENT,
+    resolveContent: [
+      "# Guide",
+      "",
+      "## Twin",
+      "",
+      "Identical twin body text.",
+      "",
+      "## Twin",
+      "",
+      "Identical twin body text.",
+      "",
+      "## Twin",
+      "",
+      "Identical twin body text.",
+    ].join("\n"),
+    selector: { line: 3 },
+    expectedStatus: "ambiguous",
+    navigable: false,
+  },
+  {
+    id: "stale",
+    captureContent: SECTION_FIXTURE_CONTENT,
+    resolveContent: SECTION_STALE_CONTENT,
+    selector: { anchor: "setup" },
+    expectedStatus: "stale",
+    navigable: false,
+  },
+  {
+    id: "missing",
+    captureContent: SECTION_FIXTURE_CONTENT,
+    resolveContent: SECTION_MISSING_CONTENT,
+    selector: { anchor: "setup" },
+    expectedStatus: "missing",
+    navigable: false,
+  },
+];
+
+export async function captureFixtureTarget(
+  content: string,
+  selector: { anchor?: string; line?: number },
+  uri = SECTION_FIXTURE_URI
+): Promise<SectionTargetV1> {
+  const target = await createSectionTarget({
+    content,
+    uri,
+    ...selector,
+  });
+  if (!target) {
+    throw new Error("Failed to capture fixture section target");
+  }
+  return target;
+}
+
+export async function wrongDocumentTarget(
+  content: string
+): Promise<SectionTargetV1> {
+  const target = await captureFixtureTarget(content, { anchor: "setup" });
+  return {
+    ...target,
+    document: { uri: "gno://other/wrong.md" },
+    sourceFingerprint: await fingerprintSourceContent(content),
+  };
+}

--- a/test/mcp/http-parity.test.ts
+++ b/test/mcp/http-parity.test.ts
@@ -13,8 +13,17 @@ import type { DocumentInput } from "../../src/store/types";
 
 import { createMcpServerSurface } from "../../src/mcp/context";
 import { HttpMcpTransport } from "../../src/mcp/http-transport";
+import { SECTION_MCP_ANNOTATIONS } from "../../src/mcp/tools/sections";
 import { SqliteAdapter } from "../../src/store/sqlite/adapter";
 import { safeRm } from "../helpers/cleanup";
+
+const SECTION_FIXTURE_CONTENT = [
+  "# Shared fixture",
+  "",
+  "## Setup",
+  "",
+  "Transport-neutral evidence.",
+].join("\n");
 
 describe("stdio and HTTP MCP parity", () => {
   let root: string;
@@ -41,14 +50,13 @@ describe("stdio and HTTP MCP parity", () => {
       },
     ];
     expect((await store.syncCollections(collections)).ok).toBe(true);
-    const fixtureContent = "# Shared fixture\n\nTransport-neutral evidence.";
     const fixture: DocumentInput = {
       collection: "notes",
       relPath: "fixture.md",
       sourceHash: "http-parity-fixture",
       sourceMime: "text/markdown",
       sourceExt: ".md",
-      sourceSize: fixtureContent.length,
+      sourceSize: SECTION_FIXTURE_CONTENT.length,
       sourceMtime: new Date(0).toISOString(),
       title: "Shared fixture",
       mirrorHash: "http-parity-fixture",
@@ -56,7 +64,8 @@ describe("stdio and HTTP MCP parity", () => {
     };
     expect((await store.upsertDocument(fixture)).ok).toBe(true);
     expect(
-      (await store.upsertContent(fixture.mirrorHash!, fixtureContent)).ok
+      (await store.upsertContent(fixture.mirrorHash!, SECTION_FIXTURE_CONTENT))
+        .ok
     ).toBe(true);
 
     const config: Config = {
@@ -132,6 +141,42 @@ describe("stdio and HTTP MCP parity", () => {
     expect(httpTools).toEqual(stdioTools);
     expect(httpResources).toEqual(stdioResources);
 
+    const sectionTool = stdioTools.tools.find(
+      (tool) => tool.name === "gno_section"
+    );
+    expect(sectionTool).toBeDefined();
+    expect(sectionTool?.annotations).toEqual(SECTION_MCP_ANNOTATIONS);
+    expect(sectionTool?.inputSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+    });
+    expect(sectionTool?.inputSchema.required).toEqual(
+      expect.arrayContaining(["action", "ref"])
+    );
+    expect(sectionTool?.inputSchema.properties).toMatchObject({
+      action: expect.anything(),
+      ref: expect.anything(),
+      anchor: expect.anything(),
+      line: expect.anything(),
+      target: expect.anything(),
+    });
+    expect(sectionTool?.outputSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+    });
+    expect(sectionTool?.outputSchema?.required).toEqual(
+      expect.arrayContaining(["schemaVersion", "action", "uri", "target"])
+    );
+    expect(sectionTool?.outputSchema?.properties).toMatchObject({
+      schemaVersion: expect.anything(),
+      action: expect.anything(),
+      uri: expect.anything(),
+      target: expect.anything(),
+      status: expect.anything(),
+      citation: expect.anything(),
+      diagnostics: expect.anything(),
+    });
+
     const [stdioStatus, httpStatus] = await Promise.all([
       stdioClient.callTool({ name: "gno_status", arguments: {} }),
       httpClient.callTool({ name: "gno_status", arguments: {} }),
@@ -143,5 +188,55 @@ describe("stdio and HTTP MCP parity", () => {
       httpClient.readResource({ uri: "gno://notes/fixture.md" }),
     ]);
     expect(httpTags).toEqual(stdioTags);
+
+    const createArgs = {
+      action: "create",
+      ref: "gno://notes/fixture.md",
+      anchor: "setup",
+    };
+    const [stdioCreate, httpCreate] = await Promise.all([
+      stdioClient.callTool({ name: "gno_section", arguments: createArgs }),
+      httpClient.callTool({ name: "gno_section", arguments: createArgs }),
+    ]);
+    expect(stdioCreate.isError).not.toBe(true);
+    expect(httpCreate).toEqual(stdioCreate);
+    expect(stdioCreate.structuredContent).toMatchObject({
+      schemaVersion: "1.0",
+      action: "create",
+      uri: "gno://notes/fixture.md",
+    });
+    const createdTarget = (
+      stdioCreate.structuredContent as {
+        target: Record<string, unknown>;
+      }
+    ).target;
+
+    const resolveArgs = {
+      action: "resolve",
+      ref: "gno://notes/fixture.md",
+      target: createdTarget,
+    };
+    const [stdioResolve, httpResolve] = await Promise.all([
+      stdioClient.callTool({ name: "gno_section", arguments: resolveArgs }),
+      httpClient.callTool({ name: "gno_section", arguments: resolveArgs }),
+    ]);
+    expect(stdioResolve.isError).not.toBe(true);
+    expect(httpResolve).toEqual(stdioResolve);
+    expect(stdioResolve.structuredContent).toMatchObject({
+      schemaVersion: "1.0",
+      action: "resolve",
+      status: "exact",
+      uri: "gno://notes/fixture.md",
+      citation: {
+        uri: "gno://notes/fixture.md",
+        anchor: "setup",
+      },
+    });
+    const citation = (
+      stdioResolve.structuredContent as {
+        citation: { lineStart: number; lineEnd: number };
+      }
+    ).citation;
+    expect(citation.lineEnd).toBeGreaterThanOrEqual(citation.lineStart);
   });
 });

--- a/test/mcp/tools/capture.test.ts
+++ b/test/mcp/tools/capture.test.ts
@@ -92,6 +92,7 @@ describe("gno_capture MCP", () => {
 
     expect(names).not.toContain("gno_capture");
     expect(names).toContain("gno_search");
+    expect(names).toContain("gno_section");
     expect(names).toContain("gno_trace_list");
     expect(names).toContain("gno_trace_show");
     expect(names).not.toContain("gno_trace_label");

--- a/test/mcp/tools/sections.test.ts
+++ b/test/mcp/tools/sections.test.ts
@@ -1,0 +1,555 @@
+/**
+ * MCP gno_section tool tests — create/resolve, annotations, no-write, gno_get.
+ */
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ToolContext } from "../../../src/mcp/server";
+import type { DocumentInput } from "../../../src/store/types";
+
+import resolveResultSchema from "../../../spec/output-schemas/section-target-resolve-result.schema.json";
+import targetSchema from "../../../spec/output-schemas/section-target.schema.json";
+import sectionSchema from "../../../spec/output-schemas/section.schema.json";
+import { SECTION_TARGET_BOUNDS } from "../../../src/core/sections";
+import { handleGet } from "../../../src/mcp/tools/get";
+import {
+  MCP_TOOL_DESCRIPTIONS,
+  MCP_WRITE_TOOL_NAMES,
+  registerTools,
+} from "../../../src/mcp/tools/index";
+import {
+  handleSection,
+  SECTION_MCP_ANNOTATIONS,
+  sectionInputSchema,
+  sectionOutputSchema,
+  type SectionMcpResult,
+} from "../../../src/mcp/tools/sections";
+import { SqliteAdapter } from "../../../src/store/sqlite/adapter";
+import { safeRm } from "../../helpers/cleanup";
+import {
+  SECTION_FIXTURE_CONTENT,
+  SECTION_SEMANTIC_CASES,
+  wrongDocumentTarget,
+} from "../../helpers/section-target-fixtures";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(targetSchema);
+ajv.addSchema(resolveResultSchema);
+const validateSection = ajv.compile(sectionSchema);
+
+const SECTION_READ_METHODS = [
+  "getDocumentByDocid",
+  "getDocumentByUri",
+  "getDocument",
+  "getContent",
+] as const;
+
+type SectionReadMethod = (typeof SECTION_READ_METHODS)[number];
+
+function createReadOnlyStoreFacade(store: SqliteAdapter): {
+  facade: SqliteAdapter;
+  readAccesses: SectionReadMethod[];
+  blockedAccesses: string[];
+} {
+  const readAccesses: SectionReadMethod[] = [];
+  const blockedAccesses: string[] = [];
+  const allowed = new Set<string>(SECTION_READ_METHODS);
+
+  const facade = new Proxy(store, {
+    get(target, prop, receiver) {
+      if (typeof prop === "symbol") {
+        return Reflect.get(target, prop, receiver);
+      }
+      const name = String(prop);
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+      if (allowed.has(name)) {
+        return (...args: unknown[]) => {
+          readAccesses.push(name as SectionReadMethod);
+          return (value as (...inner: unknown[]) => unknown).apply(
+            target,
+            args
+          );
+        };
+      }
+      return (..._args: unknown[]) => {
+        blockedAccesses.push(name);
+        throw new Error(
+          `Read-only store facade blocked non-read method: ${name}`
+        );
+      };
+    },
+  }) as SqliteAdapter;
+
+  return { facade, readAccesses, blockedAccesses };
+}
+
+function oversizedSerializedTarget() {
+  return {
+    schemaVersion: "1" as const,
+    document: {
+      uri: `gno://${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars - 6)}`,
+    },
+    anchor: "a".repeat(SECTION_TARGET_BOUNDS.anchorMaxChars),
+    headingPath: Array.from(
+      { length: SECTION_TARGET_BOUNDS.headingPathMaxItems },
+      (_, index) =>
+        `${index}${"H".repeat(SECTION_TARGET_BOUNDS.headingPathItemMaxChars - 1)}`
+    ),
+    occurrence: 1,
+    quote: {
+      exact: "x".repeat(SECTION_TARGET_BOUNDS.exactMaxChars),
+      prefix: "y".repeat(SECTION_TARGET_BOUNDS.prefixMaxChars),
+      suffix: "z".repeat(SECTION_TARGET_BOUNDS.suffixMaxChars),
+    },
+    sourceFingerprint: "a".repeat(64),
+    hints: { line: 3, startOffset: 0, endOffset: 1 },
+  };
+}
+
+describe("gno_section MCP", () => {
+  let tmpDir: string;
+  let store: SqliteAdapter;
+  let contentByHash: Map<string, string>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "gno-mcp-section-"));
+    store = new SqliteAdapter();
+    const opened = await store.open(join(tmpDir, "test.db"), "porter");
+    expect(opened.ok).toBe(true);
+    const sync = await store.syncCollections([
+      {
+        name: "notes",
+        path: tmpDir,
+        pattern: "**/*.md",
+        include: [],
+        exclude: [],
+      },
+    ]);
+    expect(sync.ok).toBe(true);
+
+    contentByHash = new Map();
+    const originalGetContent = store.getContent.bind(store);
+    store.getContent = async (hash: string) => {
+      const local = contentByHash.get(hash);
+      if (local !== undefined) {
+        return { ok: true as const, value: local };
+      }
+      return originalGetContent(hash);
+    };
+  });
+
+  afterEach(async () => {
+    await store.close();
+    await safeRm(tmpDir);
+  });
+
+  function toolContext(
+    enableWrite = false,
+    storeOverride: SqliteAdapter = store
+  ): ToolContext {
+    return {
+      indexName: "default",
+      store: storeOverride,
+      config: {
+        version: "1.0",
+        ftsTokenizer: "porter",
+        collections: [],
+        contexts: [],
+      },
+      collections: [
+        {
+          name: "notes",
+          path: tmpDir,
+          pattern: "**/*.md",
+          include: [],
+          exclude: [],
+        },
+      ],
+      actualConfigPath: join(tmpDir, "config.yml"),
+      toolMutex: {
+        acquire: async () => () => {},
+      } as ToolContext["toolMutex"],
+      jobManager: {} as ToolContext["jobManager"],
+      serverInstanceId: "test-server",
+      writeLockPath: join(tmpDir, ".lock"),
+      enableWrite,
+      isShuttingDown: () => false,
+    };
+  }
+
+  async function upsertDoc(
+    content: string,
+    relPath = "pilot.md"
+  ): Promise<{ docid: string; uri: string }> {
+    const hash = `h-${Bun.hash(content).toString(16)}`;
+    contentByHash.set(hash, content);
+    const doc: DocumentInput = {
+      collection: "notes",
+      relPath,
+      sourceHash: hash,
+      sourceMime: "text/markdown",
+      sourceExt: ".md",
+      sourceSize: content.length,
+      sourceMtime: new Date().toISOString(),
+      title: "Pilot",
+      mirrorHash: hash,
+      ingestVersion: 2,
+    };
+    const result = await store.upsertDocument(doc);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("upsert failed");
+    const loaded = await store.getDocumentByDocid(result.value.docid);
+    expect(loaded.ok && loaded.value).toBeTruthy();
+    if (!loaded.ok || !loaded.value) throw new Error("load failed");
+    return { docid: loaded.value.docid, uri: loaded.value.uri };
+  }
+
+  test("registers as read-only when enableWrite=false and is not a write tool", () => {
+    const names: string[] = [];
+    const annotationsByName = new Map<string, unknown>();
+    const fakeServer = {
+      tool: (name: string) => {
+        names.push(name);
+      },
+      registerTool: (
+        name: string,
+        config: { annotations?: unknown; outputSchema?: unknown }
+      ) => {
+        names.push(name);
+        annotationsByName.set(name, config.annotations);
+        if (name === "gno_section") {
+          expect(config.outputSchema).toBeDefined();
+        }
+      },
+    };
+
+    registerTools(fakeServer as never, toolContext(false));
+
+    expect(names).toContain("gno_section");
+    expect(names).toContain("gno_get");
+    expect(MCP_WRITE_TOOL_NAMES.has("gno_section")).toBe(false);
+    expect(annotationsByName.get("gno_section")).toEqual(
+      SECTION_MCP_ANNOTATIONS
+    );
+    expect(MCP_TOOL_DESCRIPTIONS.section).toContain("Read-only");
+  });
+
+  test("input schema rejects malformed, unknown, and XOR violations", () => {
+    expect(sectionInputSchema.safeParse({}).success).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({ action: "create", ref: "notes/a.md" })
+        .success
+    ).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "create",
+        ref: "notes/a.md",
+        anchor: "setup",
+        line: 3,
+      }).success
+    ).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "resolve",
+        ref: "notes/a.md",
+      }).success
+    ).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "unknown",
+        ref: "notes/a.md",
+        anchor: "setup",
+      }).success
+    ).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "create",
+        ref: "notes/a.md",
+        anchor: "setup",
+        extra: true,
+      }).success
+    ).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "create",
+        ref: "notes/a.md",
+        anchor: "x".repeat(513),
+      }).success
+    ).toBe(false);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "create",
+        ref: "notes/a.md",
+        anchor: "setup",
+      }).success
+    ).toBe(true);
+    expect(
+      sectionInputSchema.safeParse({
+        action: "create",
+        ref: "notes/a.md",
+        line: 3,
+      }).success
+    ).toBe(true);
+  });
+
+  test("input schema rejects inverted hints and oversized serialized targets", () => {
+    const fingerprint = "b".repeat(64);
+    const legalFields = {
+      schemaVersion: "1" as const,
+      document: { uri: "gno://notes/a.md" },
+      anchor: "setup",
+      headingPath: ["Guide", "Setup"],
+      occurrence: 1,
+      quote: { exact: "Install", prefix: "", suffix: "" },
+      sourceFingerprint: fingerprint,
+    };
+
+    const inverted = sectionInputSchema.safeParse({
+      action: "resolve",
+      ref: "gno://notes/a.md",
+      target: {
+        ...legalFields,
+        hints: { line: 3, startOffset: 40, endOffset: 10 },
+      },
+    });
+    expect(inverted.success).toBe(false);
+
+    const oversized = oversizedSerializedTarget();
+    expect(oversized.document.uri.length).toBe(
+      SECTION_TARGET_BOUNDS.uriMaxChars
+    );
+    const oversizeParse = sectionInputSchema.safeParse({
+      action: "resolve",
+      ref: "gno://notes/a.md",
+      target: oversized,
+    });
+    expect(oversizeParse.success).toBe(false);
+  });
+
+  for (const fixture of SECTION_SEMANTIC_CASES) {
+    test(`create+resolve ${fixture.id}`, async () => {
+      const captureDoc = await upsertDoc(fixture.captureContent, "capture.md");
+      const createArgs =
+        "anchor" in fixture.selector
+          ? {
+              action: "create" as const,
+              ref: captureDoc.uri,
+              anchor: fixture.selector.anchor,
+            }
+          : {
+              action: "create" as const,
+              ref: captureDoc.uri,
+              line: fixture.selector.line,
+            };
+
+      const created = await handleSection(createArgs, toolContext(false));
+      expect(created.isError).toBeFalsy();
+      const createData = created.structuredContent as SectionMcpResult;
+      expect(validateSection(createData)).toBe(true);
+      expect(sectionOutputSchema.safeParse(createData).success).toBe(true);
+      expect(createData).toMatchObject({
+        schemaVersion: "1.0",
+        action: "create",
+        uri: captureDoc.uri,
+      });
+      expect(created.content[0]?.text).toContain('"action": "create"');
+
+      const resolveDoc = await upsertDoc(fixture.resolveContent, "resolve.md");
+      if (createData.action !== "create") throw new Error("expected create");
+      const targetForResolve = {
+        ...createData.target,
+        document: { uri: resolveDoc.uri },
+      };
+
+      const resolved = await handleSection(
+        {
+          action: "resolve",
+          ref: resolveDoc.uri,
+          target: targetForResolve,
+        },
+        toolContext(false)
+      );
+      expect(resolved.isError).toBeFalsy();
+      const resolveData = resolved.structuredContent as SectionMcpResult;
+      expect(validateSection(resolveData)).toBe(true);
+      expect(sectionOutputSchema.safeParse(resolveData).success).toBe(true);
+      expect(resolveData).toMatchObject({
+        schemaVersion: "1.0",
+        action: "resolve",
+        status: fixture.expectedStatus,
+        uri: resolveDoc.uri,
+      });
+
+      if (fixture.navigable) {
+        expect(resolveData.citation).toBeDefined();
+        expect(resolveData.citation).toMatchObject({
+          uri: resolveDoc.uri,
+        });
+        expect(resolved.content[0]?.text).toContain("gno_get");
+        expect(resolved.content[0]?.text).toContain("fromLine");
+        expect(resolved.content[0]?.text).not.toContain(
+          "not safe to navigate or cite"
+        );
+      } else {
+        expect(resolveData.citation).toBeUndefined();
+        expect(resolved.content[0]?.text).toContain(
+          "not safe to navigate or cite"
+        );
+      }
+    });
+  }
+
+  test("wrong-document target resolves as missing without citation", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const wrong = await wrongDocumentTarget(SECTION_FIXTURE_CONTENT);
+    const result = await handleSection(
+      { action: "resolve", ref: doc.uri, target: wrong },
+      toolContext(false)
+    );
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as SectionMcpResult;
+    expect(validateSection(data)).toBe(true);
+    expect(data).toMatchObject({
+      action: "resolve",
+      status: "missing",
+    });
+    expect(data.citation).toBeUndefined();
+    expect(result.content[0]?.text).toContain("not safe to navigate or cite");
+  });
+
+  test("create with unknown section returns NOT_FOUND", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const result = await handleSection(
+      { action: "create", ref: doc.uri, anchor: "does-not-exist" },
+      toolContext(false)
+    );
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      error: "NOT_FOUND",
+    });
+  });
+
+  test("create/resolve with enableWrite=false never touch non-read store methods", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const { facade, readAccesses, blockedAccesses } =
+      createReadOnlyStoreFacade(store);
+    const ctx = toolContext(false, facade);
+
+    const created = await handleSection(
+      { action: "create", ref: doc.uri, anchor: "setup" },
+      ctx
+    );
+    expect(created.isError).toBeFalsy();
+    const createData = created.structuredContent as SectionMcpResult;
+    expect(createData.action).toBe("create");
+
+    const resolved = await handleSection(
+      {
+        action: "resolve",
+        ref: doc.uri,
+        target: createData.target,
+      },
+      ctx
+    );
+    expect(resolved.isError).toBeFalsy();
+    expect(resolved.structuredContent).toMatchObject({
+      action: "resolve",
+      status: "exact",
+    });
+
+    expect(blockedAccesses).toEqual([]);
+    expect(readAccesses.length).toBeGreaterThan(0);
+    expect(new Set(readAccesses).size).toBeGreaterThan(0);
+    for (const name of readAccesses) {
+      expect(SECTION_READ_METHODS).toContain(name);
+    }
+
+    // Prove the facade still fails closed if a mutation method is touched.
+    expect(() => {
+      void facade.upsertDocument({} as never);
+    }).toThrow(/blocked non-read method: upsertDocument/);
+    expect(blockedAccesses).toContain("upsertDocument");
+  });
+
+  test("resolve rejects inverted hints before core resolution", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const { facade, readAccesses, blockedAccesses } =
+      createReadOnlyStoreFacade(store);
+    const created = await handleSection(
+      { action: "create", ref: doc.uri, anchor: "setup" },
+      toolContext(false)
+    );
+    expect(created.isError).toBeFalsy();
+    const createData = created.structuredContent as SectionMcpResult;
+
+    readAccesses.length = 0;
+    const result = await handleSection(
+      {
+        action: "resolve",
+        ref: doc.uri,
+        target: {
+          ...createData.target,
+          hints: {
+            ...createData.target.hints,
+            startOffset: 40,
+            endOffset: 10,
+          },
+        },
+      },
+      toolContext(false, facade)
+    );
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      error: "VALIDATION",
+    });
+    expect(String(result.structuredContent?.message)).toContain(
+      "hints.endOffset"
+    );
+    expect(readAccesses).toEqual([]);
+    expect(blockedAccesses).toEqual([]);
+  });
+
+  test("resolve rejects oversized serialized target before core resolution", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const { facade, readAccesses } = createReadOnlyStoreFacade(store);
+    const oversized = oversizedSerializedTarget();
+
+    const result = await handleSection(
+      {
+        action: "resolve",
+        ref: doc.uri,
+        target: oversized,
+      },
+      toolContext(false, facade)
+    );
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      error: "VALIDATION",
+      message: "Section target exceeds size bounds",
+    });
+    expect(readAccesses).toEqual([]);
+  });
+
+  test("gno_get line-range behavior remains unchanged", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const result = await handleGet(
+      { ref: doc.uri, fromLine: 3, lineCount: 2, lineNumbers: true },
+      toolContext(false)
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+      uri: doc.uri,
+      returnedLines: { start: 3, end: 4 },
+    });
+    expect(result.structuredContent?.content).toBe("3: ## Setup\n4: ");
+  });
+});

--- a/test/sdk/section-targets.test.ts
+++ b/test/sdk/section-targets.test.ts
@@ -12,7 +12,8 @@ import {
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdir, writeFile } from "node:fs/promises";
+// Bun has no atomic temporary-directory creation API.
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -43,7 +44,7 @@ describe("SDK section targets", () => {
   let notesDir: string;
 
   beforeAll(async () => {
-    testDir = join(tmpdir(), `gno-sdk-section-targets-${Date.now()}`);
+    testDir = await mkdtemp(join(tmpdir(), "gno-sdk-section-targets-"));
     notesDir = join(testDir, "notes");
     await mkdir(notesDir, { recursive: true });
 

--- a/test/sdk/section-targets.test.ts
+++ b/test/sdk/section-targets.test.ts
@@ -1,0 +1,235 @@
+/**
+ * SDK section-target create/resolve tests using the shared semantic matrix.
+ */
+
+import {
+  createDefaultConfig,
+  createGnoClient,
+  GnoSdkError,
+  type GnoClient,
+  type SectionTargetResolveResult,
+} from "@gmickel/gno";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import createResultSchema from "../../spec/output-schemas/section-target-create-result.schema.json";
+import resolveResultSchema from "../../spec/output-schemas/section-target-resolve-result.schema.json";
+import targetSchema from "../../spec/output-schemas/section-target.schema.json";
+import {
+  CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+  SECTION_TARGET_BOUNDS,
+} from "../../src/core/sections";
+import { safeRm } from "../helpers/cleanup";
+import {
+  SECTION_FIXTURE_CONTENT,
+  SECTION_SEMANTIC_CASES,
+  captureFixtureTarget,
+  wrongDocumentTarget,
+} from "../helpers/section-target-fixtures";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(targetSchema);
+const validateCreate = ajv.compile(createResultSchema);
+const validateResolve = ajv.compile(resolveResultSchema);
+
+describe("SDK section targets", () => {
+  let testDir: string;
+  let client: GnoClient;
+  let notesDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `gno-sdk-section-targets-${Date.now()}`);
+    notesDir = join(testDir, "notes");
+    await mkdir(notesDir, { recursive: true });
+
+    const config = createDefaultConfig();
+    config.collections = [
+      {
+        name: "notes",
+        path: notesDir,
+        pattern: "**/*.md",
+        include: [],
+        exclude: [],
+      },
+    ];
+
+    client = await createGnoClient({
+      config,
+      dbPath: join(testDir, "index.sqlite"),
+    });
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await safeRm(testDir);
+  });
+
+  async function writeAndIndex(
+    relPath: string,
+    content: string
+  ): Promise<string> {
+    const abs = join(notesDir, relPath);
+    await mkdir(join(abs, ".."), { recursive: true });
+    await writeFile(abs, content);
+    await client.index({ noEmbed: true });
+    return `gno://notes/${relPath}`;
+  }
+
+  test("getSections remains backward compatible", async () => {
+    const uri = await writeAndIndex("compat.md", SECTION_FIXTURE_CONTENT);
+    const sections = await client.getSections(uri);
+    expect(sections.map((section) => section.anchor)).toEqual([
+      "guide",
+      "setup",
+      "usage",
+    ]);
+    expect(sections[0]).toMatchObject({
+      anchor: "guide",
+      level: 1,
+      title: "Guide",
+    });
+  });
+
+  for (const fixture of SECTION_SEMANTIC_CASES) {
+    test(`create+resolve ${fixture.id}`, async () => {
+      const captureUri = await writeAndIndex(
+        `${fixture.id}-capture.md`,
+        fixture.captureContent
+      );
+      const created = await client.createSectionTarget(
+        captureUri,
+        fixture.selector
+      );
+      expect(validateCreate(created)).toBe(true);
+      expect(created.uri).toBe(captureUri);
+      expect(created.target.document.uri).toBe(captureUri);
+
+      const resolveUri = await writeAndIndex(
+        `${fixture.id}-resolve.md`,
+        fixture.resolveContent
+      );
+      const target = {
+        ...created.target,
+        document: { uri: resolveUri },
+      };
+      const resolved: SectionTargetResolveResult =
+        await client.resolveSectionTarget(resolveUri, target);
+      expect(validateResolve(resolved)).toBe(true);
+      expect(resolved.status).toBe(fixture.expectedStatus);
+      expect(resolved.uri).toBe(resolveUri);
+      if (fixture.navigable) {
+        expect(resolved.citation?.uri).toBe(resolveUri);
+        expect(resolved.citation?.anchor).toBeTruthy();
+      } else {
+        expect(resolved.citation).toBeUndefined();
+      }
+    });
+  }
+
+  test("rejects invalid selectors and malformed targets", async () => {
+    const uri = await writeAndIndex("validate.md", SECTION_FIXTURE_CONTENT);
+
+    try {
+      await client.createSectionTarget(uri, {
+        anchor: "setup",
+        line: 3,
+      } as never);
+      throw new Error("expected validation failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(GnoSdkError);
+    }
+
+    try {
+      await client.createSectionTarget(uri, {} as never);
+      throw new Error("expected validation failure");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "VALIDATION" });
+    }
+
+    try {
+      await client.resolveSectionTarget(uri, {
+        schemaVersion: "1",
+      } as never);
+      throw new Error("expected validation failure");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "VALIDATION" });
+    }
+  });
+
+  test("wrong-document target resolves as missing without citation", async () => {
+    const uri = await writeAndIndex("wrong-doc.md", SECTION_FIXTURE_CONTENT);
+    const wrong = await wrongDocumentTarget(SECTION_FIXTURE_CONTENT);
+    const resolved = await client.resolveSectionTarget(uri, wrong);
+    expect(validateResolve(resolved)).toBe(true);
+    expect(resolved.status).toBe("missing");
+    expect(resolved.diagnostics.reason).toBe("document_uri_mismatch");
+    expect(resolved.citation).toBeUndefined();
+    expect(resolved.uri).toBe(uri);
+  });
+
+  test("rejects create/resolve when stored canonical URI exceeds transport bounds", async () => {
+    const uri = await writeAndIndex(
+      "oversized-canonical.md",
+      SECTION_FIXTURE_CONTENT
+    );
+    const oversizedUri = `gno://notes/${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars)}`;
+    expect(oversizedUri.length).toBeGreaterThan(
+      SECTION_TARGET_BOUNDS.uriMaxChars
+    );
+
+    const store = (
+      client as unknown as {
+        store: {
+          getDocumentByUri: (requested: string) => Promise<{
+            ok: boolean;
+            value?: { uri: string } | null;
+            error?: unknown;
+          }>;
+        };
+      }
+    ).store;
+    const originalGetByUri = store.getDocumentByUri.bind(store);
+    store.getDocumentByUri = async (requested: string) => {
+      const result = await originalGetByUri(requested);
+      if (!result.ok || !result.value) return result;
+      return {
+        ...result,
+        value: { ...result.value, uri: oversizedUri },
+      };
+    };
+
+    try {
+      try {
+        await client.createSectionTarget(uri, { anchor: "setup" });
+        throw new Error("expected create validation failure");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GnoSdkError);
+        expect(error).toMatchObject({
+          code: "VALIDATION",
+          message: CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+        });
+      }
+
+      const target = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+        anchor: "setup",
+      });
+      try {
+        await client.resolveSectionTarget(uri, target);
+        throw new Error("expected resolve validation failure");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GnoSdkError);
+        expect(error).toMatchObject({
+          code: "VALIDATION",
+          message: CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+        });
+      }
+    } finally {
+      store.getDocumentByUri = originalGetByUri;
+    }
+  });
+});

--- a/test/serve/api-section-targets.test.ts
+++ b/test/serve/api-section-targets.test.ts
@@ -1,0 +1,319 @@
+/**
+ * REST section-target create/resolve + sections compatibility tests.
+ */
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { DocumentInput, DocumentRow } from "../../src/store/types";
+
+import createResultSchema from "../../spec/output-schemas/section-target-create-result.schema.json";
+import resolveResultSchema from "../../spec/output-schemas/section-target-resolve-result.schema.json";
+import targetSchema from "../../spec/output-schemas/section-target.schema.json";
+import {
+  CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS,
+  SECTION_TARGET_BOUNDS,
+  type SectionTargetCreateResult,
+  type SectionTargetResolveResult,
+} from "../../src/core/sections";
+import { handleDocSections } from "../../src/serve/routes/api";
+import {
+  handleCreateSectionTarget,
+  handleResolveSectionTarget,
+} from "../../src/serve/routes/section-targets";
+import { SqliteAdapter } from "../../src/store/sqlite/adapter";
+import { safeRm } from "../helpers/cleanup";
+import {
+  SECTION_FIXTURE_CONTENT,
+  SECTION_FIXTURE_URI,
+  SECTION_SEMANTIC_CASES,
+  captureFixtureTarget,
+  wrongDocumentTarget,
+} from "../helpers/section-target-fixtures";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(targetSchema);
+const validateCreate = ajv.compile(createResultSchema);
+const validateResolve = ajv.compile(resolveResultSchema);
+
+describe("REST section targets", () => {
+  let tmpDir: string;
+  let store: SqliteAdapter;
+  let contentByHash: Map<string, string>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "gno-section-targets-"));
+    store = new SqliteAdapter();
+    const opened = await store.open(join(tmpDir, "test.db"), "porter");
+    expect(opened.ok).toBe(true);
+
+    const sync = await store.syncCollections([
+      {
+        name: "notes",
+        path: tmpDir,
+        pattern: "**/*.md",
+        include: [],
+        exclude: [],
+      },
+    ]);
+    expect(sync.ok).toBe(true);
+
+    contentByHash = new Map();
+    const originalGetContent = store.getContent.bind(store);
+    store.getContent = async (hash: string) => {
+      const local = contentByHash.get(hash);
+      if (local !== undefined) {
+        return { ok: true as const, value: local };
+      }
+      return originalGetContent(hash);
+    };
+  });
+
+  afterEach(async () => {
+    await store.close();
+    await safeRm(tmpDir);
+  });
+
+  async function upsertDoc(
+    content: string,
+    relPath = "pilot.md"
+  ): Promise<{ docid: string; uri: string }> {
+    const hash = `h-${Bun.hash(content).toString(16)}`;
+    contentByHash.set(hash, content);
+    const doc: DocumentInput = {
+      collection: "notes",
+      relPath,
+      sourceHash: hash,
+      sourceMime: "text/markdown",
+      sourceExt: ".md",
+      sourceSize: content.length,
+      sourceMtime: new Date().toISOString(),
+      title: "Pilot",
+      mirrorHash: hash,
+      ingestVersion: 2,
+    };
+    const result = await store.upsertDocument(doc);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("upsert failed");
+    const loaded = await store.getDocumentByDocid(result.value.docid);
+    expect(loaded.ok).toBe(true);
+    expect(loaded.ok && loaded.value).toBeTruthy();
+    if (!loaded.ok || !loaded.value) throw new Error("load failed");
+    return { docid: loaded.value.docid, uri: loaded.value.uri };
+  }
+
+  test("GET /api/doc/:id/sections remains backward compatible", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const res = await handleDocSections(store, doc.docid);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sections: Array<{ anchor: string; line: number; title: string }>;
+    };
+    expect(body.sections.map((section) => section.anchor)).toEqual([
+      "guide",
+      "setup",
+      "usage",
+    ]);
+    expect(Object.keys(body)).toEqual(["sections"]);
+  });
+
+  for (const fixture of SECTION_SEMANTIC_CASES) {
+    test(`create+resolve ${fixture.id}`, async () => {
+      const captureDoc = await upsertDoc(fixture.captureContent, "capture.md");
+      const createRes = await handleCreateSectionTarget(
+        store,
+        captureDoc.docid,
+        new Request("http://localhost/api/doc/x/section-targets", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(fixture.selector),
+        })
+      );
+      expect(createRes.status).toBe(200);
+      const created = (await createRes.json()) as SectionTargetCreateResult;
+      expect(validateCreate(created)).toBe(true);
+      expect(created.uri).toBe(captureDoc.uri);
+      expect(created.target.document.uri).toBe(captureDoc.uri);
+
+      const resolveDoc = await upsertDoc(fixture.resolveContent, "resolve.md");
+      // Retarget captured evidence to the resolve document URI for same-doc cases.
+      const targetForResolve = {
+        ...created.target,
+        document: { uri: resolveDoc.uri },
+      };
+
+      const resolveRes = await handleResolveSectionTarget(
+        store,
+        resolveDoc.docid,
+        new Request("http://localhost/api/doc/x/section-targets/resolve", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ target: targetForResolve }),
+        })
+      );
+      expect(resolveRes.status).toBe(200);
+      const resolved = (await resolveRes.json()) as SectionTargetResolveResult;
+      expect(validateResolve(resolved)).toBe(true);
+      expect(resolved.status).toBe(fixture.expectedStatus);
+      expect(resolved.uri).toBe(resolveDoc.uri);
+      if (fixture.navigable) {
+        expect(resolved.citation).toBeDefined();
+        expect(resolved.citation?.uri).toBe(resolveDoc.uri);
+      } else {
+        expect(resolved.citation).toBeUndefined();
+        expect("section" in resolved).toBe(false);
+      }
+    });
+  }
+
+  test("rejects invalid create selectors and oversized bodies", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+
+    const both = await handleCreateSectionTarget(
+      store,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ anchor: "setup", line: 3 }),
+      })
+    );
+    expect(both.status).toBe(400);
+
+    const neither = await handleCreateSectionTarget(
+      store,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({}),
+      })
+    );
+    expect(neither.status).toBe(400);
+
+    const oversized = await handleCreateSectionTarget(
+      store,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: "x".repeat(2048),
+      })
+    );
+    expect(oversized.status).toBe(400);
+  });
+
+  test("rejects malformed resolve targets and wrong-document targets", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+
+    const malformed = await handleResolveSectionTarget(
+      store,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ target: { schemaVersion: "1" } }),
+      })
+    );
+    expect(malformed.status).toBe(400);
+
+    const wrong = await wrongDocumentTarget(SECTION_FIXTURE_CONTENT);
+    const mismatch = await handleResolveSectionTarget(
+      store,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ target: wrong }),
+      })
+    );
+    expect(mismatch.status).toBe(200);
+    const body = (await mismatch.json()) as SectionTargetResolveResult;
+    expect(validateResolve(body)).toBe(true);
+    expect(body.status).toBe("missing");
+    expect(body.diagnostics.reason).toBe("document_uri_mismatch");
+    expect(body.citation).toBeUndefined();
+    expect(body.uri).toBe(doc.uri);
+  });
+
+  test("create uses stored uri even when capture fixture uri differs", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const res = await handleCreateSectionTarget(
+      store,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ anchor: "setup" }),
+      })
+    );
+    const body = (await res.json()) as SectionTargetCreateResult;
+    expect(body.uri).toBe(doc.uri);
+    expect(body.target.document.uri).toBe(doc.uri);
+    expect(body.uri).not.toBe(SECTION_FIXTURE_URI);
+
+    const coreTarget = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    expect(coreTarget.document.uri).toBe(SECTION_FIXTURE_URI);
+  });
+
+  test("rejects create/resolve when stored canonical URI exceeds transport bounds", async () => {
+    const doc = await upsertDoc(SECTION_FIXTURE_CONTENT);
+    const oversizedUri = `gno://notes/${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars)}`;
+    expect(oversizedUri.length).toBeGreaterThan(
+      SECTION_TARGET_BOUNDS.uriMaxChars
+    );
+
+    const withOversizedUri = {
+      getDocumentByDocid: async (docid: string) => {
+        const result = await store.getDocumentByDocid(docid);
+        if (!result.ok || !result.value) return result;
+        return {
+          ok: true as const,
+          value: { ...result.value, uri: oversizedUri } satisfies DocumentRow,
+        };
+      },
+      getDocumentByUri: store.getDocumentByUri.bind(store),
+      getContent: store.getContent.bind(store),
+    };
+
+    const createRes = await handleCreateSectionTarget(
+      withOversizedUri,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ anchor: "setup" }),
+      })
+    );
+    expect(createRes.status).toBe(422);
+    const createBody = (await createRes.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(createBody.error.code).toBe("VALIDATION");
+    expect(createBody.error.message).toBe(
+      CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS
+    );
+    expect(JSON.stringify(createBody)).not.toContain(oversizedUri);
+
+    const target = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const resolveRes = await handleResolveSectionTarget(
+      withOversizedUri,
+      doc.docid,
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ target }),
+      })
+    );
+    expect(resolveRes.status).toBe(422);
+    const resolveBody = (await resolveRes.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(resolveBody.error.code).toBe("VALIDATION");
+    expect(resolveBody.error.message).toBe(
+      CANONICAL_URI_EXCEEDS_TRANSPORT_BOUNDS
+    );
+    expect(JSON.stringify(resolveBody)).not.toContain(oversizedUri);
+  });
+});

--- a/test/serve/public/lib/deep-links.test.ts
+++ b/test/serve/public/lib/deep-links.test.ts
@@ -41,4 +41,17 @@ describe("deep link helpers", () => {
       lineEnd: 14,
     });
   });
+
+  test("parseDocumentDeepLink ignores additive citation selectors", () => {
+    expect(
+      parseDocumentDeepLink(
+        "?uri=gno%3A%2F%2Fnotes%2Freadme.md&view=rendered&st=1.abc"
+      )
+    ).toEqual({
+      uri: "gno://notes/readme.md",
+      view: "rendered",
+      lineStart: undefined,
+      lineEnd: undefined,
+    });
+  });
 });

--- a/test/serve/public/lib/section-links.test.ts
+++ b/test/serve/public/lib/section-links.test.ts
@@ -1,0 +1,202 @@
+/**
+ * URL/copy behavior for readable section links vs citation selectors.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createSectionTarget,
+  SECTION_TARGET_LINK_PARAM,
+} from "../../../../src/core/sections";
+import {
+  buildCitationSectionUrl,
+  buildReadableSectionUrl,
+  createCitationSectionUrl,
+  readSectionTargetLinkParam,
+  resolveSectionLinkNavigation,
+  SECTION_LINK_NOTICE_COPY,
+  stripSectionTargetLinkParam,
+} from "../../../../src/serve/public/lib/section-links";
+import {
+  SECTION_AMBIGUOUS_CONTENT,
+  SECTION_FIXTURE_CONTENT,
+  SECTION_FIXTURE_URI,
+  SECTION_MISSING_CONTENT,
+  SECTION_RECOVERED_CONTENT,
+  SECTION_STALE_CONTENT,
+  captureFixtureTarget,
+} from "../../../helpers/section-target-fixtures";
+
+const ORIGIN = "http://127.0.0.1:3000";
+
+describe("section link helpers", () => {
+  test("readable copy-link stays human and omits durable selector", () => {
+    const url = buildReadableSectionUrl(ORIGIN, {
+      uri: SECTION_FIXTURE_URI,
+      view: "rendered",
+      anchor: "setup",
+    });
+    expect(url).toBe(
+      `${ORIGIN}/doc?uri=gno%3A%2F%2Fwork%2Fnotes%2Fpilot.md&view=rendered#setup`
+    );
+    expect(url.includes(`${SECTION_TARGET_LINK_PARAM}=`)).toBe(false);
+    expect(url).not.toContain("Install Bun");
+  });
+
+  test("citation link is additive versioned and size-bounded", async () => {
+    const target = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const url = buildCitationSectionUrl(
+      ORIGIN,
+      {
+        uri: SECTION_FIXTURE_URI,
+        view: "rendered",
+        anchor: "setup",
+      },
+      target
+    );
+    expect(url).not.toBeNull();
+    expect(url!).toContain(`#setup`);
+    expect(url!).toContain(`${SECTION_TARGET_LINK_PARAM}=1.`);
+    expect(url!.length).toBeLessThan(4000);
+
+    const param = readSectionTargetLinkParam(
+      `?${url!.split("?")[1]?.split("#")[0] ?? ""}`
+    );
+    expect(param?.startsWith("1.")).toBe(true);
+  });
+
+  test("old readable links still navigate without citation evidence", async () => {
+    const result = await resolveSectionLinkNavigation({
+      content: SECTION_FIXTURE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: null,
+      hashAnchor: "setup",
+    });
+    expect(result.blockHashNavigation).toBe(false);
+    expect(result.navigateAnchor).toBe("setup");
+    expect(result.notice).toBeNull();
+  });
+
+  test("exact and recovered citation links navigate to current anchor", async () => {
+    const created = await createCitationSectionUrl({
+      origin: ORIGIN,
+      uri: SECTION_FIXTURE_URI,
+      content: SECTION_FIXTURE_CONTENT,
+      anchor: "setup",
+    });
+    expect(created).not.toBeNull();
+    const encoded = readSectionTargetLinkParam(
+      `?${created!.split("?")[1]?.split("#")[0] ?? ""}`
+    );
+
+    const exact = await resolveSectionLinkNavigation({
+      content: SECTION_FIXTURE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: encoded,
+      hashAnchor: "setup",
+    });
+    expect(exact.blockHashNavigation).toBe(false);
+    expect(exact.navigateAnchor).toBe("setup");
+    expect(exact.notice).toBe("exact");
+    expect(exact.cleanCitationParam).toBe(true);
+
+    const recovered = await resolveSectionLinkNavigation({
+      content: SECTION_RECOVERED_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: encoded,
+      hashAnchor: "setup",
+    });
+    expect(recovered.blockHashNavigation).toBe(false);
+    expect(recovered.navigateAnchor).toBe("getting-started");
+    expect(recovered.notice).toBe("recovered");
+  });
+
+  test("ambiguous stale missing and invalid never navigate", async () => {
+    const twin = await createSectionTarget({
+      content: SECTION_AMBIGUOUS_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      anchor: "twin",
+    });
+    expect(twin).not.toBeNull();
+    const twinUrl = buildCitationSectionUrl(
+      ORIGIN,
+      { uri: SECTION_FIXTURE_URI, anchor: "twin" },
+      twin!
+    );
+    const twinEncoded = readSectionTargetLinkParam(
+      `?${twinUrl!.split("?")[1]?.split("#")[0] ?? ""}`
+    );
+    const moreIdentical = [
+      SECTION_AMBIGUOUS_CONTENT,
+      "",
+      "## Twin",
+      "",
+      "Identical twin body text.",
+    ].join("\n");
+    const ambiguous = await resolveSectionLinkNavigation({
+      content: moreIdentical,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: twinEncoded,
+      hashAnchor: "twin",
+    });
+    expect(ambiguous.blockHashNavigation).toBe(true);
+    expect(ambiguous.navigateAnchor).toBeNull();
+    expect(ambiguous.notice).toBe("ambiguous");
+
+    const setup = await captureFixtureTarget(SECTION_FIXTURE_CONTENT, {
+      anchor: "setup",
+    });
+    const setupUrl = buildCitationSectionUrl(
+      ORIGIN,
+      { uri: SECTION_FIXTURE_URI, anchor: "setup" },
+      setup
+    );
+    const setupEncoded = readSectionTargetLinkParam(
+      `?${setupUrl!.split("?")[1]?.split("#")[0] ?? ""}`
+    );
+
+    const stale = await resolveSectionLinkNavigation({
+      content: SECTION_STALE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: setupEncoded,
+      hashAnchor: "setup",
+    });
+    expect(stale.blockHashNavigation).toBe(true);
+    expect(stale.navigateAnchor).toBeNull();
+    expect(stale.notice).toBe("stale");
+
+    const missing = await resolveSectionLinkNavigation({
+      content: SECTION_MISSING_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: setupEncoded,
+      hashAnchor: "setup",
+    });
+    expect(missing.blockHashNavigation).toBe(true);
+    expect(missing.navigateAnchor).toBeNull();
+    expect(missing.notice).toBe("missing");
+
+    const invalid = await resolveSectionLinkNavigation({
+      content: SECTION_FIXTURE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      encodedTarget: "1.not-valid-base64!!!",
+      hashAnchor: "setup",
+    });
+    expect(invalid.blockHashNavigation).toBe(true);
+    expect(invalid.navigateAnchor).toBeNull();
+    expect(invalid.notice).toBe("invalid_citation");
+  });
+
+  test("notice copy never embeds section bodies and strip removes st only", () => {
+    for (const copy of Object.values(SECTION_LINK_NOTICE_COPY)) {
+      expect(copy.includes("Install Bun")).toBe(false);
+      expect(copy.includes("Identical twin")).toBe(false);
+    }
+    expect(
+      stripSectionTargetLinkParam(
+        "?uri=gno%3A%2F%2Fwork%2Fnotes%2Fpilot.md&view=rendered&st=1.abc"
+      )
+    ).toBe("?uri=gno%3A%2F%2Fwork%2Fnotes%2Fpilot.md&view=rendered");
+  });
+});

--- a/test/serve/public/pages/DocView.dom.test.tsx
+++ b/test/serve/public/pages/DocView.dom.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { useEffect, useRef } from "react";
 
+import { extractSections } from "../../../../src/core/sections";
 import { apiOk, renderWithUser, setTestLocation } from "../../../helpers/dom";
 
 const apiFetch = mock(async (..._args: unknown[]) => apiOk<unknown>({}));
@@ -36,7 +37,18 @@ void mock.module(
 );
 
 void mock.module("../../../../src/serve/public/components/editor", () => ({
-  MarkdownPreview: ({ content }: { content: string }) => <div>{content}</div>,
+  MarkdownPreview: ({ content }: { content: string }) => (
+    <div>
+      {extractSections(content).map((section) => (
+        <div
+          data-section-anchor={section.anchor}
+          id={section.anchor}
+          key={section.anchor}
+        />
+      ))}
+      <div>{content}</div>
+    </div>
+  ),
 }));
 
 void mock.module(
@@ -790,5 +802,216 @@ describe("DocView PDF integration (fn-112.5)", () => {
       )
     ).toBeTruthy();
     expect(screen.queryByTestId("pdf-no-extracted-text")).toBeNull();
+  });
+});
+
+const SECTION_OUTLINE_URI = "gno://work/notes/pilot.md";
+const SECTION_OUTLINE_CONTENT = [
+  "# Guide",
+  "",
+  "## Setup",
+  "",
+  "Install Bun first.",
+  "Then run tests.",
+  "",
+  "## Usage",
+  "",
+  "Call createSectionTarget.",
+].join("\n");
+
+function mockSectionOutlineDoc() {
+  apiFetch.mockImplementation(async (...args: unknown[]) => {
+    const endpoint = typeof args[0] === "string" ? args[0] : "";
+    if (endpoint.startsWith("/api/doc?uri=")) {
+      return apiOk({
+        docid: "outline-1",
+        uri: SECTION_OUTLINE_URI,
+        title: "Guide",
+        content: SECTION_OUTLINE_CONTENT,
+        contentAvailable: true,
+        collection: "work",
+        relPath: "notes/pilot.md",
+        tags: [],
+        source: {
+          mime: "text/markdown",
+          ext: ".md",
+          modifiedAt: "2026-08-03T10:00:00.000Z",
+          sizeBytes: 180,
+          sourceHash: "outline-hash",
+        },
+        capabilities: {
+          editable: true,
+          tagsEditable: true,
+          tagsWriteback: true,
+          canCreateEditableCopy: false,
+          mode: "editable",
+        },
+      });
+    }
+    if (endpoint.includes("/links")) {
+      return apiOk({ links: [] });
+    }
+    return apiOk({});
+  });
+}
+
+function installClipboardMock(writeText: (text: string) => Promise<void>) {
+  const clipboard = window.navigator.clipboard as {
+    writeText: (text: string) => Promise<void>;
+    readText: () => Promise<string>;
+  };
+  const previousWriteText = clipboard.writeText.bind(clipboard);
+  const calls: string[] = [];
+  clipboard.writeText = async (text: string) => {
+    calls.push(text);
+    await writeText(text);
+  };
+  return {
+    calls,
+    restore: () => {
+      clipboard.writeText = previousWriteText;
+    },
+  };
+}
+
+describe("DocView outline section links (fn-61.7)", () => {
+  let restoreClipboard: (() => void) | null = null;
+
+  afterEach(() => {
+    restoreClipboard?.();
+    restoreClipboard = null;
+    cleanup();
+  });
+
+  beforeEach(() => {
+    apiFetch.mockReset();
+    mockSectionOutlineDoc();
+    setTestLocation(
+      `/doc?uri=${encodeURIComponent(SECTION_OUTLINE_URI)}&view=rendered`
+    );
+  });
+
+  test("outline exposes readable and citation controls with distinct copy payloads", async () => {
+    const clipboard = installClipboardMock(async () => undefined);
+    restoreClipboard = clipboard.restore;
+
+    const { default: DocView } =
+      await import("../../../../src/serve/public/pages/DocView");
+    const { user } = renderWithUser(
+      <DocView navigate={mock(() => undefined)} />
+    );
+
+    await screen.findByText("Outline");
+    const readable = await screen.findByRole("button", {
+      name: "Copy link to Setup",
+    });
+    const citation = screen.getByRole("button", {
+      name: "Copy local citation link to Setup",
+    });
+    expect(readable).toBeTruthy();
+    expect(citation).toBeTruthy();
+
+    await user.click(readable);
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "Copied section link"
+      );
+    });
+    expect(clipboard.calls).toHaveLength(1);
+    expect(clipboard.calls[0]).toContain("#setup");
+    expect(clipboard.calls[0]).not.toContain("st=");
+
+    await user.click(citation);
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "Copied citation link"
+      );
+    });
+    expect(clipboard.calls).toHaveLength(2);
+    expect(clipboard.calls[1]).toContain("#setup");
+    expect(clipboard.calls[1]).toMatch(/[?&]st=1\./u);
+    expect(clipboard.calls[1]!.length).toBeLessThan(4000);
+  });
+
+  test("clipboard rejection shows unavailable feedback without copied-success", async () => {
+    const clipboard = installClipboardMock(async () => {
+      throw new Error("clipboard denied");
+    });
+    restoreClipboard = clipboard.restore;
+
+    const { default: DocView } =
+      await import("../../../../src/serve/public/pages/DocView");
+    const { user } = renderWithUser(
+      <DocView navigate={mock(() => undefined)} />
+    );
+
+    await screen.findByText("Outline");
+    await user.click(
+      await screen.findByRole("button", { name: "Copy link to Setup" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "Could not copy link"
+      );
+    });
+    expect(clipboard.calls).toHaveLength(1);
+    expect(screen.queryByText("Copied section link")).toBeNull();
+    expect(screen.queryByText("Copied citation link")).toBeNull();
+  });
+
+  test("invalid citation selector blocks hash navigation at the DocView boundary", async () => {
+    const scrolledIds: string[] = [];
+    const proto = window.HTMLElement.prototype;
+    const originalScrollDescriptor = Object.getOwnPropertyDescriptor(
+      proto,
+      "scrollIntoView"
+    );
+    proto.scrollIntoView = function scrollIntoViewSpy(
+      this: HTMLElement,
+      ..._args: unknown[]
+    ) {
+      if (this.id) {
+        scrolledIds.push(this.id);
+      }
+    };
+
+    try {
+      setTestLocation(
+        `/doc?uri=${encodeURIComponent(SECTION_OUTLINE_URI)}&view=rendered&st=1.not-valid-base64!!!#setup`
+      );
+
+      const { default: DocView } =
+        await import("../../../../src/serve/public/pages/DocView");
+      renderWithUser(<DocView navigate={mock(() => undefined)} />);
+
+      await screen.findByText("Outline");
+      await waitFor(() => {
+        expect(screen.getByRole("status").textContent).toBe(
+          "Invalid section citation — not navigating"
+        );
+      });
+
+      // Flush any pending rAF scroll attempts from mount effects.
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+      });
+
+      expect(scrolledIds).not.toContain("setup");
+      expect(window.location.search).toContain("st=1.not-valid-base64");
+      expect(window.location.hash).toBe("#setup");
+    } finally {
+      if (originalScrollDescriptor) {
+        Object.defineProperty(
+          proto,
+          "scrollIntoView",
+          originalScrollDescriptor
+        );
+      }
+    }
   });
 });

--- a/test/spec/schemas/section-target-transport.test.ts
+++ b/test/spec/schemas/section-target-transport.test.ts
@@ -1,0 +1,439 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { describe, expect, test } from "bun:test";
+
+import createResultSchema from "../../../spec/output-schemas/section-target-create-result.schema.json";
+import resolveResultSchema from "../../../spec/output-schemas/section-target-resolve-result.schema.json";
+import targetSchema from "../../../spec/output-schemas/section-target.schema.json";
+import {
+  CITATION_EXCEEDS_TRANSPORT_BOUNDS,
+  SECTION_TARGET_BOUNDS,
+  SECTION_TARGET_TRANSPORT_BOUNDS,
+  createSectionTarget,
+  isTransportBoundedCanonicalUri,
+  isTransportBoundedCitation,
+  parseSectionTargetCreateSelector,
+  parseSectionTargetV1,
+  projectSectionTargetCreateResult,
+  projectSectionTargetResolveResult,
+  resolveSectionTarget,
+  type SectionResolution,
+  type SectionTargetV1,
+} from "../../../src/core/sections";
+import {
+  SECTION_FIXTURE_CONTENT,
+  SECTION_FIXTURE_URI,
+  SECTION_MISSING_CONTENT,
+  SECTION_RECOVERED_CONTENT,
+} from "../../helpers/section-target-fixtures";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(targetSchema);
+const validateCreate = ajv.compile(createResultSchema);
+const validateResolve = ajv.compile(resolveResultSchema);
+const validateTarget = ajv.compile(targetSchema);
+
+const fingerprint = "a".repeat(64);
+
+const baseTarget = (): SectionTargetV1 => ({
+  schemaVersion: "1",
+  document: { uri: SECTION_FIXTURE_URI },
+  anchor: "setup",
+  headingPath: ["Guide", "Setup"],
+  occurrence: 1,
+  quote: { exact: "Install Bun first.", prefix: "\n\n", suffix: "\n" },
+  sourceFingerprint: fingerprint,
+  hints: { line: 3, startOffset: 20, endOffset: 38 },
+});
+
+describe("section-target transport schemas", () => {
+  test("create and navigable resolve projections match schemas", async () => {
+    const target = await createSectionTarget({
+      content: SECTION_FIXTURE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      anchor: "setup",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const created = projectSectionTargetCreateResult(
+      SECTION_FIXTURE_URI,
+      target
+    );
+    expect(validateCreate(created)).toBe(true);
+
+    const exact = await resolveSectionTarget({
+      content: SECTION_FIXTURE_CONTENT,
+      target,
+      uri: SECTION_FIXTURE_URI,
+    });
+    const exactProjected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      exact
+    );
+    expect(validateResolve(exactProjected)).toBe(true);
+    expect(exactProjected.citation).toBeDefined();
+
+    const recovered = await resolveSectionTarget({
+      content: SECTION_RECOVERED_CONTENT,
+      target,
+      uri: SECTION_FIXTURE_URI,
+    });
+    const recoveredProjected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      recovered
+    );
+    expect(validateResolve(recoveredProjected)).toBe(true);
+    expect(recoveredProjected.status).toBe("recovered");
+    expect(recoveredProjected.citation).toBeDefined();
+  });
+
+  test("non-navigable resolve projections omit citation", async () => {
+    const target = await createSectionTarget({
+      content: SECTION_FIXTURE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      anchor: "setup",
+    });
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const missing = await resolveSectionTarget({
+      content: SECTION_MISSING_CONTENT,
+      target,
+      uri: SECTION_FIXTURE_URI,
+    });
+    const projected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      missing
+    );
+    expect(projected.status).toBe("missing");
+    expect(projected.citation).toBeUndefined();
+    expect(validateResolve(projected)).toBe(true);
+
+    expect(
+      validateResolve({
+        ...projected,
+        citation: {
+          uri: SECTION_FIXTURE_URI,
+          anchor: "setup",
+          title: "Setup",
+          lineStart: 3,
+          lineEnd: 6,
+          sourceFingerprint: projected.currentFingerprint,
+        },
+      })
+    ).toBe(false);
+  });
+
+  test("caps >32 candidates with explicit count and truncation flag", () => {
+    const total =
+      SECTION_TARGET_TRANSPORT_BOUNDS.diagnosticsCandidatesMaxItems + 8;
+    const candidates = Array.from({ length: total }, (_, index) => ({
+      anchor: `twin-${index + 1}`,
+      line: index + 1,
+      title: "Twin",
+      headingPath: ["Guide", "Twin"],
+      occurrence: index + 1,
+    }));
+    const resolution: SectionResolution = {
+      status: "ambiguous",
+      target: baseTarget(),
+      currentFingerprint: fingerprint,
+      reason: "quote_context_multiple_matches",
+      candidates,
+    };
+
+    const projected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      resolution
+    );
+    expect(projected.status).toBe("ambiguous");
+    expect(projected.citation).toBeUndefined();
+    expect(projected.diagnostics.candidateCount).toBe(total);
+    expect(projected.diagnostics.candidatesTruncated).toBe(true);
+    expect(projected.diagnostics.candidates).toHaveLength(
+      SECTION_TARGET_TRANSPORT_BOUNDS.diagnosticsCandidatesMaxItems
+    );
+    expect(projected.diagnostics.candidates?.[0]?.anchor).toBe("twin-1");
+    expect(projected.diagnostics.candidates?.at(-1)?.anchor).toBe(
+      `twin-${SECTION_TARGET_TRANSPORT_BOUNDS.diagnosticsCandidatesMaxItems}`
+    );
+    expect(validateResolve(projected)).toBe(true);
+  });
+
+  test("filters oversized candidate identity without truncating strings", () => {
+    const oversizedTitle = "T".repeat(
+      SECTION_TARGET_TRANSPORT_BOUNDS.titleMaxChars + 1
+    );
+    const resolution: SectionResolution = {
+      status: "ambiguous",
+      target: baseTarget(),
+      currentFingerprint: fingerprint,
+      reason: "quote_context_multiple_matches",
+      candidates: [
+        {
+          anchor: "ok",
+          line: 1,
+          title: "Ok",
+          headingPath: ["Guide", "Ok"],
+          occurrence: 1,
+        },
+        {
+          anchor: "too-long",
+          line: 2,
+          title: oversizedTitle,
+          headingPath: ["Guide", oversizedTitle],
+          occurrence: 1,
+        },
+      ],
+    };
+
+    const projected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      resolution
+    );
+    expect(projected.diagnostics.candidateCount).toBe(2);
+    expect(projected.diagnostics.candidatesTruncated).toBe(true);
+    expect(projected.diagnostics.candidates).toEqual([
+      {
+        anchor: "ok",
+        line: 1,
+        title: "Ok",
+        headingPath: ["Guide", "Ok"],
+        occurrence: 1,
+      },
+    ]);
+    expect(
+      projected.diagnostics.candidates?.some((entry) =>
+        entry.title.includes(oversizedTitle.slice(0, 8))
+      )
+    ).toBe(false);
+    expect(validateResolve(projected)).toBe(true);
+  });
+
+  test("oversized recovered citation becomes stale without truncating identity", () => {
+    const oversizedTitle = "R".repeat(
+      SECTION_TARGET_TRANSPORT_BOUNDS.titleMaxChars + 40
+    );
+    const resolution: SectionResolution = {
+      status: "recovered",
+      target: baseTarget(),
+      currentFingerprint: fingerprint,
+      section: {
+        anchor: "recovered",
+        level: 2,
+        line: 3,
+        title: oversizedTitle,
+        endLine: 6,
+      },
+    };
+
+    const projected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      resolution
+    );
+    expect(projected.status).toBe("stale");
+    expect(projected.citation).toBeUndefined();
+    expect(projected.diagnostics.reason).toBe(
+      CITATION_EXCEEDS_TRANSPORT_BOUNDS
+    );
+    expect(JSON.stringify(projected)).not.toContain(oversizedTitle);
+    expect(validateResolve(projected)).toBe(true);
+  });
+
+  test("oversized top-level canonical URI is schema-invalid without substitution", () => {
+    const oversizedUri = `gno://${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars)}`;
+    expect(isTransportBoundedCanonicalUri(oversizedUri)).toBe(false);
+    expect(
+      isTransportBoundedCanonicalUri(
+        `gno://${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars - 6)}`
+      )
+    ).toBe(true);
+
+    const target = baseTarget();
+    const created = projectSectionTargetCreateResult(oversizedUri, target);
+    expect(created.uri).toBe(oversizedUri);
+    expect(created.target.document.uri).toBe(SECTION_FIXTURE_URI);
+    expect(validateCreate(created)).toBe(false);
+
+    const missing: SectionResolution = {
+      status: "missing",
+      target,
+      currentFingerprint: fingerprint,
+      reason: "document_uri_mismatch",
+    };
+    const missingProjected = projectSectionTargetResolveResult(
+      oversizedUri,
+      missing
+    );
+    expect(missingProjected.uri).toBe(oversizedUri);
+    expect(missingProjected.target.document.uri).toBe(SECTION_FIXTURE_URI);
+    expect(missingProjected.citation).toBeUndefined();
+    expect(validateResolve(missingProjected)).toBe(false);
+
+    const exact: SectionResolution = {
+      status: "exact",
+      target,
+      currentFingerprint: fingerprint,
+      section: {
+        anchor: "setup",
+        level: 2,
+        line: 3,
+        title: "Setup",
+        endLine: 6,
+      },
+    };
+    const exactProjected = projectSectionTargetResolveResult(
+      oversizedUri,
+      exact
+    );
+    // Citation fail-closed drops citation but still emits unbound top-level uri.
+    expect(exactProjected.status).toBe("stale");
+    expect(exactProjected.citation).toBeUndefined();
+    expect(exactProjected.uri).toBe(oversizedUri);
+    expect(exactProjected.target.document.uri).toBe(SECTION_FIXTURE_URI);
+    expect(validateResolve(exactProjected)).toBe(false);
+  });
+
+  test("citation predicate requires lineEnd >= lineStart", () => {
+    const inverted = {
+      uri: SECTION_FIXTURE_URI,
+      anchor: "setup",
+      title: "Setup",
+      lineStart: 6,
+      lineEnd: 3,
+      sourceFingerprint: fingerprint,
+    };
+    expect(isTransportBoundedCitation(inverted)).toBe(false);
+
+    const equal = { ...inverted, lineStart: 3, lineEnd: 3 };
+    expect(isTransportBoundedCitation(equal)).toBe(true);
+
+    const resolution: SectionResolution = {
+      status: "exact",
+      target: baseTarget(),
+      currentFingerprint: fingerprint,
+      section: {
+        anchor: "setup",
+        level: 2,
+        line: 6,
+        title: "Setup",
+        endLine: 3,
+      },
+    };
+    const projected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      resolution
+    );
+    expect(projected.status).toBe("stale");
+    expect(projected.citation).toBeUndefined();
+    expect(projected.diagnostics.reason).toBe(
+      CITATION_EXCEEDS_TRANSPORT_BOUNDS
+    );
+    expect(validateResolve(projected)).toBe(true);
+  });
+});
+
+describe("section-target transport input validation", () => {
+  test("rejects unsafe integers for selector line, occurrence, and hints", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+
+    expect(parseSectionTargetCreateSelector({ line: unsafe }).ok).toBe(false);
+    expect(parseSectionTargetCreateSelector({ line: 1.5 }).ok).toBe(false);
+    expect(parseSectionTargetCreateSelector({ line: 0 }).ok).toBe(false);
+
+    const target = baseTarget();
+    expect(validateTarget(target)).toBe(true);
+
+    expect(parseSectionTargetV1({ ...target, occurrence: unsafe }).ok).toBe(
+      false
+    );
+    expect(
+      parseSectionTargetV1({
+        ...target,
+        hints: { ...target.hints, line: unsafe },
+      }).ok
+    ).toBe(false);
+    expect(
+      parseSectionTargetV1({
+        ...target,
+        hints: { ...target.hints, startOffset: unsafe },
+      }).ok
+    ).toBe(false);
+    expect(
+      parseSectionTargetV1({
+        ...target,
+        hints: { ...target.hints, endOffset: unsafe },
+      }).ok
+    ).toBe(false);
+
+    expect(validateTarget({ ...target, occurrence: unsafe })).toBe(false);
+    expect(
+      validateTarget({
+        ...target,
+        hints: { ...target.hints, line: unsafe },
+      })
+    ).toBe(false);
+  });
+
+  test("requires hints.endOffset >= hints.startOffset", () => {
+    const target = baseTarget();
+    const inverted = parseSectionTargetV1({
+      ...target,
+      hints: { line: 3, startOffset: 40, endOffset: 10 },
+    });
+    expect(inverted.ok).toBe(false);
+    if (!inverted.ok) {
+      expect(inverted.error).toContain("hints.endOffset");
+    }
+
+    const equal = parseSectionTargetV1({
+      ...target,
+      hints: { line: 3, startOffset: 10, endOffset: 10 },
+    });
+    expect(equal.ok).toBe(true);
+  });
+
+  test("accepts safe integer bounds at Number.MAX_SAFE_INTEGER", () => {
+    const target = {
+      ...baseTarget(),
+      occurrence: Number.MAX_SAFE_INTEGER,
+      hints: {
+        line: Number.MAX_SAFE_INTEGER,
+        startOffset: Number.MAX_SAFE_INTEGER - 1,
+        endOffset: Number.MAX_SAFE_INTEGER,
+      },
+    };
+    // URI/quote/fingerprint still bounded; numeric fields alone must parse.
+    expect(parseSectionTargetV1(target).ok).toBe(true);
+    expect(validateTarget(target)).toBe(true);
+  });
+
+  test("rejects oversized serialized targets via isBoundedSectionTarget", () => {
+    // Field lengths are individually legal; combined UTF-8 JSON exceeds budget.
+    const target = {
+      ...baseTarget(),
+      document: {
+        uri: `gno://${"u".repeat(SECTION_TARGET_BOUNDS.uriMaxChars - 6)}`,
+      },
+      anchor: "a".repeat(SECTION_TARGET_BOUNDS.anchorMaxChars),
+      headingPath: Array.from(
+        { length: SECTION_TARGET_BOUNDS.headingPathMaxItems },
+        (_, index) =>
+          `${index}${"H".repeat(SECTION_TARGET_BOUNDS.headingPathItemMaxChars - 1)}`
+      ),
+      quote: {
+        exact: "x".repeat(SECTION_TARGET_BOUNDS.exactMaxChars),
+        prefix: "y".repeat(SECTION_TARGET_BOUNDS.prefixMaxChars),
+        suffix: "z".repeat(SECTION_TARGET_BOUNDS.suffixMaxChars),
+      },
+    };
+    expect(target.document.uri.length).toBe(SECTION_TARGET_BOUNDS.uriMaxChars);
+    const parsed = parseSectionTargetV1(target);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error).toBe("Section target exceeds size bounds");
+    }
+  });
+});

--- a/test/spec/schemas/section-target.test.ts
+++ b/test/spec/schemas/section-target.test.ts
@@ -1,0 +1,78 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { describe, expect, test } from "bun:test";
+
+import schema from "../../../spec/output-schemas/section-target.schema.json";
+import {
+  createSectionTarget,
+  type SectionTargetV1,
+} from "../../../src/core/sections";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+describe("section-target schema", () => {
+  test("accepts createSectionTarget output", async () => {
+    const target = await createSectionTarget({
+      content: "# Title\n\n## Section\n\nBody text for the schema fixture.\n",
+      uri: "gno://work/fixture.md",
+      anchor: "section",
+    });
+    expect(target).not.toBeNull();
+    expect(validate(target)).toBe(true);
+  });
+
+  test("rejects missing required fields and overlong identity/quote fields", () => {
+    const valid = {
+      schemaVersion: "1",
+      document: { uri: "gno://work/fixture.md" },
+      anchor: "section",
+      headingPath: ["Title", "Section"],
+      occurrence: 1,
+      quote: { exact: "Body", prefix: "\n\n", suffix: "\n" },
+      sourceFingerprint: "a".repeat(64),
+      hints: { line: 3, startOffset: 10, endOffset: 14 },
+    } satisfies SectionTargetV1;
+
+    expect(validate(valid)).toBe(true);
+
+    const { schemaVersion: _schemaVersion, ...missingVersion } = valid;
+    expect(validate(missingVersion)).toBe(false);
+
+    expect(
+      validate({
+        ...valid,
+        quote: { ...valid.quote, exact: "x".repeat(97) },
+      })
+    ).toBe(false);
+
+    expect(
+      validate({
+        ...valid,
+        document: { uri: `gno://${"u".repeat(1024)}` },
+      })
+    ).toBe(false);
+
+    expect(
+      validate({
+        ...valid,
+        anchor: "a".repeat(513),
+      })
+    ).toBe(false);
+
+    expect(
+      validate({
+        ...valid,
+        headingPath: ["Title", "x".repeat(513)],
+      })
+    ).toBe(false);
+
+    expect(
+      validate({
+        ...valid,
+        sourceFingerprint: "not-a-hash",
+      })
+    ).toBe(false);
+  });
+});

--- a/test/spec/schemas/section.test.ts
+++ b/test/spec/schemas/section.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Contract tests for gno://schemas/section@1.0 MCP output schema.
+ */
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { describe, expect, test } from "bun:test";
+
+import resolveResultSchema from "../../../spec/output-schemas/section-target-resolve-result.schema.json";
+import targetSchema from "../../../spec/output-schemas/section-target.schema.json";
+import sectionSchema from "../../../spec/output-schemas/section.schema.json";
+import {
+  createSectionTarget,
+  projectSectionTargetCreateResult,
+  projectSectionTargetResolveResult,
+  resolveSectionTarget,
+} from "../../../src/core/sections";
+import { sectionOutputSchema } from "../../../src/mcp/tools/sections";
+import {
+  SECTION_FIXTURE_CONTENT,
+  SECTION_FIXTURE_URI,
+  SECTION_STALE_CONTENT,
+} from "../../helpers/section-target-fixtures";
+import { loadSchema } from "./validator";
+
+const ajv = new Ajv({ strict: true, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(targetSchema);
+ajv.addSchema(resolveResultSchema);
+const validate = ajv.compile(sectionSchema);
+
+const fingerprint = "a".repeat(64);
+
+describe("section MCP output schema", () => {
+  test("is wired into the shared schema validator catalog", async () => {
+    const loaded = await loadSchema("section");
+    expect(loaded).toMatchObject({ $id: "gno://schemas/section@1.0" });
+  });
+
+  test("accepts create and navigable/non-navigable resolve branches", async () => {
+    const target = await createSectionTarget({
+      content: SECTION_FIXTURE_CONTENT,
+      uri: SECTION_FIXTURE_URI,
+      anchor: "setup",
+    });
+    expect(target).toBeTruthy();
+    if (!target) return;
+
+    const createResult = {
+      schemaVersion: "1.0" as const,
+      action: "create" as const,
+      ...projectSectionTargetCreateResult(SECTION_FIXTURE_URI, target),
+    };
+    expect(validate(createResult)).toBe(true);
+
+    const exact = await resolveSectionTarget({
+      content: SECTION_FIXTURE_CONTENT,
+      target,
+      uri: SECTION_FIXTURE_URI,
+    });
+    const exactProjected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      exact
+    );
+    const exactResult = {
+      schemaVersion: "1.0" as const,
+      action: "resolve" as const,
+      ...exactProjected,
+    };
+    expect(validate(exactResult)).toBe(true);
+
+    const stale = await resolveSectionTarget({
+      content: SECTION_STALE_CONTENT,
+      target,
+      uri: SECTION_FIXTURE_URI,
+    });
+    const staleProjected = projectSectionTargetResolveResult(
+      SECTION_FIXTURE_URI,
+      stale
+    );
+    const staleResult = {
+      schemaVersion: "1.0" as const,
+      action: "resolve" as const,
+      ...staleProjected,
+    };
+    expect(validate(staleResult)).toBe(true);
+    expect(staleResult).not.toHaveProperty("citation");
+  });
+
+  test("rejects citation on non-navigable status and unknown fields", () => {
+    expect(
+      validate({
+        schemaVersion: "1.0",
+        action: "resolve",
+        uri: SECTION_FIXTURE_URI,
+        status: "missing",
+        currentFingerprint: fingerprint,
+        target: {
+          schemaVersion: "1",
+          document: { uri: SECTION_FIXTURE_URI },
+          anchor: "setup",
+          headingPath: ["Guide", "Setup"],
+          occurrence: 1,
+          quote: { exact: "x", prefix: "", suffix: "" },
+          sourceFingerprint: fingerprint,
+          hints: { line: 3, startOffset: 0, endOffset: 1 },
+        },
+        diagnostics: {},
+        citation: {
+          uri: SECTION_FIXTURE_URI,
+          anchor: "setup",
+          title: "Setup",
+          lineStart: 3,
+          lineEnd: 4,
+          sourceFingerprint: fingerprint,
+        },
+      })
+    ).toBe(false);
+
+    expect(
+      validate({
+        schemaVersion: "1.0",
+        action: "create",
+        uri: SECTION_FIXTURE_URI,
+        target: {
+          schemaVersion: "1",
+          document: { uri: SECTION_FIXTURE_URI },
+          anchor: "setup",
+          headingPath: ["Guide", "Setup"],
+          occurrence: 1,
+          quote: { exact: "x", prefix: "", suffix: "" },
+          sourceFingerprint: fingerprint,
+          hints: { line: 3, startOffset: 0, endOffset: 1 },
+        },
+        extra: true,
+      })
+    ).toBe(false);
+  });
+
+  test("enforces diagnostics co-dependencies and citation line ordering", () => {
+    const target = {
+      schemaVersion: "1",
+      document: { uri: SECTION_FIXTURE_URI },
+      anchor: "setup",
+      headingPath: ["Guide", "Setup"],
+      occurrence: 1,
+      quote: { exact: "x", prefix: "", suffix: "" },
+      sourceFingerprint: fingerprint,
+      hints: { line: 3, startOffset: 0, endOffset: 1 },
+    };
+
+    expect(
+      validate({
+        schemaVersion: "1.0",
+        action: "resolve",
+        uri: SECTION_FIXTURE_URI,
+        status: "ambiguous",
+        currentFingerprint: fingerprint,
+        target,
+        diagnostics: {
+          candidates: [
+            {
+              anchor: "setup",
+              line: 3,
+              title: "Setup",
+              headingPath: ["Guide", "Setup"],
+              occurrence: 1,
+            },
+          ],
+        },
+      })
+    ).toBe(false);
+
+    expect(
+      validate({
+        schemaVersion: "1.0",
+        action: "resolve",
+        uri: SECTION_FIXTURE_URI,
+        status: "ambiguous",
+        currentFingerprint: fingerprint,
+        target,
+        diagnostics: {
+          candidates: [
+            {
+              anchor: "setup",
+              line: 3,
+              title: "Setup",
+              headingPath: ["Guide", "Setup"],
+              occurrence: 1,
+            },
+          ],
+          candidateCount: 1,
+          candidatesTruncated: false,
+        },
+      })
+    ).toBe(true);
+
+    const invertedCitation = {
+      schemaVersion: "1.0",
+      action: "resolve" as const,
+      uri: SECTION_FIXTURE_URI,
+      status: "exact" as const,
+      currentFingerprint: fingerprint,
+      target,
+      diagnostics: {},
+      citation: {
+        uri: SECTION_FIXTURE_URI,
+        anchor: "setup",
+        title: "Setup",
+        lineStart: 6,
+        lineEnd: 3,
+        sourceFingerprint: fingerprint,
+      },
+    };
+    // JSON Schema allows the integers; Zod output schema rejects inverted lines.
+    expect(validate(invertedCitation)).toBe(true);
+    expect(sectionOutputSchema.safeParse(invertedCitation).success).toBe(false);
+  });
+});

--- a/test/spec/schemas/validator.ts
+++ b/test/spec/schemas/validator.ts
@@ -88,6 +88,7 @@ async function loadAllSchemas(): Promise<void> {
     "section-target",
     "section-target-create-result",
     "section-target-resolve-result",
+    "section",
   ];
 
   for (const name of schemaFiles) {

--- a/test/spec/schemas/validator.ts
+++ b/test/spec/schemas/validator.ts
@@ -85,6 +85,9 @@ async function loadAllSchemas(): Promise<void> {
     "collection-egress-policy-set",
     "collection-egress-check",
     "egress-audit-management",
+    "section-target",
+    "section-target-create-result",
+    "section-target-resolve-result",
   ];
 
   for (const name of schemaFiles) {


### PR DESCRIPTION
# Document structure navigation and section addressability

Finish section addressability for citations and agents without rebuilding the already-shipped outline experience. Durable targets now preserve evidence across edits while readable anchors remain the human-facing default.

> **Spec:** [fn-61-document-structure-navigation-and-section-addressability](https://github.com/gmickel/gno/blob/b289a3bbf57df607d497c6539fae62a2d8e18124/.flow/specs/fn-61-document-structure-navigation-and-section-addressability.md)
> **Branch:** `fn-61-document-structure-navigation-and-section-addressability` → `origin/main`
> **Tasks:** 8 completed
> **R-ID coverage:** 6/6 satisfied

## TL;DR

- Adds bounded, versioned section targets and a deterministic resolver that returns exact, recovered, ambiguous, stale, or missing.
- Exposes one fail-closed contract through REST, SDK, and read-only MCP while preserving existing readable anchors and section APIs.
- Adds a separate durable citation-copy path in DocView; ambiguous or stale targets never navigate or cite.
- Updates repo docs, hosted gno.sh reference docs, and the GNO skill; 47/47 skill evaluation passed.
- Verifies the change with 3,698 passing tests, live UI/REST/MCP/docs QA, and atomic temporary test fixtures after CodeQL review.

## Not in this PR (by design)

- No block-level identity, transclusion, collaborative annotation store, canvas, or general-purpose fuzzy anchoring platform.
- No database table of persistent section IDs in the first release.
- No change to current heading slug/render IDs unless compatibility tests prove a required parser bug fix.
- No automatic navigation for ambiguous or stale targets.
- No rebuild of the shipped outline, current-section highlighting, or QuickSwitcher UI.

## The change, top to bottom

GNO now preserves readable section links while adding bounded, versioned evidence that lets UI, REST, SDK, and MCP resolve citations exactly or fail closed instead of silently selecting the wrong section.

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn61-b289a3bbf57d-1785719632490` | artifact identity |
| Base commit | `839b5ac3dceab40d2b7108bd4525f1b62ef0a365` | artifact currentness |
| Head commit | `b289a3bbf57df607d497c6539fae62a2d8e18124` | artifact identity |
| Human-review lines | 6859 | deterministic file stats |
| Canonical files | 45 | deterministic membership |
| Total files | 59 | deterministic membership |
| Acceptance criteria | 6/6 linked | source:r1, source:r2, source:r3, source:r4, source:r5, source:r6 |
| Full test gate | 3698 pass, 2 expected skips | source:task7 |
| Live QA | SHIP with 6/6 R-ID coverage | source:qa, source:task7 |
| Skill evaluation | 47/47 | source:task7 |

**Legend:** `WHY` `PRINCIPLE` `STEP` `KEPT` `VERIFY` · `NEW` `MODIFIED` `DELETED` `RENAMED` `COPIED` · `CANONICAL` `GENERATED` `MECHANICAL`

<details open>
<summary><code>STEP</code> 1. Define durable section identity — Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence.</summary>

Evidence: source:spec, source:diff, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `spec/mcp.md` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +62/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `spec/output-schemas/section-target-create-result.schema.json` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +20/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `spec/output-schemas/section-target-resolve-result.schema.json` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +194/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `spec/output-schemas/section-target.schema.json` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +118/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `spec/output-schemas/section.schema.json` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +113/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `COPIED` | `CANONICAL` | `src/core/section-parse.ts` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +79/-17 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `src/core/section-target-link.ts` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +154/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `src/core/section-target-resolve.ts` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +351/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `src/core/section-target-transport.ts` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +519/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `NEW` | `CANONICAL` | `src/core/section-target.ts` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +263/-0 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |
| `MODIFIED` | `CANONICAL` | `src/core/sections.ts` | Adds bounded versioned section targets, shared heading parsing, and a deterministic resolver that fails closed on ambiguous, stale, or missing evidence. | +64/-119 | — | source:diff, source:spec, source:r1, source:r2, source:r3, source:r5, source:task5, R-ID:R1, R-ID:R2, R-ID:R3, R-ID:R5, task:fn-61-document-structure-navigation-and-section-addressability.5 |

</details>

<details>
<summary><code>STEP</code> 2. Expose one contract across REST, SDK, and MCP — Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool.</summary>

Evidence: source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `src/mcp/AGENTS.md` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +1/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/mcp/CLAUDE.md` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +1/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/mcp/http-egress.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +1/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/mcp/tools/index.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +19/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `NEW` | `CANONICAL` | `src/mcp/tools/sections.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +512/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/sdk/client.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +71/-1 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/sdk/index.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +5/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/sdk/types.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +29/-1 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `NEW` | `CANONICAL` | `src/serve/routes/section-targets.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +221/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |
| `MODIFIED` | `CANONICAL` | `src/serve/server.ts` | Projects the same section-target creation and resolution semantics through the server routes, SDK client, and read-only MCP tool. | +34/-0 | — | source:diff, source:r4, source:task6, source:task8, R-ID:R4, task:fn-61-document-structure-navigation-and-section-addressability.6, task:fn-61-document-structure-navigation-and-section-addressability.8 |

</details>

<details>
<summary><code>STEP</code> 3. Integrate citation-safe user and agent workflows — Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces.</summary>

Evidence: source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7

<details>
<summary>Generated/mechanical files (4)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `.claude/skills/gno/SKILL.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +2/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `GENERATED` | `.claude/skills/gno/mcp-reference.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +6/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `GENERATED` | `.codex/skills/gno/SKILL.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +2/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `GENERATED` | `.codex/skills/gno/mcp-reference.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +6/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `README.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +1/-1 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `assets/skill/SKILL.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +2/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `assets/skill/mcp-reference.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +6/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `docs/API.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +137/-32 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `docs/MCP.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +26/-2 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `docs/SDK.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +36/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `docs/WEB-UI.md` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +12/-2 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `src/serve/public/lib/section-links.ts` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +189/-0 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `src/serve/public/pages/DocView.tsx` | Keeps readable anchor links for people, adds a separate durable citation link, and documents fail-closed behavior across repo docs and installed skill surfaces. | +219/-36 | — | source:diff, source:r3, source:r5, source:r6, source:task7, R-ID:R3, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |

</details>

<details>
<summary><code>VERIFY</code> 4. Verify contracts and live behavior — Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately.</summary>

Evidence: source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7

<details>
<summary>Generated/mechanical files (10)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `NEW` | `MECHANICAL` | `.flow/memory/bug/ui/mobile-user-sees-clipped-docview-960px-2026-08-03.md` | Flow task, receipt, or memory state produced by the completed work. | +49/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `MECHANICAL` | `.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json` | Flow task, receipt, or memory state produced by the completed work. | +64/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.json` | Flow task, receipt, or memory state produced by the completed work. | +2/-2 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.md` | Flow task, receipt, or memory state produced by the completed work. | +3/-4 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.json` | Flow task, receipt, or memory state produced by the completed work. | +2/-2 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.md` | Flow task, receipt, or memory state produced by the completed work. | +3/-4 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.json` | Flow task, receipt, or memory state produced by the completed work. | +4/-4 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.md` | Flow task, receipt, or memory state produced by the completed work. | +4/-5 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.json` | Flow task, receipt, or memory state produced by the completed work. | +2/-2 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `MECHANICAL` | `.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.md` | Flow task, receipt, or memory state produced by the completed work. | +3/-4 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `NEW` | `CANONICAL` | `test/core/section-target-link.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +166/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `test/core/sections.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +465/-1 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/helpers/section-target-fixtures.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +165/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `test/mcp/http-parity.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +98/-3 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `test/mcp/tools/capture.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +1/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/mcp/tools/sections.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +555/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/sdk/section-targets.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +236/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/serve/api-section-targets.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +319/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `test/serve/public/lib/deep-links.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +13/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/serve/public/lib/section-links.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +202/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `test/serve/public/pages/DocView.dom.test.tsx` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +224/-1 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/spec/schemas/section-target-transport.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +439/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/spec/schemas/section-target.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +78/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `NEW` | `CANONICAL` | `test/spec/schemas/section.test.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +219/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |
| `MODIFIED` | `CANONICAL` | `test/spec/schemas/validator.ts` | Adds contract, unit, DOM, transport-parity, and schema coverage; records live QA evidence and the one pre-existing mobile overflow finding separately. | +4/-0 | — | source:diff, source:r5, source:r6, source:task7, source:qa, R-ID:R5, R-ID:R6, task:fn-61-document-structure-navigation-and-section-addressability.7 |

</details>

## Critical changes

- **High-churn transport boundary:** [`src/core/section-target-transport.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-d921f663e79c7c3d888b84b8e6940652bf8d04ae8d09483859c50380d3207a7f) (+519/-0)
- **High-churn MCP surface:** [`src/mcp/tools/sections.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-7bc44064e67c649e71c7617036aef4b1347a4b409fb398910cb3f7c5eaccc257) (+512/-0)
- **Conservative resolver:** [`src/core/section-target-resolve.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-abd3ebc6d10e1a82bfe2f0821b9d3a6c10effe5321c015f0592beb9d509bdaff) (+351/-0)
- **Behavior-visible DocView:** [`src/serve/public/pages/DocView.tsx`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-28ca7f629c729b7a3c07a92064c4e463f074a59cd94471acde69d0f2c3240531) (+219/-36)
- **Behavior-visible REST route:** [`src/serve/routes/section-targets.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-265286b83efcb872f02bea7bd5605ed1d63e43f47bc18294ed9b0e96805ab582) (+221/-0)

## How to review this PR

The pipeline already verified this — you don't re-check it from scratch:
- **Tests / gates:** 3,698 pass, 2 expected skips; lint and docs verification clean; skill eval 47/47.
- **R-ID coverage:** 6/6 acceptance criteria linked in the walkthrough above.
- **Live QA:** SHIP across UI, REST, Streamable HTTP MCP, and local hosted docs.

Your job — the calls the pipeline can't make:
- Line-review the Must review bucket below — about 26% of changed lines.
- Spot-check the verified claims above; sample, don't re-run everything.
- Own product intent, API taste, privacy boundaries, and failure semantics.

## Review plan

### Must review (~26%)

- [ ] 🔴 [`src/core/section-target.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-9352451c442aa86bca536b3e0820fb01abd506e43427325d7eea321cc4d646d0) — durable identity contract — Is the bounded evidence sufficient without leaking section bodies?
- [ ] 🔴 [`src/core/section-target-resolve.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-abd3ebc6d10e1a82bfe2f0821b9d3a6c10effe5321c015f0592beb9d509bdaff) — deterministic recovery policy — Do all non-unique or weak-evidence paths fail closed?
- [ ] 🔴 [`src/core/section-target-transport.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-d921f663e79c7c3d888b84b8e6940652bf8d04ae8d09483859c50380d3207a7f) — shared untrusted-input boundary — Are size limits and cross-surface projections consistent?
- [ ] 🔴 [`src/serve/public/lib/section-links.ts`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-6545f96e170661005f5598cff35dcdb697013cc921e86b624c6b573e2433ddb2) — browser URL encoding and cleanup — Does readable-link compatibility survive all selector outcomes?
- [ ] 🔴 [`src/serve/public/pages/DocView.tsx`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-28ca7f629c729b7a3c07a92064c4e463f074a59cd94471acde69d0f2c3240531) — user-visible copy and navigation behavior — Are success, recovery, and refusal states understandable and content-safe?

### Spot-check

- [ ] 🟡 [`src/mcp/AGENTS.md`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-fd237195f74dddfdc2b5771c205e1089120372f57caf9e98f561e97b39d82e44), [`src/mcp/CLAUDE.md`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-d9d771ec5fb756f29d833e3c768503dd86c610c6b807885de98cf5ff1e12b6a9), [`src/mcp/http-egress.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-1855031a731c503014a70c6699f079f9856b31d5a82ba078f4cdca5ed1ab6e4f), [`src/mcp/tools/index.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-ca2db716a0fc2923ac94b5ccf40855c1b1f18ad153cac2a1289bba01fb27c757), [`src/mcp/tools/sections.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-7bc44064e67c649e71c7617036aef4b1347a4b409fb398910cb3f7c5eaccc257), [`src/sdk/client.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-c151cd1b47a94a841f4730d5e78f9b3d71295daa0d17e06ebe6b4bc5cbe36979), [`src/sdk/index.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-49c734839cb20446f67a02c235bbe003a185f84cc574a87f237079744a504645), [`src/sdk/types.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-a2d1035afff3a13aba287bf2d1c4ccdd8c7f5babf18aaa1494420215536dc846), [`src/serve/routes/section-targets.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-265286b83efcb872f02bea7bd5605ed1d63e43f47bc18294ed9b0e96805ab582), [`src/serve/server.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-6cc36e15347f9f66381058d885a55509501f17be464d80cf1f62051ee70ce5a2) — cross-surface parity; sample schemas, diagnostics, and backward compatibility.
- [ ] 🟡 [`README.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), [`assets/skill/SKILL.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-098982c1009c35421fb18487fdd5e6f0a294b83cbae6afea7afd4b7429dd9f41), [`assets/skill/mcp-reference.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-01a8b062bdf0c4b0bec4cc38d5fda5f407e0ec8f826114bc5d9554e988a3a408), [`docs/API.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797), [`docs/MCP.md`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-fb9f3004fc2a20967eeec2c5eba483f46998ab4af0bc0b202c0ebeec8118a050), [`docs/SDK.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-c3887363bee7c42d9bc7a7d7d8ded7c8c50639610284d7b2969941786107f22b), [`docs/WEB-UI.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-363967f0c0dae05c8a5980a7b43d902cbe5badd9c902c9d7b2ea10eefae9b7c7), [`spec/mcp.md`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-c76021210ac5b523abe89dcdb52e130ec6233f40ee74857433135c6dadf7b4be), [`spec/output-schemas/section-target-create-result.schema.json`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-a808bba652826f701626d7903ebd92cfb7c2dab858ff3dcb928470cd8e0623cf), [`spec/output-schemas/section-target-resolve-result.schema.json`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-0f2a5380d40c43617f26c8aaf553afe92e9c59fba97c848284fbdc5aca0d7c97), [`spec/output-schemas/section-target.schema.json`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-b6fc985de0f213991fdd770dab1e751bdba928f3e7488694016b2c06daafa5fa), [`spec/output-schemas/section.schema.json`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-ba4bbda318a0becd13e891c4908e6011644758e96f111373ec8d2c30b4a1da96) — contracts and user guidance; confirm terminology and fail-closed promises agree.
- [ ] 🟡 [`test/core/section-target-link.test.ts`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-7a5ae00720941f3fc15f17f35ca13035375d9d420ac792976fbe92998892d6ee), [`test/core/sections.test.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-b3f9b02df0d613953afca480444f734f350a993386dd67bb10188670f0be7552), [`test/helpers/section-target-fixtures.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-d68c76cbae8eef9fe4f40cf24887b8641946f849c593da6fa1cfa755e8dcfb0b), [`test/mcp/http-parity.test.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-10df7e05edfe3b11d266f337117c98e8ca87db27d9947c56cef5293979e5fe10), [`test/mcp/tools/capture.test.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-f2cebd6f3b71e50cbfea68b0961b4198dba29f2eaae7ed7e2d0eb6c5564cdf0e), [`test/mcp/tools/sections.test.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-999485521caae606fe2a31e6280953f5f0ee374a91ab3a908a502ba8b6f72712), [`test/sdk/section-targets.test.ts`](https://github.com/gmickel/gno/commit/3888a3dbdba544f2b226e7294e4992fdd358a27b#diff-c67970f2268c9392809fcbecf72c4d94ff6523331778335eebdc34d8da4ed6cf), [`test/serve/api-section-targets.test.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-7af59dced5bc36cbe3e04d2946dd56f499c794bc5e68bb5595b0b8f17d8067d3), [`test/serve/public/lib/deep-links.test.ts`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-6a26fabb554987b6e6af1818c0116b53233c8b879a35b9066bae2dfaf39ae82d), [`test/serve/public/lib/section-links.test.ts`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-3742374be5612e9c8a489660b23af105faba188374fb17de11a9bb2de7efbc49), [`test/serve/public/pages/DocView.dom.test.tsx`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-13d72e31a94b8d7b070558833a2e688e279a48e5b62c388cbc0b8858f15c3942), [`test/spec/schemas/section-target-transport.test.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-5911c44589aac7fe83d1a92a67d7d7bcf5e10977e929c3c5e2be96ded812824e), [`test/spec/schemas/section-target.test.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-90c88cbc004db6664872e686d109a996733743f91286d366fd66683ed5e9c333), [`test/spec/schemas/section.test.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-e50b792cf5686744bb7eb4f41700f6e1631f8ccd6c17bb4539804ad8229c5d9e), [`test/spec/schemas/validator.ts`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-dc71246dd30fed133562212586cb0f8e05e28a1fd5de0d7fa2ebeb7af2ea1fef) — verification code; sample adversarial duplicate, edit, transport, DOM, and secure-temp cases.
- [ ] 🟡 [`src/core/section-parse.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-39c524b028e2145080e887c87c82d08da15bb731bcdb4d90049b032371243e6f), [`src/core/section-target-link.ts`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-026cc67122d1e35f479e2f54f4ff8f0cf899b08cd3ff6e40c1e94b4796894d28), [`src/core/sections.ts`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-13409fff56a0d4d5f540778ccab0d3a562fea4d9da31eb632481d5b674204430) — shared parsing and readable-link compatibility; confirm copied/refactored behavior remains stable.

### Safe to skim (~2%)

- [ ] ⚪ [`.claude/skills/gno/SKILL.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-849e7b2d03d425f80b80065887d6e5afe7dc60fa7e24d8c098f64672c4b41c8b), [`.claude/skills/gno/mcp-reference.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-aa1ef65a9aa2a729a3db6c768494be30dcb6268be941194a30b06154ef2402c4), [`.codex/skills/gno/SKILL.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-70f89c6637d495ad5925a1480c1829018930765029a2c1b455f830cc11c19a3d), [`.codex/skills/gno/mcp-reference.md`](https://github.com/gmickel/gno/commit/2ffa6971d396ed447c1ea6f1d1793ac07e33696d#diff-6af64a5a35fe53232ccbffdbc6f800405126c7e587284addddeebe12009e1d89), [`.flow/memory/bug/ui/mobile-user-sees-clipped-docview-960px-2026-08-03.md`](https://github.com/gmickel/gno/commit/d8502ef7c1f080bfe555753cdf2fee76b6e38f5d#diff-95e5e56c44a4b8b6c7ca28ffc661bca80fe8614daeb17966b0a926494c9342c3), [`.flow/review-receipts/qa-fn-61-document-structure-navigation-and-section-addressability.json`](https://github.com/gmickel/gno/commit/b289a3bbf57df607d497c6539fae62a2d8e18124#diff-c1de1fdf031d100ccba3d207ebc1a617910ba7ff381ad51f1fab8a1278468853), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.json`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-4f26eb5b5f6d11d7c526126853dc06084777a24b4c26a4b0c43023e945202863), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.5.md`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-e650e9eb2891c3fe4c84f69b695c95831fccb6b79bb7a836957ff7fd03cee9ec), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.json`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-a00bdf6bc4ce3e7dc7aa9b5734f07c048a5ba71bf3b838182141793b5367839c), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.6.md`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-d294270a3bc37d103c6a939be29f91df596fec1e72d9ca602d600b79eb4f1159), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.json`](https://github.com/gmickel/gno/commit/d8502ef7c1f080bfe555753cdf2fee76b6e38f5d#diff-b9b590a4bee849549c3705019e65079459a4863930bc4102ab80c2e6e27b088c), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.7.md`](https://github.com/gmickel/gno/commit/d8502ef7c1f080bfe555753cdf2fee76b6e38f5d#diff-0e01a3b0d2cd18fa1f1cd5741669463047ec003de6c13b60edd7241273af6895), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.json`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-8f555b7085bbff5ee97c02c634cac2d701b70195238865c0aa4f0eaa8dddba2a), [`.flow/tasks/fn-61-document-structure-navigation-and-section-addressability.8.md`](https://github.com/gmickel/gno/commit/636218aed9b4ec54df898c4d903363fdf657abcc#diff-5f2145ec37c651a08dee9639541ca88a51ddfdb16244d14344a0e9942cdf6477) — generated skill mirrors and Flow state/receipts; verify parity and provenance, not implementation detail.

## Structural changes

The durable target contract begins in [`src/core/section-target.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-9352451c442aa86bca536b3e0820fb01abd506e43427325d7eea321cc4d646d0) and resolves through [`src/core/section-target-resolve.ts`](https://github.com/gmickel/gno/commit/77d9aeca777b7c8277bc23ce4eecb68f418e45d8#diff-abd3ebc6d10e1a82bfe2f0821b9d3a6c10effe5321c015f0592beb9d509bdaff). [`src/core/section-target-transport.ts`](https://github.com/gmickel/gno/commit/7247bd1d6713ad3a1282bc5546b0a0fb0f73d238#diff-d921f663e79c7c3d888b84b8e6940652bf8d04ae8d09483859c50380d3207a7f) projects the result into REST, SDK, MCP, and browser-safe representations. DocView keeps readable anchors while using the same contract for durable citations, and the test modules exercise each public surface.

```mermaid
graph TB
 contract["SectionTarget v1"]
 resolver["Conservative resolver"]
 transport["Shared transport projection"]
 rest["REST routes"]
 sdk["SDK client"]
 mcp["Read-only MCP"]
 ui["DocView citation links"]
 tests["Contract and live tests"]
 contract --> resolver
 resolver --> transport
 transport --> rest
 transport --> sdk
 transport --> mcp
 transport --> ui
 rest --> tests
 sdk --> tests
 mcp --> tests
 ui --> tests
```

## Memory left behind

**Bugs captured during this spec:**

- `bug/ui/mobile-user-sees-clipped-docview-960px-2026-08-03` — A mobile-width user opening DocView sees a desktop-width canvas clipped behind horizontal scrolling; header actions extend off-screen.

## Live QA

> **Outcome:** SHIP · **Ran against:** `3888a3db` · **R-ID coverage:** 6/6

> Live QA passed: all derived scenarios passed on the running app with captured evidence; zero open P0/P1.

---

*Generated by `/flow-next:make-pr` from [fn-61-document-structure-navigation-and-section-addressability](https://github.com/gmickel/gno/blob/b289a3bbf57df607d497c6539fae62a2d8e18124/.flow/specs/fn-61-document-structure-navigation-and-section-addressability.md) against `origin/main` on 2026-08-03.*
<!-- flow-next:make-pr spec=fn-61-document-structure-navigation-and-section-addressability base=origin/main -->

---
Ref GNO-26
