### PR TITLE
chore: refresh Flow-Next copy install to 3.13.1

### DIFF
--- a/.flow/.gitignore
+++ b/.flow/.gitignore
@@ -7,6 +7,7 @@ tmp/
 .migrating
 .migration-manifest
 sync-runs/
+.locks/
 locks/
 pilot-runs/
 .cache/

--- a/.flow/bin/flowctl-help.txt
+++ b/.flow/bin/flowctl-help.txt
@@ -1,25 +1,29 @@
 usage: flowctl.py [-h]
-                  {init,setup-block,detect,status,config,sync,pilot-log,review-backend,models,review-rounds,memory,prospect,anchor,repo-map,prime,glossary,strategy,spec,scope,task,dep,show,specs,tasks,list,cat,usage,setup-mode,ready,next,start,done,block,validate,triage-skip,gate,checkpoint,rp,codex,copilot,cursor,review-deep-auto,review-walkthrough-defer,review-walkthrough-record} ...
+                  {init,setup-block,detect,status,config,tracker,sync,pilot-log,review-backend,review-findings,models,review-rounds,memory,prospect,chart,anchor,repo-map,prime,glossary,criteria,strategy,spec,scope,pr-cognitive-aid,task,dep,show,specs,tasks,list,cat,usage,setup-mode,ready,next,start,done,block,validate,triage-skip,gate,checkpoint,rp,codex,copilot,cursor,review-deep-auto,review-walkthrough-defer,review-walkthrough-record} ...
 
 flowctl - CLI for .flow/ task tracking
 
 positional arguments:
-  {init,setup-block,detect,status,config,sync,pilot-log,review-backend,models,review-rounds,memory,prospect,anchor,repo-map,prime,glossary,strategy,spec,scope,task,dep,show,specs,tasks,list,cat,usage,setup-mode,ready,next,start,done,block,validate,triage-skip,gate,checkpoint,rp,codex,copilot,cursor,review-deep-auto,review-walkthrough-defer,review-walkthrough-record}
+  {init,setup-block,detect,status,config,tracker,sync,pilot-log,review-backend,review-findings,models,review-rounds,memory,prospect,chart,anchor,repo-map,prime,glossary,criteria,strategy,spec,scope,pr-cognitive-aid,task,dep,show,specs,tasks,list,cat,usage,setup-mode,ready,next,start,done,block,validate,triage-skip,gate,checkpoint,rp,codex,copilot,cursor,review-deep-auto,review-walkthrough-defer,review-walkthrough-record}
     init                Initialize .flow/ directory
     setup-block         Apply or resolve the tracked Flow-Next docs block
     detect              Check if .flow/ exists
     status              Show .flow state and active runs
     config              Config commands
+    tracker             Deterministic tracker transport verbs (fn-139)
     sync                Tracker sync plumbing (config / state / enumerate /
                         receipt)
     pilot-log           Pilot backlog-mode decision log (append / summary)
     review-backend      Get review backend (ASK if not configured)
+    review-findings     Attach versioned structured findings to a direct-
+                        writer receipt
     models              Model role-map helpers (read-only resolve; no
                         judgment)
     review-rounds       Deterministic review-round cap counter (rp workflows:
                         increment before dispatch, reset on SHIP)
     memory              Memory commands
     prospect            Prospect artifact commands
+    chart               Chart commands (decision-map discovery; fn-135)
     anchor              Single-call worker anchor bundle — verbatim Phase-1
                         re-anchor reads (task+spec show/cat, git state, memory
                         flag, glossary, memory index, dependencies) in one
@@ -33,6 +37,7 @@ positional arguments:
     glossary            Project glossary commands (GLOSSARY.md at repo root or
                         nearest ancestor). Lives outside .flow/ so it survives
                         flow-next removal.
+    criteria            Global acceptance criteria (.flow/criteria.md)
     strategy            Project strategy commands (STRATEGY.md at repo root,
                         single-root). Lives outside .flow/ so it survives
                         flow-next removal. Read-only plumbing — the skill
@@ -40,6 +45,8 @@ positional arguments:
     spec                Spec commands (canonical)
     scope               Scope helpers for --scope=business|technical|both
                         (parser + write policy)
+    pr-cognitive-aid    Validate, persist, select, and render a v1 PR
+                        cognitive-aid artifact
     task                Task commands
     dep                 Dependency commands
     show                Show spec or task

--- a/.flow/bin/flowctl.py
+++ b/.flow/bin/flowctl.py
@@ -9,6 +9,7 @@ Agents must use flowctl for all writes - never edit .flow/* directly.
 import argparse
 import errno
 import hashlib
+import html
 import io
 import json
 import math
@@ -26,6 +27,7 @@ import unicodedata
 import uuid
 from abc import ABC, abstractmethod
 from collections import deque
+from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from dataclasses import dataclass, field, replace as dataclass_replace
 from datetime import date, datetime, timedelta, timezone
@@ -186,6 +188,44 @@ TASKS_DIR = "tasks"
 MEMORY_DIR = "memory"
 PROSPECTS_DIR = "prospects"
 PROSPECTS_ARCHIVE_DIR = "_archive"
+# fn-135: charts share the native fn-N allocation domain with specs.
+CHARTS_DIR = "charts"
+CHART_TRANSACTIONS_DIR = ".transactions"
+CHART_JSON_SCHEMA_VERSION = 1
+CHART_ERROR_CLASSES = frozenset(
+    {
+        "not_found",
+        "conflict",
+        "invalid_state",
+        "invalid_graph",
+        "stale_claim",
+        "validation",
+        "io",
+    }
+)
+# Single cross-kind lock leaf under .flow/locks/ for specs + charts.
+NATIVE_FN_ALLOC_LOCK_NAME = "native-fn-id-alloc.lock"
+CHARTS_RESOURCE_LOCK_NAME = "charts-resource.lock"
+# Chart discovery size/claim defaults (fn-135.9).
+CHART_DEFAULT_MAX_DECISIONS = 12
+# Stale-claim age threshold in hours; break-stale requires age >= this.
+CHART_DEFAULT_CLAIM_STALE_AFTER_HOURS = 24
+CHART_DECISION_TYPES = frozenset(
+    {"research", "probe", "eval", "prototype", "interview", "task"}
+)
+# Derived attendance for five types; task requires an explicit value.
+CHART_TYPE_ATTENDANCE = {
+    "research": "unattended",
+    "probe": "unattended",
+    "eval": "unattended",
+    "prototype": "attended",
+    "interview": "attended",
+}
+CHART_ATTENDANCE_VALUES = frozenset({"attended", "unattended"})
+CHART_DECISION_STATUS_VALUES = frozenset(
+    {"open", "resolved", "superseded", "out-of-scope"}
+)
+CHART_CLOSED_STATUSES = frozenset({"resolved", "superseded", "out-of-scope"})
 CONFIG_FILE = "config.json"
 # Post-1.0 layout sentinel. Presence of `.flow/.flow_version` means the repo
 # uses the canonical specs/ write path (see get_specs_json_write_dir). Payload
@@ -852,7 +892,7 @@ def get_state_dir() -> Path:
     # 2. Git common-dir (shared across worktrees)
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--git-common-dir", "--path-format=absolute"],
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
             capture_output=True,
             text=True, encoding="utf-8",
             check=True,
@@ -1106,6 +1146,11 @@ def get_default_tracker_config() -> dict:
             # optional verdict comment, never the (MERGED-gated) status write.
             "land": {"merged": "off"},
         },
+        # fn-135.5 — optional chart lifecycle projection. String-enum off|on
+        # (NOT a bool): only the literal "on" activates parent/child chart
+        # projection through the post-fn-141 facade. Default off keeps every
+        # existing repo silent; local chart ops always succeed either way.
+        "charts": "off",
         "perTracker": {
             "teamId": None,
             "projectId": None,
@@ -1130,8 +1175,9 @@ def get_default_tracker_config() -> dict:
             # and persisted (`cloud-basic` = Cloud HTTP-basic `email:API_TOKEN`;
             # `bearer-pat` = DC/Server `Authorization: Bearer <PAT>`) so runtime
             # never re-infers it — credentials still read from env each run, never
-            # stored here. `apiVersion` is the REST endpoint family (`3` Cloud ADF
-            # / `2` DC/Server) the adapter branches on. `sslVerify` is an opt-in
+            # stored here. `apiVersion` is null until resolver output pins version
+            # 2 for either deployment shape; migration also converges legacy 3 to
+            # 2. `sslVerify` is an opt-in
             # escape hatch (default true) for self-hosted internal-CA / self-signed
             # certs (`JIRA_SSL_VERIFY=false` env override); never silent. `statusMap`
             # maps the FULL normalized status set → a Jira status `{name}`/`{id}`
@@ -1338,6 +1384,16 @@ def get_default_config() -> dict:
         # flowctl only stores/serves the knob; the QA stage is host-agent
         # skill wiring (no new subcommand/engine).
         "pipeline": {"qa": "off"},
+        # fn-135.9 — chart discovery size ceiling and stale-claim threshold.
+        # Seeded so `config get chart.maxDecisions` / `chart.claimStaleAfter`
+        # return defaults (NOT null) on a fresh repo via the defaults MERGE.
+        # maxDecisions is a charting-time guard only (later sharpening may
+        # grow past it). claimStaleAfter is hours; break-stale requires age
+        # >= this value and always records actor/prior owner/age/reason.
+        "chart": {
+            "maxDecisions": CHART_DEFAULT_MAX_DECISIONS,
+            "claimStaleAfter": CHART_DEFAULT_CLAIM_STALE_AFTER_HOURS,
+        },
         # fn-68.1 — pilot backlog-mode autonomy gate, seeded so
         # `config get pilot.autonomy` returns the enum string "ready" (NOT
         # null) on a fresh repo via the defaults MERGE. SCALAR STRING-ENUM
@@ -1391,10 +1447,19 @@ _INIT_UNMATERIALIZED_BLOCKS = ("artifacts",)
 # fn-134.2: tracker.specIds — see get_default_tracker_config comment for the
 # materialization decision (DO NOT materialize; unset must be detectable).
 _INIT_UNMATERIALIZED_LEAVES = ("tracker.specIds",)
+# fn-138.3 (R3): stable published URL of the flow-config JSON Schema, stamped
+# as "$schema" into configs cmd_init scaffolds/refreshes so editors validate
+# and autocomplete .flow/config.json. Latest-mutable (not versioned). Inert to
+# flowctl: never fetched, never read back. This is the ONE flowctl constant
+# carrying the URL (the committed artifact's $id and tests reference it).
+FLOW_CONFIG_SCHEMA_URL = "https://flow-next.dev/schema/flow-config.schema.json"
 
 # Strict enum for tracker.specIds (fn-134.2). Write-side rejects anything else;
 # read-side fail-closes anything else to "flow".
 TRACKER_SPEC_IDS_VALUES = frozenset({"flow", "tracker"})
+TRACKER_CONFLICT_TIEBREAK_VALUES = frozenset(
+    {"always-ask", "flow-wins", "tracker-wins"}
+)
 
 
 def normalize_tracker_spec_ids(value) -> str:
@@ -1621,9 +1686,48 @@ def resolve_config_key_for_write(key: str) -> tuple[str, str]:
     return key, ""
 
 
+def _shared_config_lock(flow_dir: Path):
+    """The `.flow/config.json` writer lock (fn-139.3, R8b), or a no-op.
+
+    EVERY config writer must route through `flowctl_tracker.config_lock` so a
+    read-modify-write cannot clobber a concurrent resolve transaction. The
+    import is guarded because the package ships alongside flowctl.py in the
+    repo and in post-fn-139.5 installs, but older `.flow/bin` copies carry only
+    the named files - and those copies also have no resolver to race, so the
+    unlocked fallback preserves exactly their current semantics.
+    """
+    import contextlib
+
+    try:
+        from flowctl_tracker.config_lock import config_lock as _lock
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+            try:
+                from flowctl_tracker.config_lock import config_lock as _lock
+            except ImportError:
+                return contextlib.nullcontext()
+        else:
+            return contextlib.nullcontext()
+    return _lock(flow_dir)
+
+
 def set_config(key: str, value) -> dict:
-    """Set nested config value and return updated config."""
-    config_path = get_flow_dir() / CONFIG_FILE
+    """Set nested config value and return updated config.
+
+    The whole read-modify-write runs INSIDE the shared config lock: reading
+    outside it is exactly the stale-read clobber the lock exists to prevent
+    (two writers read, compute different changes, serially replace the file,
+    and the second silently discards the first - fn-139 R8b).
+    """
+    flow_dir = get_flow_dir()
+    with _shared_config_lock(flow_dir):
+        return _set_config_locked(flow_dir, key, value)
+
+
+def _set_config_locked(flow_dir: Path, key: str, value) -> dict:
+    config_path = flow_dir / CONFIG_FILE
     if config_path.exists():
         try:
             config = json.loads(config_path.read_text(encoding="utf-8"))
@@ -1749,7 +1853,7 @@ def require_rp_cli() -> str:
 
 
 def run_rp_cli(
-    args: list[str], timeout: Optional[int] = None
+    args: list[str], timeout: Optional[int] = None, *, rp_cli: Optional[str] = None
 ) -> subprocess.CompletedProcess:
     """Run the selected RepoPrompt CLI with safe error handling and timeout.
 
@@ -1759,7 +1863,7 @@ def run_rp_cli(
     """
     if timeout is None:
         timeout = int(os.environ.get("FLOW_RP_TIMEOUT", "1200"))
-    rp = require_rp_cli()
+    rp = rp_cli or require_rp_cli()
     cmd = [rp] + args
     try:
         return subprocess.run(
@@ -1773,7 +1877,7 @@ def run_rp_cli(
 
 
 def run_rp_cli_unchecked(
-    args: list[str], timeout: Optional[int] = None
+    args: list[str], timeout: Optional[int] = None, *, rp_cli: Optional[str] = None
 ) -> subprocess.CompletedProcess:
     """Run the selected RepoPrompt CLI without collapsing command failures.
 
@@ -1782,7 +1886,7 @@ def run_rp_cli_unchecked(
     """
     if timeout is None:
         timeout = int(os.environ.get("FLOW_RP_TIMEOUT", "1200"))
-    rp = require_rp_cli()
+    rp = rp_cli or require_rp_cli()
     cmd = [rp] + args
     try:
         return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", timeout=timeout)
@@ -1791,7 +1895,7 @@ def run_rp_cli_unchecked(
 
 
 def try_run_rp_cli(
-    args: list[str], timeout: Optional[int] = None
+    args: list[str], timeout: Optional[int] = None, *, rp_cli: Optional[str] = None
 ) -> Optional[subprocess.CompletedProcess]:
     """Run optional Classic capability probes without masking real failures.
 
@@ -1801,7 +1905,7 @@ def try_run_rp_cli(
     """
     if timeout is None:
         timeout = int(os.environ.get("FLOW_RP_TIMEOUT", "1200"))
-    rp = require_rp_cli()
+    rp = rp_cli or require_rp_cli()
     cmd = [rp] + args
     try:
         return subprocess.run(
@@ -2082,15 +2186,177 @@ def extract_builder_tab_from_payload(data: Any) -> Optional[str]:
     return None
 
 
+def validate_rp_classic_builder_context(data: Any) -> None:
+    """Reject Classic builder tabs without a published prompt or selection."""
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        if "prompt" in data or "selection" in data:
+            break
+        for key in ("result", "data", "context"):
+            nested = data.get(key)
+            if isinstance(nested, dict):
+                data = nested
+                break
+        else:
+            break
+
+    if not isinstance(data, dict):
+        error_exit(
+            "Builder context JSON has unexpected shape", use_json=False, code=2
+        )
+
+    prompt = data.get("prompt")
+    selection = data.get("selection")
+    files = selection.get("files") if isinstance(selection, dict) else None
+    if not isinstance(prompt, str) or not prompt.strip():
+        error_exit(
+            "Builder returned an empty prompt; setup is unusable",
+            use_json=False,
+            code=2,
+        )
+    if not isinstance(files, list) or not files:
+        error_exit(
+            "Builder returned an empty selection; setup is unusable",
+            use_json=False,
+            code=2,
+        )
+
+
+def verify_rp_classic_builder_context(
+    window: int, tab: str, *, rp_cli: Optional[str] = None
+) -> None:
+    """Read Classic's published builder tab and require usable context."""
+    expression = 'workspace_context include=["prompt","selection"]'
+    result = run_rp_cli(
+        ["-w", str(window), "-t", tab, "--raw-json", "-e", expression],
+        rp_cli=rp_cli,
+    )
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        error_exit(
+            f"Builder context JSON parse failed: {exc}", use_json=False, code=2
+        )
+    validate_rp_classic_builder_context(data)
+
+
+def validate_rp_ce_builder_review(data: Any) -> dict[str, Any]:
+    """Validate CE's authoritative direct ``context_builder`` review result.
+
+    RepoPrompt CE intentionally need not publish an explicitly targeted
+    Context Builder run into the visible compose tab.  The MCP tool result is
+    therefore the only success oracle on the CE path.
+    """
+    if not isinstance(data, dict):
+        error_exit(
+            "CE context_builder JSON has unexpected shape",
+            use_json=False,
+            code=2,
+        )
+
+    context_id = data.get("context_id")
+    status = data.get("status")
+    prompt = data.get("prompt")
+    selection = data.get("selection")
+    file_count = data.get("file_count")
+    total_tokens = data.get("total_tokens")
+    response_type = data.get("response_type")
+    review = data.get("review")
+
+    if not isinstance(context_id, str) or not context_id.strip():
+        error_exit(
+            "CE context_builder response missing context_id",
+            use_json=False,
+            code=2,
+        )
+    if status != "completed":
+        error_exit(
+            f"CE context_builder did not complete: {status!r}",
+            use_json=False,
+            code=2,
+        )
+    if not isinstance(prompt, str) or not prompt.strip():
+        error_exit(
+            "CE context_builder returned an empty prompt",
+            use_json=False,
+            code=2,
+        )
+    if not isinstance(selection, str) or not selection.strip():
+        error_exit(
+            "CE context_builder returned an empty formatted selection",
+            use_json=False,
+            code=2,
+        )
+    if (
+        isinstance(file_count, bool)
+        or not isinstance(file_count, int)
+        or file_count <= 0
+    ):
+        error_exit(
+            "CE context_builder returned non-positive file_count",
+            use_json=False,
+            code=2,
+        )
+    if (
+        isinstance(total_tokens, bool)
+        or not isinstance(total_tokens, int)
+        or total_tokens <= 0
+    ):
+        error_exit(
+            "CE context_builder returned non-positive total_tokens",
+            use_json=False,
+            code=2,
+        )
+    if response_type != "review":
+        error_exit(
+            "CE context_builder response_type is not review",
+            use_json=False,
+            code=2,
+        )
+    if not isinstance(review, dict):
+        error_exit(
+            "CE context_builder response missing review result",
+            use_json=False,
+            code=2,
+        )
+    chat_id = review.get("chat_id")
+    review_mode = review.get("mode")
+    review_response = review.get("response")
+    if not isinstance(chat_id, str) or not chat_id.strip():
+        error_exit(
+            "CE context_builder review missing chat_id",
+            use_json=False,
+            code=2,
+        )
+    if review_mode != "review":
+        error_exit(
+            "CE context_builder review mode is not review",
+            use_json=False,
+            code=2,
+        )
+    if not isinstance(review_response, str) or not review_response.strip():
+        error_exit(
+            "CE context_builder review returned an empty response",
+            use_json=False,
+            code=2,
+        )
+    return data
+
+
 def bind_context_window(
-    repo_root: str, *, create_if_missing: bool = False
+    repo_root: str,
+    *,
+    create_if_missing: bool = False,
+    rp_cli: Optional[str] = None,
 ) -> Optional[int]:
     """Prefer RepoPrompt's bind_context repo-path matching when available."""
     payload = {"op": "bind", "working_dirs": normalize_repo_root(repo_root)}
     if create_if_missing:
         payload["create_if_missing"] = True
     result = try_run_rp_cli(
-        ["--raw-json", "-e", f"call bind_context {json.dumps(payload)}"]
+        ["--raw-json", "-e", f"call bind_context {json.dumps(payload)}"],
+        rp_cli=rp_cli,
     )
     if result is None:
         return None
@@ -2418,7 +2684,7 @@ def _setup_block_write(target: Path, content: str) -> None:
             umask = os.umask(0)
             os.umask(umask)
             os.chmod(target, 0o666 & ~umask)
-    except OSError:
+    except (CrossProcessLockError, OSError, ReviewReceiptHistoryError):
         pass
 
 
@@ -4101,7 +4367,7 @@ def run_codex_exec(
                 resolution_out["resumed"] = True
             # For resumed sessions, thread_id stays the same
             return output, session_id, 0, result.stderr
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             # Resume failed - fall through to new session
             pass
         except subprocess.TimeoutExpired:
@@ -4204,7 +4470,6 @@ def extract_codex_final_message(output: str) -> str:
     if not output:
         return output
     messages: list[str] = []
-    saw_json = False
     for line in output.split("\n"):
         line = line.strip()
         if not line:
@@ -4215,7 +4480,6 @@ def extract_codex_final_message(output: str) -> str:
             continue
         if not isinstance(data, dict):
             continue
-        saw_json = True
         if data.get("type") == "item.completed":
             item = data.get("item", {})
             if isinstance(item, dict) and item.get("type") == "agent_message":
@@ -4265,6 +4529,1824 @@ _REVIEW_JSON_FENCE_RE = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 _VALID_SUPPRESSED_ANCHORS = frozenset({"0", "25", "50", "75", "100"})
+
+# Versioned structured-review findings (fn-136).
+_FINDINGS_SCHEMA_VERSION = 1
+_FINDINGS_INPUT_MAX_BYTES = 1024 * 1024
+_FINDINGS_CONTAINER_MAX_BYTES = 256 * 1024
+_FINDINGS_MAX_ITEMS = 200
+_FINDINGS_MAX_RIDS = 32
+_FINDINGS_MAX_ID = 160
+_FINDINGS_MAX_PATH = 1024
+_FINDINGS_MAX_TITLE = 240
+_FINDINGS_MAX_BODY = 4000
+_FINDINGS_MAX_SUGGESTION = 4000
+_FINDINGS_SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+_FINDINGS_CONFIDENCE = frozenset({0, 25, 50, 75, 100})
+_FINDINGS_CLASSIFICATIONS = frozenset({"introduced", "pre_existing"})
+_FINDINGS_STATUSES = frozenset({"open", "fixed", "not_fixed", "withdrawn"})
+_FINDINGS_REVIEW_KINDS = frozenset(
+    {"plan", "implementation", "completion", "qa"}
+)
+_FINDINGS_SEVERITY_ALIASES = {
+    "p0": "P0",
+    "critical": "P0",
+    "p1": "P1",
+    "major": "P1",
+    "p2": "P2",
+    "minor": "P2",
+    "p3": "P3",
+    "nitpick": "P3",
+}
+_FINDINGS_STATUS_ALIASES = {
+    "open": "open",
+    "fixed": "fixed",
+    "fixed in review": "fixed",
+    "resolved": "fixed",
+    "not fixed": "not_fixed",
+    "not_fixed": "not_fixed",
+    "remains open": "not_fixed",
+    "unresolved": "not_fixed",
+    "withdrawn": "withdrawn",
+}
+_FINDINGS_FIELD_RE = re.compile(
+    r"""(?ix)
+    ^\s*(?:[-*]\s*)?
+    (?:\*\*)?
+    (?P<label>
+      severity|confidence|classification|problem|suggestion|suggested\ fix|
+      finding|title|file\s*:\s*line|file|path|line|side|original\s*path|
+      original\s*file|blob\s*oid|r-?ids?|prior\s*finding\s*id
+    )
+    (?:\*\*)?\s*[:=]\s*(?P<value>.*?)\s*$
+    """
+)
+_FINDINGS_INLINE_HOST_RE = re.compile(
+    r"(?im)\b([a-z][a-z0-9_-]*)\b"
+    r"\s*[·|,-]\s*confidence\s+([^\s·|,]+)"
+    r"\s*[·|,-]\s*([a-z][a-z0-9_-]*(?:[ -][a-z][a-z0-9_-]*)?)"
+    r"\s*(?:\*\*)?\s*$"
+)
+_FINDINGS_COMPACT_CANDIDATE_RE = re.compile(
+    r"""(?imx)
+    ^[ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?(?:\*\*)?
+    \[[^\]\r\n]*\bconfidence\b[^\]\r\n]*\bintroduced[ \t]*=
+    """
+)
+_FINDINGS_COMPACT_RE = re.compile(
+    r"""(?imx)
+    ^[ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?(?:\*\*)?
+    \[
+      (?P<severity>[^,\]\r\n]+),[ \t]*
+      confidence[ \t]+(?P<confidence>[^,\]\s]+),[ \t]*
+      introduced[ \t]*=[ \t]*(?P<introduced>[^,\]\s]+)
+    \]
+    [ \t]+(?P<file_line>.+?)
+    [ \t]+—[ \t]+
+    (?P<summary>.+?)(?:\*\*)?[ \t]*$
+    """
+)
+_FINDINGS_PRIOR_RE = re.compile(
+    r"""(?imx)
+    ^[ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?
+    prior[ \t-]+finding(?:[ \t]*(?:\#)?(?P<ordinal>\d+))?
+    [ \t]*(?:[:—-][ \t]*)?
+    (?:\*\*)?
+    (?P<status>
+      fixed(?:[ \t]+in[ \t]+review)?|resolved|not[\s_]fixed|remains[ \t]+open|
+      unresolved|withdrawn
+    )
+    (?:\*\*)?
+    (?![A-Za-z0-9_-])
+    """
+)
+_FINDINGS_PRIOR_RECORD_RE = re.compile(
+    r"""(?imx)
+    ^[ \t]*(?:(?:[-*+]|\d+[.)])[ \t]+)?
+    prior[ \t-]+finding(?![ \t]+id[ \t]*[:=])(?:[ \t]*(?:\#)?\d+)?
+    [ \t]*(?:[:—-][ \t]*)?
+    (?:\*\*)?
+    [A-Za-z][^\r\n]*
+    $
+    """
+)
+_FINDINGS_FILE_LINE_RE = re.compile(
+    r"^(?P<path>.+?):(?P<start>[1-9]\d*)"
+    r"(?:\s*[-–]\s*(?P<end>[1-9]\d*))?$"
+)
+_FINDINGS_HOST_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|(?:\s*:?-{3,}:?\s*\|)+\s*$"
+)
+
+
+def _review_finding_lineage_id(source_receipt_id: str, ordinal: int) -> str:
+    """Derive a stable, opaque finding identity from receipt + local ordinal."""
+    digest = hashlib.sha256(
+        f"flow-next-finding-v1\0{source_receipt_id}\0{ordinal}".encode("utf-8")
+    ).hexdigest()
+    return f"finding-{digest[:32]}"
+
+
+def _review_finding_clean_markdown(value: str) -> str:
+    value = value.strip()
+    if value.startswith("`") and value.endswith("`") and len(value) >= 2:
+        value = value[1:-1]
+    value = re.sub(r"^\*{1,2}|\*{1,2}$", "", value).strip()
+    return value.rstrip()
+
+
+def _review_finding_fields(block: str) -> Optional[dict[str, str]]:
+    fields: dict[str, str] = {}
+    for line in block.splitlines():
+        normalized_line = re.sub(
+            r"^\s*(?:(?:[-*]|\d+[.)])\s*)?", "", line
+        ).replace("**", "")
+        match = _FINDINGS_FIELD_RE.match(normalized_line)
+        if not match:
+            continue
+        label = re.sub(r"[\s_-]+", " ", match.group("label").lower()).strip()
+        if label in fields:
+            # Finding fields are singletons. Accepting a duplicate would make
+            # line order choose which value survives, potentially hiding an
+            # unsupported enum or conflicting anchor.
+            return None
+        fields[label] = _review_finding_clean_markdown(match.group("value"))
+    return fields
+
+
+def _review_finding_enum(
+    fields: dict[str, str], block: str
+) -> Optional[tuple[str, int, str]]:
+    severity_value = fields.get("severity", "").strip().lower()
+    confidence_value = fields.get("confidence", "").strip()
+    classification_value = fields.get("classification", "").strip().lower()
+    inline = _FINDINGS_INLINE_HOST_RE.search(block)
+    if inline:
+        try:
+            inline_confidence = int(inline.group(2))
+        except ValueError:
+            return None
+        inline_values = (
+            _FINDINGS_SEVERITY_ALIASES.get(inline.group(1).lower()),
+            inline_confidence,
+            re.sub(r"[\s-]+", "_", inline.group(3).lower()),
+        )
+        if (
+            inline_values[0] is None
+            or inline_values[1] not in _FINDINGS_CONFIDENCE
+            or inline_values[2] not in _FINDINGS_CLASSIFICATIONS
+        ):
+            return None
+    else:
+        inline_values = None
+    severity = _FINDINGS_SEVERITY_ALIASES.get(severity_value) if severity_value else None
+    if severity_value and severity is None:
+        return None
+    try:
+        confidence = int(confidence_value) if confidence_value else None
+    except (TypeError, ValueError):
+        return None
+    classification = (
+        re.sub(r"[\s-]+", "_", classification_value)
+        if classification_value
+        else None
+    )
+    labeled_values = (severity, confidence, classification)
+    if inline_values is not None:
+        for labeled, inline_value in zip(labeled_values, inline_values, strict=True):
+            if labeled is not None and labeled != inline_value:
+                return None
+        severity = severity if severity is not None else inline_values[0]
+        confidence = confidence if confidence is not None else inline_values[1]
+        classification = (
+            classification if classification is not None else inline_values[2]
+        )
+    if (
+        severity is None
+        or confidence not in _FINDINGS_CONFIDENCE
+        or classification not in _FINDINGS_CLASSIFICATIONS
+    ):
+        return None
+    return severity, confidence, classification
+
+
+def _review_finding_safe_path(value: str) -> Optional[str]:
+    path = _review_finding_clean_markdown(value).replace("\\", "/")
+    if (
+        not path
+        or len(path) > _FINDINGS_MAX_PATH
+        or path.startswith("/")
+        or re.match(r"^[A-Za-z]:/", path)
+    ):
+        return None
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return path
+
+
+def _review_finding_anchor(
+    fields: dict[str, str],
+    *,
+    base_sha: Optional[str],
+    head_sha: str,
+    anchor_side: Optional[str],
+) -> Optional[dict] | bool:
+    """Build an anchor only when every portability component is explicit."""
+    combined_values: Optional[tuple[str, str, Optional[str]]] = None
+    combined = fields.get("file:line")
+    explicit_no_anchor = combined == "-"
+    if explicit_no_anchor:
+        combined = None
+    if combined:
+        match = _FINDINGS_FILE_LINE_RE.match(combined)
+        if not match:
+            return False
+        combined_path = _review_finding_safe_path(match.group("path"))
+        if combined_path is None:
+            return False
+        combined_values = (
+            combined_path,
+            match.group("start"),
+            match.group("end"),
+        )
+
+    separate_paths = [
+        _review_finding_safe_path(value)
+        for value in (fields.get("path"), fields.get("file"))
+        if value
+    ]
+    if any(path is None for path in separate_paths):
+        return False
+    if len(set(separate_paths)) > 1:
+        return False
+    separate_values: Optional[tuple[str, str, Optional[str]]] = None
+    line_value = fields.get("line")
+    if explicit_no_anchor and (separate_paths or line_value):
+        return False
+    if separate_paths or line_value:
+        if not separate_paths or not line_value:
+            return False
+        line_match = re.fullmatch(
+            r"([1-9]\d*)(?:\s*[-–]\s*([1-9]\d*))?", line_value
+        )
+        if not line_match:
+            return False
+        separate_values = (
+            separate_paths[0],
+            line_match.group(1),
+            line_match.group(2),
+        )
+    if (
+        combined_values is not None
+        and separate_values is not None
+        and combined_values != separate_values
+    ):
+        return False
+    location = combined_values or separate_values
+    has_anchor_evidence = bool(
+        combined or separate_paths or line_value
+    )
+    if not has_anchor_evidence:
+        return None
+    if location is None:
+        return False
+    path, start_value, end_value = location
+    start_line = int(start_value)
+    explicit_side = fields.get("side")
+    if explicit_side:
+        explicit_side = explicit_side.strip().lower()
+        if explicit_side not in {"base", "head"}:
+            return False
+        if anchor_side is not None and anchor_side != explicit_side:
+            return False
+        resolved_side = explicit_side
+    else:
+        resolved_side = anchor_side
+    if not base_sha or resolved_side not in {"base", "head"}:
+        return None
+    anchor: dict[str, Any] = {
+        "path": path,
+        "side": resolved_side,
+        "startLine": start_line,
+        "baseSha": base_sha,
+        "headSha": head_sha,
+    }
+    if end_value:
+        end_line = int(end_value)
+        if end_line < start_line:
+            return False
+        anchor["endLine"] = end_line
+    original_paths = [
+        _review_finding_safe_path(value)
+        for value in (fields.get("original path"), fields.get("original file"))
+        if value
+    ]
+    if any(original is None for original in original_paths):
+        return False
+    if len(set(original_paths)) > 1:
+        return False
+    if original_paths:
+        anchor["originalPath"] = original_paths[0]
+    blob_oid = fields.get("blob oid")
+    if blob_oid:
+        if not re.fullmatch(r"[0-9a-fA-F]{7,64}", blob_oid):
+            return False
+        anchor["blobOid"] = blob_oid.lower()
+    return anchor
+
+
+def _review_finding_compact(
+    block: str,
+    *,
+    base_sha: Optional[str],
+    head_sha: str,
+    anchor_side: Optional[str],
+) -> Optional[dict] | bool:
+    """Parse Classic's compact pre-existing finding form."""
+    candidates = list(_FINDINGS_COMPACT_CANDIDATE_RE.finditer(block))
+    if not candidates:
+        return None
+    matches = list(_FINDINGS_COMPACT_RE.finditer(block))
+    if len(candidates) != 1 or len(matches) != 1:
+        return False
+    match = matches[0]
+    severity = _FINDINGS_SEVERITY_ALIASES.get(
+        match.group("severity").strip().lower()
+    )
+    try:
+        confidence = int(match.group("confidence"))
+    except ValueError:
+        return False
+    introduced = match.group("introduced").lower()
+    if (
+        severity is None
+        or confidence not in _FINDINGS_CONFIDENCE
+        or introduced not in {"true", "false"}
+    ):
+        return False
+    summary = _review_finding_clean_markdown(match.group("summary"))
+    if not summary:
+        return False
+    fields = {"file:line": _review_finding_clean_markdown(match.group("file_line"))}
+    anchor = _review_finding_anchor(
+        fields,
+        base_sha=base_sha,
+        head_sha=head_sha,
+        anchor_side=anchor_side,
+    )
+    if anchor is False:
+        return False
+    row: dict[str, Any] = {
+        "severity": severity,
+        "confidence": confidence,
+        "classification": "introduced" if introduced == "true" else "pre_existing",
+        "status": "open",
+        "title": summary.split(".", 1)[0].strip(),
+        "body": summary,
+        "rIds": _review_finding_rids(block, fields),
+    }
+    if anchor is not None:
+        row["anchor"] = anchor
+    return row
+
+
+def _review_finding_rids(block: str, fields: dict[str, str]) -> list[str]:
+    # The explicit per-finding field is authoritative. Falling back to the
+    # block keeps older backend prose parseable without letting nearby
+    # aggregate metadata override an explicit finding-to-requirement link.
+    source = fields["r ids"] if "r ids" in fields else block
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in re.finditer(r"(?<![A-Za-z0-9])R(?:-|\s)?(\d+)(?![A-Za-z0-9])", source):
+        rid = f"R{match.group(1)}"
+        if rid not in seen:
+            seen.add(rid)
+            result.append(rid)
+            if len(result) > _FINDINGS_MAX_RIDS:
+                break
+    return result
+
+
+def _review_finding_alias_value(
+    fields: dict[str, str], *labels: str
+) -> tuple[bool, Optional[str]]:
+    values = [fields[label] for label in labels if label in fields]
+    if not values:
+        return True, None
+    normalized = {re.sub(r"\s+", " ", value).strip() for value in values}
+    if len(normalized) != 1:
+        return False, None
+    return True, values[0]
+
+
+def _review_finding_text(
+    fields: dict[str, str], block: str
+) -> Optional[tuple[str, str, Optional[str]]]:
+    body_valid, body_value = _review_finding_alias_value(
+        fields, "problem", "finding", "evidence"
+    )
+    suggestion_valid, suggestion = _review_finding_alias_value(
+        fields, "suggestion", "suggested fix"
+    )
+    if not body_valid or not suggestion_valid:
+        return None
+    body = body_value or ""
+    if not body:
+        prose: list[str] = []
+        for line in block.splitlines():
+            stripped = line.strip().lstrip("-* ").strip()
+            if (
+                not stripped
+                or stripped.startswith("#")
+                or _FINDINGS_FIELD_RE.match(line)
+                or _FINDINGS_INLINE_HOST_RE.search(line)
+            ):
+                continue
+            prose.append(_review_finding_clean_markdown(stripped))
+        body = " ".join(prose)
+    body = body.strip()
+    title = (
+        fields.get("title")
+        or fields.get("requirement")
+        or body.split(".", 1)[0]
+    ).strip()
+    return title, body, suggestion.strip() if suggestion else None
+
+
+def _review_finding_blocks(output: str) -> tuple[list[str], bool]:
+    """Return severity-bearing prose blocks and whether a severity label existed."""
+    lines = output.splitlines()
+    starts: list[int] = []
+    saw_severity_label = False
+    for index, line in enumerate(lines):
+        fields = _review_finding_fields(line)
+        has_severity_field = fields is not None and "severity" in fields
+        candidate_start = index
+        has_finding_heading = False
+        if has_severity_field and index > 0:
+            previous_fields = _review_finding_fields(lines[index - 1])
+            if previous_fields is not None and "finding" in previous_fields:
+                candidate_start = index - 1
+                has_finding_heading = True
+        if has_severity_field and starts:
+            preceding = "\n".join(lines[starts[-1]:index])
+            between = lines[starts[-1] + 1:index]
+            if (
+                not has_finding_heading
+                and _FINDINGS_INLINE_HOST_RE.search(preceding)
+                and all(not value.strip() for value in between)
+            ):
+                # A host heading may repeat its inline enum tuple as labeled
+                # fields. Keep both representations in one block so semantic
+                # equality is checked instead of manufacturing two findings.
+                continue
+        if (
+            has_severity_field
+            or _FINDINGS_INLINE_HOST_RE.search(line)
+            or _FINDINGS_COMPACT_CANDIDATE_RE.search(line)
+        ):
+            starts.append(candidate_start)
+            saw_severity_label = True
+            if len(starts) > _FINDINGS_MAX_ITEMS:
+                return [], True
+    blocks: list[str] = []
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+        block_lines: list[str] = []
+        for line in lines[start:end]:
+            if re.search(r"<verdict>", line, re.IGNORECASE):
+                break
+            if re.match(
+                r"(?i)^\s*##\s+requirements coverage\s*#*\s*$",
+                line,
+            ):
+                break
+            if re.match(
+                r"(?i)^\s*(classification counts|suppressed findings|unaddressed r-ids)\s*:",
+                line,
+            ):
+                break
+            block_lines.append(line)
+        blocks.append("\n".join(block_lines).strip())
+    return blocks, saw_severity_label
+
+
+def _review_finding_host_table(output: str) -> Optional[list[dict]]:
+    """Parse the observed host-review finding table, or return None."""
+    lines = output.splitlines()
+    candidates: list[tuple[int, list[str]]] = []
+    required_headers = {
+        "sev",
+        "confidence",
+        "classification",
+        "finding",
+        "disposition",
+    }
+    saw_malformed_header = False
+    for index, line in enumerate(lines):
+        if not line.strip().startswith("|"):
+            continue
+        candidate = [cell.strip().lower() for cell in line.strip().strip("|").split("|")]
+        present_headers = set(candidate)
+        if required_headers <= present_headers:
+            if len(candidate) != len(set(candidate)):
+                # Header names are singleton keys. dict(zip(...)) would
+                # otherwise silently select the last duplicate column.
+                return []
+            candidates.append((index, candidate))
+            if len(candidates) > 1:
+                # Multiple finding tables make completeness and deduplication
+                # ambiguous. Reject rather than silently selecting the first.
+                return []
+        elif len(required_headers & present_headers) >= 4 or (
+            "finding" in present_headers
+            and len(required_headers & present_headers) >= 3
+        ):
+            saw_malformed_header = True
+    if saw_malformed_header:
+        return []
+    if not candidates:
+        return None
+    header_index, headers = candidates[0]
+    if header_index + 1 >= len(lines):
+        return []
+    if not _FINDINGS_HOST_TABLE_SEPARATOR_RE.match(lines[header_index + 1]):
+        return []
+    rows: list[dict] = []
+    for line in lines[header_index + 2:]:
+        if not line.strip().startswith("|"):
+            break
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) != len(headers):
+            return []
+        row = dict(zip(headers, cells, strict=True))
+        severity = _FINDINGS_SEVERITY_ALIASES.get(row["sev"].lower())
+        try:
+            confidence = int(row["confidence"])
+        except ValueError:
+            return []
+        classification = re.sub(
+            r"[\s-]+", "_", row["classification"].lower()
+        )
+        status_value = re.sub(r"\s+", " ", row["disposition"].lower()).strip()
+        status = _FINDINGS_STATUS_ALIASES.get(status_value)
+        if (
+            severity is None
+            or confidence not in _FINDINGS_CONFIDENCE
+            or classification not in _FINDINGS_CLASSIFICATIONS
+            or status not in _FINDINGS_STATUSES
+        ):
+            return []
+        body = _review_finding_clean_markdown(row["finding"])
+        rows.append(
+            {
+                "severity": severity,
+                "confidence": confidence,
+                "classification": classification,
+                "status": status,
+                "title": body.split(".", 1)[0].strip(),
+                "body": body,
+                "rIds": _review_finding_rids(body, {}),
+            }
+        )
+        if len(rows) > _FINDINGS_MAX_ITEMS:
+            return []
+    return rows
+
+
+def _review_finding_prior_items(
+    output: str,
+    prior_findings: Optional[dict],
+    source_receipt_id: str,
+) -> Optional[list[dict]]:
+    record_count = 0
+    for _match in _FINDINGS_PRIOR_RECORD_RE.finditer(output):
+        record_count += 1
+        if record_count > _FINDINGS_MAX_ITEMS:
+            return None
+    matches = []
+    for match in _FINDINGS_PRIOR_RE.finditer(output):
+        matches.append(match)
+        if len(matches) > _FINDINGS_MAX_ITEMS:
+            return None
+    if record_count != len(matches):
+        # Detect line-level prior-finding records independently of canonical
+        # status parsing. Otherwise an unknown status such as "pending" can
+        # disappear into an explicit-empty SHIP response.
+        return None
+    if not matches and prior_findings is None:
+        return []
+    if not isinstance(prior_findings, dict):
+        return None
+    if prior_findings.get("schemaVersion") != _FINDINGS_SCHEMA_VERSION:
+        return None
+    prior_items = prior_findings.get("items")
+    if (
+        not isinstance(prior_items, list)
+        or len(prior_items) > _FINDINGS_MAX_ITEMS
+        or not _review_findings_container_valid(prior_findings)
+    ):
+        return None
+    by_ordinal = {
+        item.get("ordinal"): item for item in prior_items if isinstance(item, dict)
+    }
+    # Some backends omit the ordinal only when exactly one prior finding exists.
+    if any(match.group("ordinal") is None for match in matches) and len(prior_items) != 1:
+        return None
+    carried: list[dict] = [
+        {
+            key: (
+                dict(value)
+                if key == "anchor"
+                else list(value)
+                if key == "rIds"
+                else value
+            )
+            for key, value in item.items()
+        }
+        for item in prior_items
+    ]
+    carried_by_ordinal = {item["ordinal"]: item for item in carried}
+    for item in carried:
+        # Every generation is a complete snapshot. An omitted prior finding
+        # remains current until the reviewer explicitly fixes or withdraws it.
+        item["lastSeenReceiptId"] = source_receipt_id
+    for match in matches:
+        ordinal = (
+            int(match.group("ordinal"))
+            if match.group("ordinal") is not None
+            else prior_items[0].get("ordinal")
+        )
+        prior = by_ordinal.get(ordinal)
+        if not isinstance(prior, dict):
+            return None
+        status_key = re.sub(r"[_\s]+", " ", match.group("status").lower()).strip()
+        status = _FINDINGS_STATUS_ALIASES.get(status_key)
+        if status is None:
+            return None
+        item = carried_by_ordinal[ordinal]
+        item["status"] = status
+        item["lastSeenReceiptId"] = source_receipt_id
+    return carried
+
+
+def _review_finding_item_valid(item: dict) -> bool:
+    required = {
+        "id",
+        "ordinal",
+        "severity",
+        "confidence",
+        "classification",
+        "status",
+        "title",
+        "body",
+        "rIds",
+        "firstSeenReceiptId",
+        "lastSeenReceiptId",
+    }
+    allowed = required | {"priorFindingId", "anchor", "suggestion"}
+    if set(item) - allowed or not required <= set(item):
+        return False
+    if (
+        not isinstance(item["id"], str)
+        or not item["id"]
+        or len(item["id"]) > _FINDINGS_MAX_ID
+        or not isinstance(item["ordinal"], int)
+        or isinstance(item["ordinal"], bool)
+        or item["ordinal"] < 1
+        or not isinstance(item["severity"], str)
+        or item["severity"] not in _FINDINGS_SEVERITY_ORDER
+        or not isinstance(item["confidence"], int)
+        or isinstance(item["confidence"], bool)
+        or item["confidence"] not in _FINDINGS_CONFIDENCE
+        or not isinstance(item["classification"], str)
+        or item["classification"] not in _FINDINGS_CLASSIFICATIONS
+        or not isinstance(item["status"], str)
+        or item["status"] not in _FINDINGS_STATUSES
+        or not isinstance(item["title"], str)
+        or not item["title"]
+        or len(item["title"]) > _FINDINGS_MAX_TITLE
+        or not isinstance(item["body"], str)
+        or not item["body"]
+        or len(item["body"]) > _FINDINGS_MAX_BODY
+        or not isinstance(item["rIds"], list)
+        or len(item["rIds"]) > _FINDINGS_MAX_RIDS
+        or len(set(item["rIds"])) != len(item["rIds"])
+        or not all(
+            isinstance(rid, str)
+            and len(rid) <= _FINDINGS_MAX_ID
+            and re.fullmatch(r"R\d+", rid)
+            for rid in item["rIds"]
+        )
+    ):
+        return False
+    for key in ("firstSeenReceiptId", "lastSeenReceiptId"):
+        if (
+            not isinstance(item[key], str)
+            or not item[key]
+            or len(item[key]) > _FINDINGS_MAX_ID
+        ):
+            return False
+    suggestion = item.get("suggestion")
+    if suggestion is not None and (
+        not isinstance(suggestion, str)
+        or not suggestion
+        or len(suggestion) > _FINDINGS_MAX_SUGGESTION
+    ):
+        return False
+    prior_id = item.get("priorFindingId")
+    if prior_id is not None and (
+        not isinstance(prior_id, str)
+        or not prior_id
+        or len(prior_id) > _FINDINGS_MAX_ID
+        or prior_id == item["id"]
+    ):
+        return False
+    anchor = item.get("anchor")
+    if anchor is not None:
+        if not isinstance(anchor, dict):
+            return False
+        anchor_required = {
+            "path",
+            "side",
+            "startLine",
+            "baseSha",
+            "headSha",
+        }
+        anchor_allowed = anchor_required | {
+            "originalPath",
+            "endLine",
+            "blobOid",
+        }
+        if (
+            set(anchor) - anchor_allowed
+            or not anchor_required <= set(anchor)
+            or not isinstance(anchor.get("path"), str)
+            or _review_finding_safe_path(anchor["path"]) is None
+            or anchor.get("side") not in {"base", "head"}
+            or not isinstance(anchor.get("startLine"), int)
+            or isinstance(anchor.get("startLine"), bool)
+            or anchor["startLine"] < 1
+            or not isinstance(anchor.get("baseSha"), str)
+            or not anchor["baseSha"]
+            or not isinstance(anchor.get("headSha"), str)
+            or not anchor["headSha"]
+            or len(anchor["baseSha"]) > _FINDINGS_MAX_ID
+            or len(anchor["headSha"]) > _FINDINGS_MAX_ID
+        ):
+            return False
+        end_line = anchor.get("endLine")
+        if end_line is not None and (
+            not isinstance(end_line, int)
+            or isinstance(end_line, bool)
+            or end_line < anchor["startLine"]
+        ):
+            return False
+        original_path = anchor.get("originalPath")
+        if original_path is not None and (
+            not isinstance(original_path, str)
+            or _review_finding_safe_path(original_path) is None
+        ):
+            return False
+        blob_oid = anchor.get("blobOid")
+        if blob_oid is not None and (
+            not isinstance(blob_oid, str)
+            or not re.fullmatch(r"[0-9a-f]{7,64}", blob_oid)
+        ):
+            return False
+    return True
+
+
+def _review_findings_container_valid(container: dict) -> bool:
+    """Strictly validate one complete v1 container before reuse or emission."""
+    required = {
+        "schemaVersion",
+        "sourceReceiptId",
+        "reviewKind",
+        "backend",
+        "round",
+        "headSha",
+        "items",
+    }
+    allowed = required | {"baseSha", "supersedesReceiptId"}
+    if not isinstance(container, dict) or set(container) - allowed:
+        return False
+    if not required <= set(container):
+        return False
+    source_id = container["sourceReceiptId"]
+    supersedes = container.get("supersedesReceiptId")
+    if (
+        not isinstance(container["schemaVersion"], int)
+        or isinstance(container["schemaVersion"], bool)
+        or container["schemaVersion"] != _FINDINGS_SCHEMA_VERSION
+        or not isinstance(source_id, str)
+        or not source_id
+        or len(source_id) > _FINDINGS_MAX_ID
+        or not isinstance(container["reviewKind"], str)
+        or container["reviewKind"] not in _FINDINGS_REVIEW_KINDS
+        or not isinstance(container["backend"], str)
+        or not container["backend"]
+        or len(container["backend"]) > _FINDINGS_MAX_ID
+        or not isinstance(container["round"], int)
+        or isinstance(container["round"], bool)
+        or container["round"] < 1
+        or (supersedes is None and container["round"] != 1)
+        or (supersedes is not None and container["round"] <= 1)
+        or not isinstance(container["headSha"], str)
+        or not container["headSha"]
+        or len(container["headSha"]) > _FINDINGS_MAX_ID
+        or (
+            "baseSha" in container
+            and (
+                not isinstance(container["baseSha"], str)
+                or not container["baseSha"]
+                or len(container["baseSha"]) > _FINDINGS_MAX_ID
+            )
+        )
+        or (
+            supersedes is not None
+            and (
+                not isinstance(supersedes, str)
+                or not supersedes
+                or len(supersedes) > _FINDINGS_MAX_ID
+                or supersedes == source_id
+            )
+        )
+        or not isinstance(container["items"], list)
+        or len(container["items"]) > _FINDINGS_MAX_ITEMS
+    ):
+        return False
+    items = container["items"]
+    if not all(
+        isinstance(item, dict) and _review_finding_item_valid(item)
+        for item in items
+    ):
+        return False
+    if len({item["id"] for item in items}) != len(items):
+        return False
+    if len({item["ordinal"] for item in items}) != len(items):
+        return False
+    if any(
+        item["id"]
+        != _review_finding_lineage_id(item["firstSeenReceiptId"], item["ordinal"])
+        or item["lastSeenReceiptId"] != source_id
+        or (
+            "anchor" in item
+            and (
+                item["anchor"]["headSha"] != container["headSha"]
+                or item["anchor"]["baseSha"] != container.get("baseSha")
+            )
+        )
+        for item in items
+    ):
+        return False
+    encoded = json.dumps(
+        container, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    if len(encoded) > _FINDINGS_CONTAINER_MAX_BYTES:
+        return False
+    return True
+
+
+def _parse_review_findings_v1(
+    output: str,
+    *,
+    source_receipt_id: str,
+    review_kind: str,
+    backend: str,
+    round_number: int,
+    head_sha: str,
+    base_sha: Optional[str],
+    supersedes_receipt_id: Optional[str],
+    prior_findings: Optional[dict],
+    anchor_side: Optional[str],
+) -> Optional[dict]:
+    if (
+        not isinstance(output, str)
+        or len(output.encode("utf-8")) > _FINDINGS_INPUT_MAX_BYTES
+        or not isinstance(source_receipt_id, str)
+        or not source_receipt_id
+        or len(source_receipt_id) > _FINDINGS_MAX_ID
+        or review_kind not in _FINDINGS_REVIEW_KINDS
+        or not isinstance(backend, str)
+        or not backend
+        or len(backend) > _FINDINGS_MAX_ID
+        or not isinstance(round_number, int)
+        or isinstance(round_number, bool)
+        or round_number < 1
+        or (supersedes_receipt_id is None and round_number != 1)
+        or (supersedes_receipt_id is not None and round_number <= 1)
+        or (supersedes_receipt_id is None and prior_findings is not None)
+        or not isinstance(head_sha, str)
+        or not head_sha
+        or len(head_sha) > _FINDINGS_MAX_ID
+        or (
+            base_sha is not None
+            and (not isinstance(base_sha, str) or not base_sha or len(base_sha) > _FINDINGS_MAX_ID)
+        )
+        or (
+            supersedes_receipt_id is not None
+            and (
+                not isinstance(supersedes_receipt_id, str)
+                or not supersedes_receipt_id
+                or len(supersedes_receipt_id) > _FINDINGS_MAX_ID
+                or supersedes_receipt_id == source_receipt_id
+            )
+        )
+    ):
+        return None
+
+    prior_items = _review_finding_prior_items(
+        output, prior_findings, source_receipt_id
+    )
+    if prior_items is None:
+        return None
+    for item in prior_items:
+        anchor = item.get("anchor")
+        if isinstance(anchor, dict) and (
+            anchor.get("headSha") != head_sha
+            or anchor.get("baseSha") != base_sha
+        ):
+            # A line anchor cannot be relabeled onto a newer snapshot without
+            # re-reading the diff. Preserve the finding but omit the stale
+            # location rather than guessing.
+            item.pop("anchor", None)
+    if supersedes_receipt_id is not None:
+        if (
+            not isinstance(prior_findings, dict)
+            or prior_findings.get("sourceReceiptId") != supersedes_receipt_id
+            or prior_findings.get("reviewKind") != review_kind
+            or prior_findings.get("backend") != backend
+            or not isinstance(prior_findings.get("round"), int)
+            or isinstance(prior_findings.get("round"), bool)
+            or prior_findings["round"] + 1 != round_number
+        ):
+            return None
+    parsed_rows = _review_finding_host_table(output)
+    if parsed_rows == []:
+        return None
+    rows = parsed_rows or []
+    blocks, saw_severity_label = _review_finding_blocks(output)
+    if parsed_rows is not None and saw_severity_label:
+        # Multiple representations make completeness/deduplication ambiguous.
+        return None
+    if parsed_rows is None:
+        for block in blocks:
+            compact = _review_finding_compact(
+                block,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                anchor_side=anchor_side,
+            )
+            if compact is False:
+                return None
+            if compact is not None:
+                rows.append(compact)
+                continue
+            fields = _review_finding_fields(block)
+            if fields is None:
+                return None
+            enums = _review_finding_enum(fields, block)
+            if enums is None:
+                return None
+            severity, confidence, classification = enums
+            text_fields = _review_finding_text(fields, block)
+            if text_fields is None:
+                return None
+            title, body, suggestion = text_fields
+            if not title or not body:
+                return None
+            row: dict[str, Any] = {
+                "severity": severity,
+                "confidence": confidence,
+                "classification": classification,
+                "status": "open",
+                "title": title,
+                "body": body,
+                "rIds": _review_finding_rids(block, fields),
+            }
+            anchor = _review_finding_anchor(
+                fields,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                anchor_side=anchor_side,
+            )
+            if anchor is False:
+                return None
+            if anchor is not None:
+                row["anchor"] = anchor
+            if suggestion:
+                row["suggestion"] = suggestion
+            prior_finding_id = fields.get("prior finding id")
+            if prior_finding_id:
+                row["priorFindingId"] = prior_finding_id
+            rows.append(row)
+
+    prior_item_ids = (
+        {
+            item["id"]
+            for item in prior_findings["items"]
+            if isinstance(item, dict) and isinstance(item.get("id"), str)
+        }
+        if isinstance(prior_findings, dict)
+        and isinstance(prior_findings.get("items"), list)
+        else set()
+    )
+    prior_references = [
+        row["priorFindingId"] for row in rows if "priorFindingId" in row
+    ]
+    if (
+        any(prior_id not in prior_item_ids for prior_id in prior_references)
+        or len(prior_references) != len(set(prior_references))
+    ):
+        return None
+
+    explicit_empty = bool(
+        re.search(
+            r"""(?ix)
+            \b(?:no\s+(?:blocking\s+)?findings?|found\s+no\s+correctness|
+            no\s+blocking\s+gaps|review\s+result:\s*no\s+findings?)\b
+            """,
+            output,
+        )
+        and re.search(r"<verdict>\s*SHIP\s*</verdict>", output, re.IGNORECASE)
+    )
+    has_prior_records = _FINDINGS_PRIOR_RE.search(output) is not None
+    if not rows and not has_prior_records and not explicit_empty:
+        # Prior state is context, not evidence that this generation parsed.
+        # Arbitrary re-review prose must not advance the structured lineage.
+        return None
+    if saw_severity_label and not rows:
+        return None
+
+    items: list[dict] = list(prior_items)
+    used_ordinals = {
+        item.get("ordinal") for item in items if isinstance(item.get("ordinal"), int)
+    }
+    next_ordinal = 1
+    for row in rows:
+        while next_ordinal in used_ordinals:
+            next_ordinal += 1
+        item = {
+            "id": _review_finding_lineage_id(source_receipt_id, next_ordinal),
+            "ordinal": next_ordinal,
+            **row,
+            "firstSeenReceiptId": source_receipt_id,
+            "lastSeenReceiptId": source_receipt_id,
+        }
+        items.append(item)
+        used_ordinals.add(next_ordinal)
+        next_ordinal += 1
+    items.sort(
+        key=lambda item: (
+            _FINDINGS_SEVERITY_ORDER[item["severity"]],
+            -item["confidence"],
+            item["ordinal"],
+        )
+    )
+    container: dict[str, Any] = {
+        "schemaVersion": _FINDINGS_SCHEMA_VERSION,
+        "sourceReceiptId": source_receipt_id,
+        "reviewKind": review_kind,
+        "backend": backend,
+        "round": round_number,
+    }
+    if base_sha is not None:
+        container["baseSha"] = base_sha
+    container["headSha"] = head_sha
+    if supersedes_receipt_id is not None:
+        container["supersedesReceiptId"] = supersedes_receipt_id
+    container["items"] = items
+    if not _review_findings_container_valid(container):
+        return None
+    encoded = json.dumps(
+        container, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    if len(encoded) > _FINDINGS_CONTAINER_MAX_BYTES:
+        return None
+    return container
+
+
+def parse_review_findings(
+    output: str,
+    *,
+    source_receipt_id: str,
+    review_kind: str,
+    backend: str,
+    round_number: int,
+    head_sha: str,
+    base_sha: Optional[str] = None,
+    supersedes_receipt_id: Optional[str] = None,
+    prior_findings: Optional[dict] = None,
+    anchor_side: Optional[str] = None,
+    schema_version: int = _FINDINGS_SCHEMA_VERSION,
+) -> Optional[dict]:
+    """Parse reviewer prose into the additive v1 findings container.
+
+    Unsupported versions, unknown enums, over-limit data, and unparseable
+    prose return ``None``. The public boundary intentionally never raises.
+    """
+    try:
+        if (
+            not isinstance(schema_version, int)
+            or isinstance(schema_version, bool)
+            or schema_version != _FINDINGS_SCHEMA_VERSION
+        ):
+            return None
+        return _parse_review_findings_v1(
+            output,
+            source_receipt_id=source_receipt_id,
+            review_kind=review_kind,
+            backend=backend,
+            round_number=round_number,
+            head_sha=head_sha,
+            base_sha=base_sha,
+            supersedes_receipt_id=supersedes_receipt_id,
+            prior_findings=prior_findings,
+            anchor_side=anchor_side,
+        )
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError, UnicodeError):
+        return None
+
+
+_REVIEW_TYPE_TO_FINDINGS_KIND = {
+    "plan_review": "plan",
+    "impl_review": "implementation",
+    "completion_review": "completion",
+    "qa_verdict": "qa",
+}
+
+
+class ReviewReceiptHistoryError(RuntimeError):
+    """A valid findings generation could not be preserved immutably."""
+
+
+def _review_receipt_findings_id(
+    *,
+    review_kind: str,
+    review_id: str,
+    backend: str,
+    round_number: int,
+    head_sha: str,
+    review_text: str,
+) -> str:
+    """Return a deterministic, bounded identity for one receipt generation."""
+    identity = json.dumps(
+        [
+            _FINDINGS_SCHEMA_VERSION,
+            review_kind,
+            review_id,
+            backend,
+            round_number,
+            head_sha,
+            review_text,
+        ],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"review-{hashlib.sha256(identity).hexdigest()}"
+
+
+def _load_prior_receipt_findings(
+    path: Optional[Path],
+    *,
+    review_type: str,
+    review_id: str,
+    backend: str,
+) -> Optional[dict]:
+    """Load valid findings only from the same receipt scope.
+
+    A failed review removes the latest pointer after preserving it. Recover
+    that prior generation only when immutable history proves one unambiguous
+    explicit lineage tip for this exact scope.
+    """
+    if path is None:
+        return None
+    if not path.exists():
+        history_dir = _review_receipt_history_dir(path)
+        if not history_dir.exists():
+            return None
+        generations = load_review_receipt_generations(path)
+        expected_scope = (review_type, review_id, backend)
+        if generations is None or any(
+            (receipt.get("type"), receipt.get("id"), receipt.get("mode"))
+            != expected_scope
+            for receipt in generations
+        ):
+            raise ReviewReceiptHistoryError(
+                f"cannot recover scoped receipt history: {history_dir}"
+            )
+        review_kind = _REVIEW_TYPE_TO_FINDINGS_KIND.get(review_type)
+        candidate_heads = {
+            receipt["findings"]["headSha"]
+            for receipt in generations
+            if isinstance(receipt.get("findings"), dict)
+        }
+        tips: dict[str, dict] = {}
+        for candidate_head in sorted(candidate_heads):
+            tip = select_current_review_findings(
+                generations,
+                current_head_sha=candidate_head,
+                review_kind=review_kind,
+                backend=backend,
+            )
+            if tip is not None:
+                tips[tip["sourceReceiptId"]] = tip
+        if len(tips) != 1:
+            raise ReviewReceiptHistoryError(
+                f"receipt history has no unique scoped tip: {history_dir}"
+            )
+        return next(iter(tips.values()))
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+    if not isinstance(receipt, dict):
+        return None
+    if (
+        receipt.get("type") != review_type
+        or receipt.get("id") != review_id
+        or receipt.get("mode") != backend
+    ):
+        return None
+    findings = receipt.get("findings")
+    return (
+        findings
+        if isinstance(findings, dict)
+        and _review_findings_container_valid(findings)
+        else None
+    )
+
+
+def build_review_receipt_findings(
+    review_text: str,
+    *,
+    review_type: str,
+    review_id: str,
+    backend: str,
+    head_sha: str,
+    base_sha: Optional[str] = None,
+    prior_receipt_path: Optional[Path] = None,
+    anchor_side: Optional[str] = "head",
+) -> Optional[dict]:
+    """Build the optional findings field while receipt inputs are already held.
+
+    The only read is the receipt path the caller is about to replace. No model,
+    network, or reviewer dispatch occurs. A legacy, malformed, stale-lineage,
+    or unparseable input simply leaves the additive field absent.
+    """
+    review_kind = _REVIEW_TYPE_TO_FINDINGS_KIND.get(review_type)
+    if review_kind is None:
+        return None
+    prior = _load_prior_receipt_findings(
+        prior_receipt_path,
+        review_type=review_type,
+        review_id=review_id,
+        backend=backend,
+    )
+    if prior is not None and (
+        prior.get("reviewKind") != review_kind
+        or prior.get("backend") != backend
+    ):
+        prior = None
+    round_number = prior["round"] + 1 if prior is not None else 1
+    supersedes = prior["sourceReceiptId"] if prior is not None else None
+    source_receipt_id = _review_receipt_findings_id(
+        review_kind=review_kind,
+        review_id=review_id,
+        backend=backend,
+        round_number=round_number,
+        head_sha=head_sha,
+        review_text=review_text,
+    )
+    return parse_review_findings(
+        review_text,
+        source_receipt_id=source_receipt_id,
+        review_kind=review_kind,
+        backend=backend,
+        round_number=round_number,
+        head_sha=head_sha,
+        base_sha=base_sha,
+        supersedes_receipt_id=supersedes,
+        prior_findings=prior,
+        anchor_side=anchor_side,
+    )
+
+
+def validate_review_receipt_findings(receipt: object) -> bool:
+    """Validate the optional additive field; legacy receipts remain valid."""
+    if not isinstance(receipt, dict):
+        return False
+    findings = receipt.get("findings")
+    if findings is None:
+        return True
+    expected_kind = _REVIEW_TYPE_TO_FINDINGS_KIND.get(receipt.get("type"))
+    return (
+        isinstance(findings, dict)
+        and _review_findings_container_valid(findings)
+        and expected_kind == findings["reviewKind"]
+        and isinstance(receipt.get("mode"), str)
+        and receipt["mode"] == findings["backend"]
+    )
+
+
+# --- Global-criteria compliance in completion-review receipts (fn-137.2) ---
+#
+# The completion-review prompt (when .flow/criteria.md exists) mandates a
+# `## Global criteria` output section, one `G<N>: met|violated|n/a - <note>`
+# line per criterion. parse_review_criteria() projects that section into the
+# additive receipt field `criteria: [{id, status, note?}]`. Same public
+# boundary as parse_review_findings: unparseable degrades to None (field
+# absent), never an error. Because the array is authoritative for compliance
+# status, bind_review_criteria() additionally requires the parsed ids to
+# exactly match the currently configured `.flow/criteria.md` id set before
+# either attach site writes the field - omitted, extra, or invented ids (or a
+# missing/invalid criteria file) degrade to absent, never an error. Findings
+# carry the detail; no cross-validation links the two.
+
+GLOBAL_CRITERIA_OUTPUT_HEADING = "## Global criteria"
+
+_REVIEW_CRITERIA_HEADING_RE = re.compile(
+    r"^#{2,3}\s+Global criteria\s*:?\s*$", re.IGNORECASE
+)
+_REVIEW_CRITERIA_LINE_RE = re.compile(
+    r"^G([1-9][0-9]*):\s*(met|violated|n/a)\s*(?:-\s*(.*))?$"
+)
+_REVIEW_CRITERIA_MAX_ENTRIES = 100
+_REVIEW_CRITERIA_MAX_NOTE = 400
+
+
+def parse_review_criteria(output: str) -> Optional[list[dict]]:
+    """Parse the reviewer's `## Global criteria` section into [{id, status, note?}].
+
+    Deterministic projection of completion-review output (fn-137.2). Uses the
+    LAST matching heading (mirrors the tally-block precedent: the real section
+    follows any quoted prompt text). The section is machine-mandated output
+    with an exact grammar, so ANY non-blank line inside it that is not a valid
+    record (after stripping a plain bullet marker) is ambiguity and returns
+    None - as do duplicate ids and oversized content. Degrade-to-absent,
+    never an error; this subsumes every Markdown-prefix variant (ordered
+    lists, blockquotes, exotic bullets) generically instead of enumerating
+    them.
+    """
+    try:
+        if not isinstance(output, str) or not output:
+            return None
+        lines = output.replace("\r\n", "\n").split("\n")
+        idx = None
+        for i, line in enumerate(lines):
+            if _REVIEW_CRITERIA_HEADING_RE.match(line.strip()):
+                idx = i
+        if idx is None:
+            return None
+        entries: list[dict] = []
+        seen: set[str] = set()
+        for line in lines[idx + 1:]:
+            stripped = line.strip()
+            if re.match(r"^#{1,6}\s", stripped):
+                break
+            if not stripped:
+                continue
+            if re.match(r"^<verdict>(SHIP|NEEDS_WORK)</verdict>$", stripped):
+                break  # the required terminal verdict tag ends the section
+            if stripped.startswith(("- ", "* ", "+ ")):
+                stripped = stripped[2:].strip()
+            m = _REVIEW_CRITERIA_LINE_RE.match(stripped)
+            if not m:
+                # Strict section: any non-blank, non-record line is ambiguous
+                # reviewer output -> whole projection degrades to absent.
+                return None
+            cid = f"G{m.group(1)}"
+            if cid in seen:
+                return None
+            seen.add(cid)
+            entry: dict[str, Any] = {"id": cid, "status": m.group(2)}
+            note = (m.group(3) or "").strip()
+            if len(note) > _REVIEW_CRITERIA_MAX_NOTE:
+                return None
+            if note:
+                entry["note"] = note
+            entries.append(entry)
+            if len(entries) > _REVIEW_CRITERIA_MAX_ENTRIES:
+                return None
+        return entries or None
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError, UnicodeError):
+        return None
+
+
+def validate_review_receipt_criteria(receipt: object) -> bool:
+    """Validate the optional additive `criteria` field; legacy receipts stay valid."""
+    if not isinstance(receipt, dict):
+        return False
+    criteria = receipt.get("criteria")
+    if criteria is None:
+        return True
+    if receipt.get("type") != "completion_review":
+        return False
+    if (
+        not isinstance(criteria, list)
+        or not criteria
+        or len(criteria) > _REVIEW_CRITERIA_MAX_ENTRIES
+    ):
+        return False
+    seen: set[str] = set()
+    for item in criteria:
+        if not isinstance(item, dict):
+            return False
+        if not set(item) <= {"id", "status", "note"}:
+            return False
+        cid = item.get("id")
+        if (
+            not isinstance(cid, str)
+            or not re.fullmatch(r"G[1-9][0-9]*", cid)
+            or cid in seen
+        ):
+            return False
+        seen.add(cid)
+        if item.get("status") not in ("met", "violated", "n/a"):
+            return False
+        note = item.get("note")
+        if note is not None and (
+            not isinstance(note, str)
+            or not note
+            or len(note) > _REVIEW_CRITERIA_MAX_NOTE
+        ):
+            return False
+    return True
+
+
+def bind_review_criteria(
+    criteria: Optional[list[dict]],
+) -> Optional[list[dict]]:
+    """Bind parsed reviewer criteria to the configured `.flow/criteria.md` ids.
+
+    The receipt criteria array is documented as authoritative for compliance,
+    so it must never silently drop a standing criterion or assert compliance
+    with an id that is not configured. Returns ``criteria`` only when the
+    parsed id set exactly equals the configured id set; any mismatch, or an
+    absent/unreadable/invalid/empty criteria file, degrades to None (field
+    absent) - never an error.
+    """
+    if criteria is None:
+        return None
+    try:
+        path = get_criteria_path()
+        if not path.exists():
+            return None
+        entries, errors = _criteria_parse(path.read_text(encoding="utf-8"))
+        if errors or not entries:
+            return None
+        configured_ids = {entry["id"] for entry in entries}
+        parsed_ids = {item["id"] for item in criteria}
+    except (AttributeError, KeyError, OSError, TypeError, UnicodeError, ValueError):
+        return None
+    if parsed_ids != configured_ids:
+        return None
+    return criteria
+
+
+def select_current_review_findings(
+    receipts: list[object],
+    *,
+    current_head_sha: str,
+    review_kind: Optional[str] = None,
+    backend: Optional[str] = None,
+) -> Optional[dict]:
+    """Project one unambiguous current explicit lineage tip.
+
+    Every valid receipt remains caller-owned evidence. This read-only projector
+    returns only a supported chain tip bound to ``current_head_sha``. Duplicate
+    identities, broken/cross-lineage supersedes edges, cycles, duplicate
+    finding lineage within a chain, or multiple current tips fail closed.
+    """
+    if (
+        not isinstance(receipts, list)
+        or not isinstance(current_head_sha, str)
+        or not current_head_sha
+        or (review_kind is not None and review_kind not in _FINDINGS_REVIEW_KINDS)
+        or (backend is not None and (not isinstance(backend, str) or not backend))
+    ):
+        return None
+    containers: list[dict] = []
+    for receipt in receipts:
+        if not isinstance(receipt, dict):
+            continue
+        findings = receipt.get("findings")
+        if not isinstance(findings, dict):
+            continue
+        if not _review_findings_container_valid(findings):
+            return None
+        if review_kind is not None and findings["reviewKind"] != review_kind:
+            continue
+        if backend is not None and findings["backend"] != backend:
+            continue
+        containers.append(findings)
+    by_id: dict[str, dict] = {}
+    for container in containers:
+        source_id = container["sourceReceiptId"]
+        if source_id in by_id:
+            return None
+        by_id[source_id] = container
+    if not by_id:
+        return None
+
+    superseded: set[str] = set()
+    for container in containers:
+        parent_id = container.get("supersedesReceiptId")
+        if parent_id is None:
+            if container["round"] != 1:
+                return None
+            continue
+        parent = by_id.get(parent_id)
+        if (
+            parent is None
+            or parent["reviewKind"] != container["reviewKind"]
+            or parent["backend"] != container["backend"]
+            or parent["round"] + 1 != container["round"]
+        ):
+            return None
+        superseded.add(parent_id)
+
+    tips = [
+        container
+        for container in containers
+        if container["sourceReceiptId"] not in superseded
+        and container["headSha"] == current_head_sha
+    ]
+    if len(tips) != 1:
+        return None
+    tip = tips[0]
+
+    seen_receipts: set[str] = set()
+    chain: list[dict] = []
+    cursor = tip
+    while True:
+        source_id = cursor["sourceReceiptId"]
+        if source_id in seen_receipts:
+            return None
+        seen_receipts.add(source_id)
+        chain.append(cursor)
+        parent_id = cursor.get("supersedesReceiptId")
+        if parent_id is None:
+            break
+        cursor = by_id[parent_id]
+    known_findings: set[str] = set()
+    prior_edge_owners: dict[str, str] = {}
+    seen_chain_receipts: set[str] = set()
+    for container in reversed(chain):
+        source_id = container["sourceReceiptId"]
+        seen_chain_receipts.add(source_id)
+        child_ids = {item["id"] for item in container["items"]}
+        if known_findings and not known_findings <= child_ids:
+            # Every non-root generation is a complete snapshot. A missing
+            # lineage would otherwise silently erase unresolved state.
+            return None
+        for item in container["items"]:
+            finding_id = item["id"]
+            first_seen = item["firstSeenReceiptId"]
+            prior_id = item.get("priorFindingId")
+            if first_seen not in seen_chain_receipts:
+                return None
+            if first_seen != source_id and finding_id not in known_findings:
+                # Merely naming an ancestor receipt is not proof that the
+                # ancestor contained this durable finding identity.
+                return None
+            if finding_id in known_findings and first_seen == source_id:
+                return None
+            if prior_id is not None:
+                owner = prior_edge_owners.get(prior_id)
+                if prior_id not in known_findings or (
+                    owner is not None and owner != finding_id
+                ):
+                    return None
+                prior_edge_owners[prior_id] = finding_id
+            known_findings.add(finding_id)
+    return tip
+
+
+def _review_receipt_history_dir(receipt_path: Path) -> Path:
+    """Return the deterministic immutable-generation home for one latest receipt."""
+    return receipt_path.parent / f"{receipt_path.name}.history"
+
+
+def _review_receipt_lock_path(receipt_path: Path) -> Path:
+    """Keep persistent kernel-lock files outside the reviewed repository."""
+    identity = str(receipt_path.resolve()).encode("utf-8")
+    return (
+        Path(tempfile.gettempdir())
+        / "flow-next"
+        / "review-receipt-locks"
+        / f"{hashlib.sha256(identity).hexdigest()}.lock"
+    )
+
+
+def _preserve_review_receipt_generation(receipt_path: Path) -> Optional[Path]:
+    """Persist the valid findings generation currently behind a latest pointer."""
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+    if not isinstance(receipt, dict) or not validate_review_receipt_findings(receipt):
+        return None
+    findings = receipt.get("findings")
+    if not isinstance(findings, dict):
+        return None
+    source_id = findings["sourceReceiptId"]
+    filename = f"{hashlib.sha256(source_id.encode('utf-8')).hexdigest()}.json"
+    history_path = _review_receipt_history_dir(receipt_path) / filename
+    if history_path.exists():
+        try:
+            existing = json.loads(history_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+            raise ReviewReceiptHistoryError(
+                f"cannot read receipt history generation: {history_path}"
+            ) from exc
+        if existing != receipt:
+            raise ReviewReceiptHistoryError(
+                f"receipt history generation conflicts: {history_path}"
+            )
+        return history_path
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(history_path, receipt)
+    return history_path
+
+
+def load_review_receipt_generations(receipt_path: Path) -> Optional[list[dict]]:
+    """Load immutable ancestors plus the latest receipt, failing closed."""
+    latest: Optional[dict]
+    try:
+        latest = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        latest = None
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+    if latest is not None and (
+        not isinstance(latest, dict)
+        or not validate_review_receipt_findings(latest)
+    ):
+        return None
+    scope = (
+        (latest.get("type"), latest.get("id"), latest.get("mode"))
+        if latest is not None
+        else None
+    )
+    receipts: list[dict] = []
+    history_dir = _review_receipt_history_dir(receipt_path)
+    if history_dir.exists():
+        try:
+            paths = sorted(history_dir.glob("*.json"))
+        except OSError:
+            return None
+        for path in paths:
+            try:
+                value = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError, TypeError, ValueError):
+                return None
+            if not isinstance(value, dict) or not validate_review_receipt_findings(value):
+                return None
+            findings = value.get("findings")
+            if not isinstance(findings, dict):
+                return None
+            expected_name = (
+                f"{hashlib.sha256(findings['sourceReceiptId'].encode('utf-8')).hexdigest()}"
+                ".json"
+            )
+            if path.name != expected_name:
+                return None
+            value_scope = (value.get("type"), value.get("id"), value.get("mode"))
+            if scope is None:
+                scope = value_scope
+            if value_scope == scope:
+                receipts.append(value)
+            elif latest is None:
+                return None
+    if latest is not None:
+        receipts.append(latest)
+    return receipts or None
+
+
+def cmd_review_findings_attach(args: argparse.Namespace) -> None:
+    """Atomically attach parsed findings and advance a direct-writer receipt."""
+    try:
+        input_path = Path(args.input)
+        receipt_path = Path(args.receipt)
+        review_path = Path(args.review_file)
+        receipt = json.loads(input_path.read_text(encoding="utf-8"))
+        review_text = review_path.read_text(encoding="utf-8")
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        error_exit(
+            f"review-findings attach input error: {exc}",
+            use_json=args.json,
+            code=2,
+        )
+    if not isinstance(receipt, dict):
+        error_exit(
+            "review-findings attach input must be a JSON object",
+            use_json=args.json,
+            code=2,
+        )
+    review_type = receipt.get("type")
+    review_id = receipt.get("id")
+    backend = receipt.get("mode")
+    if (
+        review_type not in _REVIEW_TYPE_TO_FINDINGS_KIND
+        or not isinstance(review_id, str)
+        or not review_id
+        or not isinstance(backend, str)
+        or not backend
+    ):
+        error_exit(
+            "review-findings attach requires input type/id/mode",
+            use_json=args.json,
+            code=2,
+        )
+    head_sha = _resolve_review_sha(args.head)
+    if head_sha is None:
+        error_exit(
+            f"review-findings attach cannot resolve head: {args.head}",
+            use_json=args.json,
+            code=2,
+        )
+    base_sha = _resolve_review_sha(args.base) if args.base else None
+    if args.base and base_sha is None:
+        error_exit(
+            f"review-findings attach cannot resolve base: {args.base}",
+            use_json=args.json,
+            code=2,
+        )
+    prior_path = Path(args.prior) if args.prior else receipt_path
+    recovery_arg = getattr(args, "recovery", None)
+    recovery_path = Path(recovery_arg) if recovery_arg else None
+    if recovery_path is not None and recovery_path.resolve() == receipt_path.resolve():
+        error_exit(
+            "review-findings attach recovery path must differ from receipt path",
+            use_json=args.json,
+            code=2,
+        )
+    with cross_process_lock(_review_receipt_lock_path(receipt_path)):
+        if getattr(args, "require_prior_current", False) and prior_path != receipt_path:
+            try:
+                prior_snapshot = json.loads(
+                    prior_path.read_text(encoding="utf-8")
+                )
+                current_receipt = json.loads(
+                    receipt_path.read_text(encoding="utf-8")
+                )
+            except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+                raise ReviewReceiptHistoryError(
+                    "cannot verify direct-writer prior snapshot currentness"
+                ) from exc
+            if prior_snapshot != current_receipt:
+                raise ReviewReceiptHistoryError(
+                    "direct-writer prior snapshot is no longer current"
+                )
+        findings = build_review_receipt_findings(
+            review_text,
+            review_type=review_type,
+            review_id=review_id,
+            backend=backend,
+            head_sha=head_sha,
+            base_sha=base_sha,
+            prior_receipt_path=prior_path,
+            anchor_side="head",
+        )
+        if findings is not None:
+            receipt["findings"] = findings
+        else:
+            receipt.pop("findings", None)
+        criteria = None
+        if review_type == "completion_review":
+            criteria = bind_review_criteria(parse_review_criteria(review_text))
+            if criteria is not None:
+                receipt["criteria"] = criteria
+            else:
+                receipt.pop("criteria", None)
+        if recovery_path is not None:
+            atomic_write_json(recovery_path, receipt)
+        if prior_path != receipt_path and prior_path.exists():
+            _preserve_review_receipt_generation(prior_path)
+        if receipt_path.exists():
+            _preserve_review_receipt_generation(receipt_path)
+        atomic_write_json(receipt_path, receipt)
+    result = {
+        "success": True,
+        "receipt": str(receipt_path),
+        "findings_attached": findings is not None,
+    }
+    if recovery_path is not None:
+        result["recovery"] = str(recovery_path)
+    if findings is not None:
+        result["source_receipt_id"] = findings["sourceReceiptId"]
+    if review_type == "completion_review":
+        result["criteria_attached"] = criteria is not None
+    if args.json:
+        json_output(result)
+    else:
+        print(
+            f"review findings {'attached' if findings is not None else 'unsupported'}: "
+            f"{receipt_path}"
+        )
 
 
 def _log_review_parse_path(field: str, path: str) -> None:
@@ -6524,6 +8606,13 @@ COMPLETION_REVIEW_PROMPT_TEMPLATE_REL = (
 )
 
 IMPL_REVIEW_PROMPT_FALLBACK = """<!-- placeholders: smell_baseline_block, r_id_coverage_block, confidence_rubric_block, classification_rubric_block, protected_artifacts_block, review_json_tally_block -->
+
+**You ARE the reviewer - review directly.** Do not invoke any flow-next skill,
+`flowctl <backend>` review command, or a nested agent/backend to perform this
+review: this prompt already reached you through that machinery, and nesting it
+fails inside the sandbox (app-server init) and can only self-review. Read the
+diff and the repository yourself and produce the verdict in this session.
+
 ## Context Gathering
 
 This review includes:
@@ -6592,15 +8681,16 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 {protected_artifacts_block}
 ## Output Format
 
-For each surviving `introduced` finding:
-- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
-- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
-- **Classification**: introduced
-- **File:Line**: Exact location
+For each surviving finding:
+- **Severity**: P0 / P1 / P2 / P3
+- **Confidence**: 0 / 25 / 50 / 75 / 100
+- **Classification**: introduced / pre_existing
+- **File:Line**: `path:line`, or `-` when repo-wide
+- **R-IDs**: `[R1, R2]`, or `[]` when none
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding using the compact form `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
+Put `pre_existing` findings under `## Pre-existing issues (not blocking this verdict)`; never drop them.
 
 After the findings, add (only when applicable): the `## Requirements coverage` table + `Unaddressed R-IDs:` line, and the `Suppressed findings:` / `Classification counts:` / `Protected-path filter:` tally lines named above.
 **Verdict gate:** only `introduced` findings affect the verdict. A review whose sole surviving findings are all `pre_existing` MUST ship. Any non-deferred `not-addressed` R-ID also forces NEEDS_WORK regardless of other findings.
@@ -6615,6 +8705,13 @@ Do NOT skip this tag. The automation depends on it.
 """
 
 STANDALONE_REVIEW_PROMPT_FALLBACK = """<!-- placeholders: base_branch, context_guidance, focus_section, diff_summary, smell_baseline_block, r_id_coverage_block, confidence_rubric_block, classification_rubric_block, protected_artifacts_block, review_json_tally_block -->
+
+**You ARE the reviewer - review directly.** Do not invoke any flow-next skill,
+`flowctl <backend>` review command, or a nested agent/backend to perform this
+review: this prompt already reached you through that machinery, and nesting it
+fails inside the sandbox (app-server init) and can only self-review. Read the
+diff and the repository yourself and produce the verdict in this session.
+
 # Implementation Review: Branch Changes vs {base_branch}
 
 Review all changes on the current branch compared to {base_branch}.
@@ -6667,15 +8764,16 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 {protected_artifacts_block}
 ## Output Format
 
-For each surviving `introduced` finding:
-- **Severity**: Critical / Major / Minor / Nitpick (P0 / P1 / P2 / P3 accepted)
-- **Confidence**: 0 / 25 / 50 / 75 / 100 (one of the five discrete anchors)
-- **Classification**: introduced
-- **File:Line**: Exact location
+For each surviving finding:
+- **Severity**: P0 / P1 / P2 / P3
+- **Confidence**: 0 / 25 / 50 / 75 / 100
+- **Classification**: introduced / pre_existing
+- **File:Line**: `path:line`, or `-` when repo-wide
+- **R-IDs**: `[R1, R2]`, or `[]` when none
 - **Problem**: What's wrong
 - **Suggestion**: How to fix
 
-Then, under a separate `## Pre-existing issues (not blocking this verdict)` heading, list each `pre_existing` finding as `[severity, confidence N, introduced=false] file:line — summary`. Never silently drop pre-existing findings.
+Put `pre_existing` findings under `## Pre-existing issues (not blocking this verdict)`; never drop them.
 
 After the findings list, emit:
 - The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
@@ -6758,11 +8856,14 @@ You MAY mention these as "FYI" observations without affecting the verdict.
 {plan_quality_block}{protected_artifacts_block}
 ## Output Format
 
-For each issue found:
-- **Severity**: Critical / Major / Minor / Nitpick
-- **Location**: Which task or section (e.g., "fn-1.3 Description" or "Epic Acceptance #2")
-- **Problem**: What's wrong
-- **Suggestion**: How to fix
+Severity: P0/P1/P2/P3
+Confidence: 0/25/50/75/100
+Classification: introduced/pre_existing
+File:Line: path:line / -
+R-IDs: [R1, R2] / []
+Location:
+Problem:
+Suggestion:
 
 After the issues list, emit a `Protected-path filter:` line tallying findings dropped by the protected-path filter (omit when nothing was dropped).
 
@@ -6777,7 +8878,14 @@ Be critical. Find real issues.
 Do NOT skip this tag. The automation depends on it.
 """
 
-COMPLETION_REVIEW_PROMPT_FALLBACK = """<!-- placeholders: r_id_coverage_block, confidence_rubric_block, classification_rubric_block, protected_artifacts_block, review_json_tally_block -->
+COMPLETION_REVIEW_PROMPT_FALLBACK = """<!-- placeholders: r_id_coverage_block, confidence_rubric_block, classification_rubric_block, protected_artifacts_block, global_criteria_block, review_json_tally_block -->
+
+**You ARE the reviewer - review directly.** Do not invoke any flow-next skill,
+`flowctl <backend>` review command, or a nested agent/backend to perform this
+review: this prompt already reached you through that machinery, and nesting it
+fails inside the sandbox (app-server init) and can only self-review. Read the
+diff and the repository yourself and produce the verdict in this session.
+
 ## Context Gathering
 
 This review includes:
@@ -6848,7 +8956,7 @@ Report untraced changes but do NOT auto-reject. `UNDOCUMENTED_ADDITION` is a fla
 {confidence_rubric_block}
 {classification_rubric_block}
 {protected_artifacts_block}
-## Output Format
+{global_criteria_block}## Output Format
 
 ```
 ## Requirements Extracted
@@ -6869,16 +8977,21 @@ Report untraced changes but do NOT auto-reject. `UNDOCUMENTED_ADDITION` is a fla
 
 ## Gaps Found
 
-[For each GAP, describe what's missing and suggest fix. Include `Confidence: <0|25|50|75|100>` and `Classification: introduced | pre_existing` — `pre_existing` means the gap existed before this epic's branch touched the code and is therefore not blocking.]
+[Each GAP uses these colon-delimited lines:
+Severity: P0/P1/P2/P3
+Confidence: 0/25/50/75/100
+Classification: introduced/pre_existing
+File:Line: path:line / -
+R-IDs: [R1, R2] / []
+Problem: what is wrong
+Suggestion: how to fix]
 ```
 
-Pre-existing gaps (code smells or missing features that predate this epic's branch) go under a separate `## Pre-existing issues (not blocking this verdict)` heading and do not gate the verdict.
+Put pre_existing gaps under `## Pre-existing issues`; they do not gate the verdict.
 
-After the findings list, emit:
-- The `## Requirements coverage` table and `Unaddressed R-IDs:` line (only when the spec uses R-IDs; otherwise skip).
-- A `Suppressed findings:` line tallying anchors dropped by the gate (omit when nothing was suppressed).
-- A `Classification counts:` line tallying `introduced` vs `pre_existing` gaps, e.g. `Classification counts: 1 introduced, 0 pre_existing.`.
-- A `Protected-path filter:` line tallying gaps dropped by the protected-path filter (omit when nothing was dropped).
+When applicable, add the Requirements coverage / Unaddressed R-IDs,
+Suppressed findings, Classification counts, and Protected-path filter outputs
+defined above.
 
 ## Verdict
 
@@ -7133,6 +9246,28 @@ def _review_attempt_summary(
     }
 
 
+def _review_head_sha() -> Optional[str]:
+    """Best-effort HEAD sha for review-attempt provenance (issue #279).
+
+    Never raises: detached HEAD still resolves; a broken/absent git, an
+    unborn branch, or a timeout returns None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True, encoding="utf-8",
+            cwd=str(get_repo_root()),
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        sha = (result.stdout or "").strip()
+        return sha or None
+    except Exception:
+        return None
+
+
 def record_review_attempt(
     spec_id: str,
     review_kind: str,
@@ -7144,6 +9279,9 @@ def record_review_attempt(
     task_id: Optional[str] = None,
     review_type: Optional[str] = None,
     use_json: bool = False,
+    finalize_status_kind: Optional[str] = None,
+    reset_rounds_on_ship: bool = False,
+    reviewed_head_sha: Optional[str] = None,
 ) -> dict:
     """Finalize one pre-dispatch reservation and persist its outcome.
 
@@ -7151,14 +9289,21 @@ def record_review_attempt(
     transport-failure count. A no-verdict attempt refunds exactly one reserved
     round, increments the separate transport-failure count, and remains
     auditable in ``review_attempts`` on the spec sidecar.
+    When ``finalize_status_kind`` is set, the denormalized
+    ``<kind>_review_status`` / ``<kind>_reviewed_at`` fields (and, with
+    ``reset_rounds_on_ship``, the SHIP round-counter reset) are folded into
+    the same single atomic sidecar write (issue #279).
     """
     flow_dir = get_flow_dir()
     spec_json_path = find_spec_json_path(flow_dir, spec_id)
     if not spec_json_path.exists():
-        return {
+        result = {
             "recorded": False,
             "outcome": "verdict" if verdict else "transport_failure",
         }
+        if finalize_status_kind is not None:
+            result["status_written"] = None
+        return result
 
     spec_data = normalize_epic(
         load_json_or_exit(spec_json_path, f"Spec {spec_id}", use_json=use_json)
@@ -7214,12 +9359,34 @@ def record_review_attempt(
             (output or "").encode("utf-8", errors="replace")
         ).hexdigest(),
         "round_consumed": not refunded,
+        # The sha the review OBSERVED (pre-dispatch snapshot) when the caller
+        # has it; finalize-time HEAD is only the fallback (rp/refund paths).
+        "head_sha": reviewed_head_sha or _review_head_sha(),
     }
     attempts = spec_data.get("review_attempts")
     if not isinstance(attempts, list):
         attempts = []
         spec_data["review_attempts"] = attempts
     attempts.append(row)
+    # issue #279: fold the denormalized status write and the SHIP cap reset
+    # into THIS sidecar mutation so the attempt ledger, <kind>_review_status,
+    # and the round counter land in ONE atomic_write_json - no interrupt
+    # window where the ledger and the read model diverge.
+    status_written: Optional[str] = None
+    if finalize_status_kind in ("plan", "completion"):
+        status = {
+            "SHIP": "ship",
+            "NEEDS_WORK": "needs_work",
+            "MAJOR_RETHINK": "needs_work",
+        }.get(verdict or "")
+        if status:
+            spec_data[f"{finalize_status_kind}_review_status"] = status
+            spec_data[f"{finalize_status_kind}_reviewed_at"] = now_iso()
+            status_written = status
+    if reset_rounds_on_ship and verdict == "SHIP":
+        # Same counter mutation reset_review_cap performs; pending is
+        # deliberately left alone (fn-134.7 / R22).
+        _write_review_rounds(spec_data, review_kind, task_id, 0)
     spec_data["updated_at"] = now_iso()
     atomic_write_json(spec_json_path, spec_data)
 
@@ -7243,6 +9410,8 @@ def record_review_attempt(
             ),
         }
     )
+    if finalize_status_kind is not None:
+        summary["status_written"] = status_written
     return summary
 
 
@@ -7676,9 +9845,14 @@ def _scan_max_fn_names_in_dir(directory: Path) -> int:
 
 
 def _scan_max_fn_in_flow_dir(flow_dir: Path) -> int:
-    """In-process max native fn-N across epics/ + specs/ of one .flow/ tree."""
+    """In-process max native fn-N across epics/ + specs/ + charts/ of one .flow/.
+
+    One cross-kind allocation domain (fn-135): charts and specs share the
+    monotonic native counter. Decision records under charts/<id>/<n>.* are
+    not scanned (names do not match the native fn-N filename pattern).
+    """
     max_n = 0
-    for sub in (EPICS_DIR, SPECS_DIR):
+    for sub in (EPICS_DIR, SPECS_DIR, CHARTS_DIR):
         n = _scan_max_fn_names_in_dir(flow_dir / sub)
         if n > max_n:
             max_n = n
@@ -7774,7 +9948,11 @@ def _scan_max_fn_from_refs(repo_root: Path) -> int:
     exists to provide. It costs nothing measurable (both forms run well inside
     the R3 budget).
     """
-    pathspecs = [f"{FLOW_DIR}/{SPECS_DIR}", f"{FLOW_DIR}/{EPICS_DIR}"]
+    pathspecs = [
+        f"{FLOW_DIR}/{SPECS_DIR}",
+        f"{FLOW_DIR}/{EPICS_DIR}",
+        f"{FLOW_DIR}/{CHARTS_DIR}",
+    ]
     rc, out, _err = _spec_alloc_git(
         repo_root,
         [
@@ -7808,23 +9986,30 @@ def scan_max_native_fn_spec_id(flow_dir: Path) -> int:
     """Union max of native `fn-N` across working tree, worktrees, and refs.
 
     NATIVE-`fn`-ONLY (fn-52.10): this feeds `fn-N` allocation in
-    `cmd_spec_create`, so tracker-key specs (`wor-9999-foo`) must NOT count —
-    else a high tracker number would push the next flow-first spec to a far
-    higher `fn-N`. Tracker-key specs are still visible to enumeration
-    (`iter_spec_json_files`); they just don't drive the native allocator.
+    `cmd_spec_create` and `cmd_chart_create`, so tracker-key specs
+    (`wor-9999-foo`) must NOT count - else a high tracker number would push
+    the next flow-first id to a far higher `fn-N`. Tracker-key specs are
+    still visible to enumeration (`iter_spec_json_files`); they just don't
+    drive the native allocator.
 
-    Three sources, take the maximum (fn-134):
-      1. Current working tree `.flow/epics/` + `.flow/specs/` (always).
+    Cross-kind domain (fn-135): specs and charts share one counter. A chart
+    at `.flow/charts/fn-N` and a spec at `.flow/specs/fn-N-slug` both reserve
+    number N under the same allocation lock.
+
+    Three sources, take the maximum (fn-134 + fn-135):
+      1. Current working tree `.flow/epics/` + `.flow/specs/` + `.flow/charts/`
+         (always).
       2. Every registered git worktree's `.flow/` (in-process scandir).
       3. Every ref via one `git log --all --full-history --diff-filter=A` over
-         the specs dirs (`--full-history` keeps pruned side branches visible).
+         the specs/epics/charts dirs (`--full-history` keeps pruned side
+         branches visible).
 
     Handles legacy (fn-N.json), short suffix (fn-N-xxx.json), and slug
     (fn-N-slug.json) formats. Returns 0 if none exist.
 
     Fail-open on every git problem (absent git, not a repo, stale worktree
     path, missing/unreadable `.flow/`, non-zero git exit): degrade to whatever
-    sources worked, worst case source 1 alone. Never blocks spec creation.
+    sources worked, worst case source 1 alone. Never blocks allocation.
     Monotonic: a number that was allocated and later deleted is never reused
     because source 3 still sees the historical add.
     """
@@ -7861,6 +10046,5514 @@ def scan_max_native_fn_spec_id(flow_dir: Path) -> int:
 # prefer the explicit name). Backward-compat `scan_max_epic_id` preserved too.
 scan_max_spec_id = scan_max_native_fn_spec_id
 scan_max_epic_id = scan_max_native_fn_spec_id
+
+
+def native_fn_alloc_lock_path(flow_dir: Path) -> Path:
+    """Shared lock path for the cross-kind native fn-N allocator (specs+charts)."""
+    return flow_dir / "locks" / NATIVE_FN_ALLOC_LOCK_NAME
+
+
+def charts_resource_lock_path(flow_dir: Path) -> Path:
+    """Lock path coordinating chart recovery and multi-file mutations."""
+    return flow_dir / "locks" / CHARTS_RESOURCE_LOCK_NAME
+
+
+def charts_dir(flow_dir: Path) -> Path:
+    return flow_dir / CHARTS_DIR
+
+
+def chart_transactions_dir(flow_dir: Path) -> Path:
+    return charts_dir(flow_dir) / CHART_TRANSACTIONS_DIR
+
+
+# Chart id is plain native `fn-N` (no slug). Specs keep `fn-N-slug`; the shared
+# allocator only cares about the numeric component.
+_CHART_ID_RE = re.compile(r"^fn-([1-9][0-9]*)$")
+# Full external D-ID: <chart-id>.D<n>
+_CHART_DID_FULL_RE = re.compile(r"^(fn-[1-9][0-9]*)\.D([1-9][0-9]*)$", re.IGNORECASE)
+# Bare decision forms accepted only when a chart context is supplied.
+_CHART_DID_BARE_RE = re.compile(r"^(?:D)?([1-9][0-9]*)$", re.IGNORECASE)
+# Ambiguous bare-or-local forms that look like another chart: fn-X.DY or fn-X.Y
+_CHART_DID_CROSS_RE = re.compile(
+    r"^(fn-[1-9][0-9]*)\.(?:D)?([1-9][0-9]*)$", re.IGNORECASE
+)
+
+
+class ChartError(Exception):
+    """Structured chart command failure (maps to v1 error envelope)."""
+
+    def __init__(
+        self,
+        error_class: str,
+        code: str,
+        message: str,
+        details: Optional[dict] = None,
+        exit_code: int = 1,
+    ) -> None:
+        if error_class not in CHART_ERROR_CLASSES:
+            raise ValueError(f"unknown chart error class: {error_class}")
+        super().__init__(message)
+        self.error_class = error_class
+        self.code = code
+        self.message = message
+        self.details = details if details is not None else {}
+        self.exit_code = exit_code
+
+
+def chart_json_success(command: str, result: dict) -> None:
+    """Emit exact v1 success envelope for chart commands."""
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "schema_version": CHART_JSON_SCHEMA_VERSION,
+                "command": command,
+                "result": result,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+
+def chart_json_error(
+    command: str,
+    error_class: str,
+    code: str,
+    message: str,
+    details: Optional[dict] = None,
+    exit_code: int = 1,
+) -> None:
+    """Emit exact v1 failure envelope and exit."""
+    if error_class not in CHART_ERROR_CLASSES:
+        error_class = "io"
+        code = "internal_error_class"
+    print(
+        json.dumps(
+            {
+                "success": False,
+                "schema_version": CHART_JSON_SCHEMA_VERSION,
+                "command": command,
+                "error": {
+                    "class": error_class,
+                    "code": code,
+                    "message": message,
+                    "details": details if details is not None else {},
+                },
+            },
+            indent=2,
+            default=str,
+        )
+    )
+    sys.exit(exit_code)
+
+
+def chart_fail(
+    command: str,
+    use_json: bool,
+    error_class: str,
+    code: str,
+    message: str,
+    details: Optional[dict] = None,
+    exit_code: int = 1,
+) -> None:
+    """Surface a chart failure (JSON envelope or stderr). Never returns."""
+    if use_json:
+        chart_json_error(
+            command, error_class, code, message, details=details, exit_code=exit_code
+        )
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def _maybe_project_chart(
+    flow_dir: Path,
+    chart_id: str,
+    *,
+    event: str,
+    revision: Optional[str] = None,
+) -> dict:
+    """Best-effort post-commit chart tracker projection (fn-135.5).
+
+    Local chart mutation has already committed. Projection failures never
+    roll back local state; the result describes skip/degradation/partial.
+    """
+    try:
+        from flowctl_tracker.facade.chart_projection import (  # noqa: PLC0415
+            project_chart,
+        )
+        from flowctl_tracker.types import TrackerError  # noqa: PLC0415
+    except ImportError:
+        return {
+            "projected": False,
+            "skipped": "facade_unavailable",
+            "reason": "flowctl_tracker package not available",
+        }
+    out = project_chart(
+        flow_dir, chart_id, event=event, revision=revision,
+    )
+    if isinstance(out, TrackerError):
+        return {
+            "projected": False,
+            "error": {
+                "class": out.cls.value if hasattr(out.cls, "value") else str(out.cls),
+                "code": out.subtype or (
+                    out.cls.value if hasattr(out.cls, "value") else "error"
+                ),
+                "message": out.message,
+                "details": out.details,
+            },
+            "completed_steps": list((out.details or {}).get("completed_steps") or []),
+        }
+    if isinstance(out, dict):
+        return out
+    return {"projected": False, "skipped": "unknown_result"}
+
+
+def _attach_tracker_projection(
+    result: dict,
+    flow_dir: Path,
+    chart_id: Optional[str],
+    event: str,
+) -> dict:
+    """Merge tracker_projection into a chart command result dict."""
+    if not chart_id:
+        result = dict(result)
+        result["tracker_projection"] = {
+            "projected": False,
+            "skipped": "no_chart_id",
+        }
+        return result
+    try:
+        chart = load_chart_sidecar(flow_dir, chart_id)
+        revision = chart_decision_revision(chart)
+    except Exception:  # noqa: BLE001 - projection is best-effort
+        revision = None
+    proj = _maybe_project_chart(
+        flow_dir, chart_id, event=event, revision=revision,
+    )
+    result = dict(result)
+    result["tracker_projection"] = proj
+    return result
+
+
+def _chart_id_from_decision_result(out: dict) -> Optional[str]:
+    cid = out.get("chart") or out.get("chart_id")
+    if cid:
+        return str(cid)
+    did = out.get("id") or out.get("decision_id")
+    if isinstance(did, str) and ".D" in did:
+        return did.split(".D", 1)[0]
+    return None
+
+
+def canonicalize_chart_id(raw: str) -> str:
+    """Return canonical chart id `fn-N` or raise ChartError(validation).
+
+    Rejects empty, slug-bearing, tracker-key, and ambiguous forms before I/O.
+    """
+    if raw is None or not isinstance(raw, str):
+        raise ChartError(
+            "validation",
+            "invalid_chart_id",
+            "Chart id is required (expected fn-N)",
+            details={"raw": raw},
+        )
+    text = raw.strip().lower()
+    if not text:
+        raise ChartError(
+            "validation",
+            "invalid_chart_id",
+            "Chart id is required (expected fn-N)",
+            details={"raw": raw},
+        )
+    match = _CHART_ID_RE.fullmatch(text)
+    if not match:
+        raise ChartError(
+            "validation",
+            "invalid_chart_id",
+            f"Invalid chart id '{raw.strip()}' (expected fn-N with no slug)",
+            details={"raw": raw.strip()},
+        )
+    return f"fn-{int(match.group(1))}"
+
+
+def canonicalize_decision_id(
+    raw: str, chart_id: Optional[str] = None
+) -> str:
+    """Return canonical external D-ID `<chart-id>.D<n>` or raise ChartError.
+
+    Accepts `fn-N.DM`, `fn-N.M`, `DM`, or `M` when chart_id is provided.
+    Rejects cross-chart identifiers and ambiguous forms before I/O.
+    """
+    if raw is None or not isinstance(raw, str) or not raw.strip():
+        raise ChartError(
+            "validation",
+            "invalid_decision_id",
+            "Decision id is required (expected <chart-id>.D<n> or D<n>)",
+            details={"raw": raw},
+        )
+    text = raw.strip()
+    # Normalize only the chart/D markers for matching; preserve digits.
+    text_norm = text.lower()
+    full = _CHART_DID_FULL_RE.fullmatch(text_norm)
+    if full:
+        chart_part = canonicalize_chart_id(full.group(1))
+        d_num = int(full.group(2))
+        if chart_id is not None:
+            expected = canonicalize_chart_id(chart_id)
+            if chart_part != expected:
+                raise ChartError(
+                    "validation",
+                    "cross_chart_decision_id",
+                    f"Decision id '{text}' belongs to {chart_part}, not {expected}",
+                    details={"raw": text, "chart_id": expected, "other_chart": chart_part},
+                )
+        return f"{chart_part}.D{d_num}"
+
+    cross = _CHART_DID_CROSS_RE.fullmatch(text_norm)
+    if cross:
+        # Form fn-N.M without the D prefix - still chart-qualified.
+        chart_part = canonicalize_chart_id(cross.group(1))
+        d_num = int(cross.group(2))
+        if chart_id is not None:
+            expected = canonicalize_chart_id(chart_id)
+            if chart_part != expected:
+                raise ChartError(
+                    "validation",
+                    "cross_chart_decision_id",
+                    f"Decision id '{text}' belongs to {chart_part}, not {expected}",
+                    details={"raw": text, "chart_id": expected, "other_chart": chart_part},
+                )
+        return f"{chart_part}.D{d_num}"
+
+    bare = _CHART_DID_BARE_RE.fullmatch(text_norm)
+    if bare:
+        if chart_id is None:
+            raise ChartError(
+                "validation",
+                "ambiguous_decision_id",
+                f"Bare decision id '{text}' requires a chart context",
+                details={"raw": text},
+            )
+        chart_part = canonicalize_chart_id(chart_id)
+        return f"{chart_part}.D{int(bare.group(1))}"
+
+    raise ChartError(
+        "validation",
+        "invalid_decision_id",
+        f"Invalid decision id '{text}' (expected <chart-id>.D<n> or D<n>)",
+        details={"raw": text},
+    )
+
+
+def decision_local_number(canonical_did: str) -> int:
+    """Extract the chart-local decision number from a canonical `<chart>.D<n>`."""
+    full = _CHART_DID_FULL_RE.fullmatch(canonical_did)
+    if not full:
+        raise ChartError(
+            "validation",
+            "invalid_decision_id",
+            f"Not a canonical decision id: {canonical_did}",
+            details={"raw": canonical_did},
+        )
+    return int(full.group(2))
+
+
+def decision_record_paths(flow_dir: Path, chart_id: str, d_num: int) -> tuple[Path, Path]:
+    """Return (md_path, json_path) for decision local number under the chart."""
+    chart_id = canonicalize_chart_id(chart_id)
+    base = charts_dir(flow_dir) / chart_id / str(d_num)
+    return (base.with_suffix(".md"), base.with_suffix(".json"))
+
+
+def chart_pair_paths(flow_dir: Path, chart_id: str) -> tuple[Path, Path]:
+    """Return (md_path, json_path) for a chart root pair."""
+    chart_id = canonicalize_chart_id(chart_id)
+    base = charts_dir(flow_dir) / chart_id
+    return (base.with_suffix(".md"), base.with_suffix(".json"))
+
+
+def _file_sha256(path: Path) -> Optional[str]:
+    """Content fingerprint for journal pre-state; None if missing."""
+    try:
+        if not path.is_file():
+            return None
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _fsync_path(path: Path) -> None:
+    """Best-effort fsync of a file."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(path: Path) -> None:
+    """Best-effort directory fsync (metadata flush before rename)."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _chart_failpoint(name: str) -> None:
+    """Test injection: FLOWCTL_CHART_FAILPOINT=exit:NAME or raise:NAME."""
+    raw = os.environ.get("FLOWCTL_CHART_FAILPOINT") or ""
+    if not raw:
+        return
+    if raw == f"exit:{name}":
+        # Hard process death without cleanup (simulates kill -9 at a failpoint).
+        os._exit(99)
+    if raw == f"raise:{name}":
+        raise RuntimeError(f"injected chart failpoint: {name}")
+
+
+def _write_bytes_fsync(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+        _fsync_path(path)
+        _fsync_dir(path.parent)
+    except Exception:
+        try:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _write_text_fsync(path: Path, content: str) -> None:
+    _write_bytes_fsync(path, content.encode("utf-8"))
+
+
+def _write_json_fsync(path: Path, data: dict) -> None:
+    content = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    _write_text_fsync(path, content)
+
+
+def _chart_relpath(flow_dir: Path, path: Path) -> str:
+    """Path relative to charts/ for journal entries."""
+    charts = charts_dir(flow_dir)
+    try:
+        return path.resolve().relative_to(charts.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def chart_body_text(
+    chart_id: str, title: str, outcome: str, notes: str = ""
+) -> str:
+    """Canonical empty-ledger chart map body.
+
+    `notes` seeds `## Notes` with grounding facts and their citations (R52);
+    it is never a resolved ledger line.
+    """
+    notes_block = f"{notes.strip()}\n" if notes and notes.strip() else ""
+    return (
+        f"# {chart_id} {title}\n"
+        f"\n"
+        f"## Outcome\n"
+        f"{outcome}\n"
+        f"\n"
+        f"## Notes\n"
+        f"{notes_block}"
+        f"\n"
+        f"## Decisions\n"
+        f"<!-- the ledger: one line per resolved decision, append-only, "
+        f"D-IDs never reused -->\n"
+        f"\n"
+        f"## Open Questions\n"
+        f"\n"
+        f"## Boundaries\n"
+        f"\n"
+    )
+
+
+def chart_sidecar_data(
+    chart_id: str,
+    title: str,
+    outcome: str,
+    *,
+    created: Optional[str] = None,
+) -> dict:
+    """v1 chart JSON sidecar with empty ledger."""
+    ts = created or now_iso()
+    return {
+        "id": chart_id,
+        "title": title,
+        "outcome": outcome,
+        "status": "open",
+        "created": ts,
+        "decisions": [],
+        "parked_questions": [],
+        "briefings": [],
+        "tracker": {
+            "id": None,
+            "identifier": None,
+            "url": None,
+            "linkState": "unlinked",
+            "depRelations": [],
+            "projection": {
+                "revision": None,
+                "event_markers": [],
+                "completed_steps": [],
+            },
+        },
+        "produced_specs": [],
+        "claim_events": [],
+    }
+
+
+def compact_decision_entry(decision: dict) -> dict:
+    """Compact decision metadata for chart sidecars and navigation (no answer/assets)."""
+    return {
+        "id": decision.get("id"),
+        "title": decision.get("title"),
+        "type": decision.get("type"),
+        "attendance": decision.get("attendance"),
+        "status": decision.get("status"),
+        "blocked_by": list(decision.get("blocked_by") or []),
+        "depends_on": list(decision.get("depends_on") or []),
+        "claimed_by": decision.get("claimed_by"),
+        "claimed_at": decision.get("claimed_at"),
+        "record_path": decision.get("record_path"),
+    }
+
+
+def compact_chart_metadata(data: dict) -> dict:
+    """Compact show/list metadata from the chart sidecar only (no decision bodies)."""
+    decisions = data.get("decisions") or []
+    if not isinstance(decisions, list):
+        decisions = []
+    parked = data.get("parked_questions") or []
+    if not isinstance(parked, list):
+        parked = []
+    open_decs = [
+        d
+        for d in decisions
+        if isinstance(d, dict) and d.get("status") == "open"
+    ]
+    closed = [
+        d
+        for d in decisions
+        if isinstance(d, dict) and d.get("status") in CHART_CLOSED_STATUSES
+    ]
+    status_index = {
+        d["id"]: d.get("status")
+        for d in decisions
+        if isinstance(d, dict) and d.get("id")
+    }
+    blocked_open = [
+        d
+        for d in open_decs
+        if _decision_is_blocked(d, status_index)
+    ]
+    claimed_open = [d for d in open_decs if d.get("claimed_by")]
+    remaining = [
+        d for d in open_decs if isinstance(d.get("attendance"), str)
+    ]
+    cost = chart_cost_estimate(remaining)
+    completion = chart_completion_predicate(data)
+    return {
+        "id": data.get("id"),
+        "title": data.get("title"),
+        "outcome": data.get("outcome"),
+        "status": data.get("status"),
+        "created": data.get("created"),
+        "decision_count": len(decisions),
+        "open_count": len(open_decs),
+        "resolved_count": sum(
+            1 for d in closed if d.get("status") == "resolved"
+        ),
+        "blocked_count": len(blocked_open),
+        "claimed_count": len(claimed_open),
+        "parked_count": len(parked),
+        "briefable": completion["briefable"],
+        "stuck_reasons": completion["stuck_reasons"],
+        "unattended_count": cost["unattended_count"],
+        "attended_count": cost["attended_count"],
+        "estimated_sessions": cost["estimated_sessions"],
+        "cost_line": cost["cost_line"],
+        "briefing_count": len(data.get("briefings") or [])
+        if isinstance(data.get("briefings"), list)
+        else 0,
+        "produced_spec_count": len(data.get("produced_specs") or [])
+        if isinstance(data.get("produced_specs"), list)
+        else 0,
+    }
+
+
+def _journal_path(txn_dir: Path) -> Path:
+    return txn_dir / "journal.json"
+
+
+def _list_incomplete_chart_txns(flow_dir: Path) -> list[Path]:
+    tx_root = chart_transactions_dir(flow_dir)
+    if not tx_root.is_dir():
+        return []
+    found: list[Path] = []
+    try:
+        with os.scandir(tx_root) as it:
+            for entry in it:
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+                if entry.name.startswith("."):
+                    continue
+                jpath = Path(entry.path) / "journal.json"
+                if jpath.is_file():
+                    found.append(Path(entry.path))
+    except OSError:
+        return found
+    return sorted(found, key=lambda p: p.name)
+
+
+def _load_journal(txn_dir: Path) -> Optional[dict]:
+    jpath = _journal_path(txn_dir)
+    try:
+        with open(jpath, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return None
+
+
+def _rm_tree(path: Path) -> None:
+    if not path.exists():
+        return
+    try:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    except OSError:
+        pass
+
+
+def _restore_pre_state(flow_dir: Path, journal: dict, txn_dir: Path) -> None:
+    """Restore recorded pre-state for every mutation target."""
+    charts = charts_dir(flow_dir)
+    pre_state = journal.get("pre_state") or {}
+    mutations = journal.get("mutations") or []
+    for mut in mutations:
+        if not isinstance(mut, dict):
+            continue
+        rel = mut.get("relpath")
+        if not isinstance(rel, str) or not rel or ".." in rel.split("/"):
+            continue
+        target = charts / rel
+        info = pre_state.get(rel) if isinstance(pre_state, dict) else None
+        if not info or not info.get("exists"):
+            # Pre-state absent: remove any partial publication.
+            try:
+                if target.is_file() or target.is_symlink():
+                    target.unlink()
+            except OSError:
+                pass
+            continue
+        backup_rel = info.get("backup")
+        if isinstance(backup_rel, str) and backup_rel:
+            backup = txn_dir / backup_rel
+            if backup.is_file():
+                try:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(backup, target)
+                    _fsync_path(target)
+                except OSError:
+                    pass
+                continue
+        # Exists-in-pre but no backup: leave target alone if fingerprint matches;
+        # otherwise delete (safer than inventing content).
+        expected = info.get("sha256")
+        current = _file_sha256(target)
+        if expected and current and expected == current:
+            continue
+        try:
+            if target.is_file() or target.is_symlink():
+                target.unlink()
+        except OSError:
+            pass
+
+
+def _publish_staged_mutation(
+    flow_dir: Path, txn_dir: Path, mut: dict
+) -> None:
+    """Publish one staged mutation (create = no-clobber link, update = replace)."""
+    charts = charts_dir(flow_dir)
+    rel = mut["relpath"]
+    op = mut.get("op") or "create"
+    staged = txn_dir / "staged" / rel
+    target = charts / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not staged.is_file():
+        raise ChartError(
+            "io",
+            "missing_staged_file",
+            f"Staged file missing for {rel}",
+            details={"relpath": rel},
+        )
+    content = staged.read_text(encoding="utf-8")
+    if op == "create":
+        if target.exists():
+            # Idempotent roll-forward: already published with matching content.
+            try:
+                if target.read_text(encoding="utf-8") == content:
+                    return
+            except OSError:
+                pass
+            raise ChartError(
+                "conflict",
+                "chart_path_exists",
+                f"Refusing to overwrite existing chart path {rel}",
+                details={"relpath": rel},
+            )
+        atomic_create(target, content)
+    else:
+        atomic_write(target, content)
+    _fsync_path(target)
+    _fsync_dir(target.parent)
+
+
+def _roll_forward_journal(flow_dir: Path, txn_dir: Path, journal: dict) -> None:
+    """Publish all staged mutations then drop the transaction."""
+    mutations = journal.get("mutations") or []
+    for mut in mutations:
+        if isinstance(mut, dict) and mut.get("relpath"):
+            _publish_staged_mutation(flow_dir, txn_dir, mut)
+    _chart_failpoint("after_publish_before_commit")
+    # Mark committed then remove txn dir.
+    journal = dict(journal)
+    journal["phase"] = "committed"
+    try:
+        _write_json_fsync(_journal_path(txn_dir), journal)
+    except OSError:
+        pass
+    _rm_tree(txn_dir)
+
+
+def recover_chart_transactions(flow_dir: Path) -> list[str]:
+    """Recover incomplete chart journals under the charts resource lock.
+
+    Deterministic policy:
+      - phase staging / unknown / corrupt: restore pre-state, drop txn
+      - phase ready or publishing with complete staged set: roll forward
+      - phase committed: drop txn
+    Returns list of recovered txn ids (for diagnostics/tests).
+    """
+    recovered: list[str] = []
+    for txn_dir in _list_incomplete_chart_txns(flow_dir):
+        journal = _load_journal(txn_dir)
+        txn_id = txn_dir.name
+        if journal is None:
+            # Corrupt journal: best-effort cleanup of any staged-only debris
+            # without touching live chart files (pre-state unknown).
+            _rm_tree(txn_dir)
+            recovered.append(txn_id)
+            continue
+        phase = journal.get("phase")
+        mutations = journal.get("mutations") or []
+        staged_complete = True
+        for mut in mutations:
+            if not isinstance(mut, dict):
+                staged_complete = False
+                break
+            rel = mut.get("relpath")
+            if not isinstance(rel, str):
+                staged_complete = False
+                break
+            if not (txn_dir / "staged" / rel).is_file():
+                staged_complete = False
+                break
+
+        if phase == "committed":
+            _rm_tree(txn_dir)
+            recovered.append(txn_id)
+            continue
+
+        if phase in ("ready", "publishing") and staged_complete:
+            try:
+                _roll_forward_journal(flow_dir, txn_dir, journal)
+            except ChartError:
+                # Roll-forward conflict: fall back to pre-state restore.
+                _restore_pre_state(flow_dir, journal, txn_dir)
+                _rm_tree(txn_dir)
+            recovered.append(txn_id)
+            continue
+
+        # Incomplete staging or unknown phase: restore pre-state.
+        _restore_pre_state(flow_dir, journal, txn_dir)
+        _rm_tree(txn_dir)
+        recovered.append(txn_id)
+    return recovered
+
+
+def _validate_chart_mutation_relpath(charts: Path, relpath: str) -> None:
+    """Reject traversal and absolute mutation paths with platform semantics.
+
+    Components are validated across BOTH separators (Windows resolves
+    backslashes as path separators, so a '/'-only split misses a
+    backslash-written dot-dot traversal), and the resolved target must stay
+    under the charts directory.
+    """
+    def _reject() -> None:
+        raise ChartError(
+            "validation",
+            "invalid_mutation_path",
+            f"Invalid mutation path: {relpath}",
+            details={"relpath": relpath},
+        )
+
+    if not relpath or relpath.startswith(("/", "\\")):
+        _reject()
+    for comp in re.split(r"[/\\]", relpath):
+        # Empty components, '.'/'..', and drive-letter colons are all
+        # rejected regardless of host platform.
+        if comp in ("", ".", "..") or ":" in comp:
+            _reject()
+    charts_res = charts.resolve()
+    target = (charts_res / relpath).resolve()
+    if target == charts_res or not target.is_relative_to(charts_res):
+        _reject()
+
+
+def _begin_chart_transaction(
+    flow_dir: Path,
+    command: str,
+    mutations: list[tuple[str, str, str]],
+) -> Path:
+    """Create a write-ahead journal with pre-state fingerprints.
+
+    mutations: list of (relpath, op, content) where op is create|update.
+    Returns the txn directory path. Caller stages contents then publishes.
+    """
+    charts = charts_dir(flow_dir)
+    charts.mkdir(parents=True, exist_ok=True)
+    # Validate every relpath before any journal/staging work so a refused
+    # mutation set leaves no transaction residue behind.
+    for relpath, _op, _content in mutations:
+        _validate_chart_mutation_relpath(charts, relpath)
+    tx_root = chart_transactions_dir(flow_dir)
+    tx_root.mkdir(parents=True, exist_ok=True)
+    txn_id = f"{int(datetime.now(timezone.utc).timestamp() * 1000):x}-{uuid.uuid4().hex[:12]}"
+    txn_dir = tx_root / txn_id
+    txn_dir.mkdir(parents=True, exist_ok=False)
+    (txn_dir / "staged").mkdir()
+    (txn_dir / "pre").mkdir()
+
+    pre_state: dict[str, dict] = {}
+    mut_records: list[dict] = []
+    for relpath, op, _content in mutations:
+        target = charts / relpath
+        exists = target.is_file()
+        entry: dict[str, Any] = {"exists": exists}
+        if exists:
+            sha = _file_sha256(target)
+            entry["sha256"] = sha
+            backup_rel = f"pre/{relpath.replace('/', '__')}"
+            backup_path = txn_dir / backup_rel
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(target, backup_path)
+            _fsync_path(backup_path)
+            entry["backup"] = backup_rel
+        pre_state[relpath] = entry
+        mut_records.append({"relpath": relpath, "op": op})
+
+    journal = {
+        "schema_version": 1,
+        "txn_id": txn_id,
+        "command": command,
+        "phase": "staging",
+        "created_at": now_iso(),
+        "pre_state": pre_state,
+        "mutations": mut_records,
+    }
+    _write_json_fsync(_journal_path(txn_dir), journal)
+    _fsync_dir(txn_dir)
+    _fsync_dir(tx_root)
+    _chart_failpoint("after_journal")
+    return txn_dir
+
+
+def _stage_chart_mutation(txn_dir: Path, relpath: str, content: str) -> None:
+    staged = txn_dir / "staged" / relpath
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    _write_text_fsync(staged, content)
+
+
+def _finalize_chart_transaction(flow_dir: Path, txn_dir: Path) -> None:
+    """Mark staged set ready, then roll forward to publication."""
+    journal = _load_journal(txn_dir)
+    if journal is None:
+        raise ChartError(
+            "io",
+            "journal_missing",
+            "Chart transaction journal missing after staging",
+            details={"txn": txn_dir.name},
+        )
+    # Verify every mutation is staged before leaving staging phase.
+    for mut in journal.get("mutations") or []:
+        rel = mut.get("relpath") if isinstance(mut, dict) else None
+        if not isinstance(rel, str) or not (txn_dir / "staged" / rel).is_file():
+            raise ChartError(
+                "io",
+                "incomplete_staging",
+                f"Staged content missing for {rel}",
+                details={"txn": txn_dir.name, "relpath": rel},
+            )
+    _chart_failpoint("after_stage")
+    journal["phase"] = "ready"
+    _write_json_fsync(_journal_path(txn_dir), journal)
+    _fsync_dir(txn_dir)
+    _chart_failpoint("before_publish")
+    journal["phase"] = "publishing"
+    _write_json_fsync(_journal_path(txn_dir), journal)
+    # Publish first mutation with a mid-publish failpoint for kill tests.
+    mutations = [m for m in (journal.get("mutations") or []) if isinstance(m, dict)]
+    if mutations:
+        _publish_staged_mutation(flow_dir, txn_dir, mutations[0])
+        _chart_failpoint("after_first_publish")
+        for mut in mutations[1:]:
+            _publish_staged_mutation(flow_dir, txn_dir, mut)
+    _chart_failpoint("after_publish_before_commit")
+    journal["phase"] = "committed"
+    _write_json_fsync(_journal_path(txn_dir), journal)
+    _rm_tree(txn_dir)
+
+
+def run_chart_transaction(
+    flow_dir: Path,
+    command: str,
+    mutations: list[tuple[str, str, str]],
+) -> None:
+    """Journal + stage + publish a multi-file chart mutation set.
+
+    On handled failure, restore pre-state and remove the txn. Crash recovery
+    is performed by recover_chart_transactions on the next chart command.
+    """
+    txn_dir: Optional[Path] = None
+    try:
+        txn_dir = _begin_chart_transaction(flow_dir, command, mutations)
+        for relpath, _op, content in mutations:
+            _stage_chart_mutation(txn_dir, relpath, content)
+        _finalize_chart_transaction(flow_dir, txn_dir)
+    except ChartError:
+        if txn_dir is not None and txn_dir.exists():
+            journal = _load_journal(txn_dir) or {
+                "pre_state": {},
+                "mutations": [{"relpath": r} for r, _o, _c in mutations],
+            }
+            _restore_pre_state(flow_dir, journal, txn_dir)
+            _rm_tree(txn_dir)
+        raise
+    except Exception as e:
+        if txn_dir is not None and txn_dir.exists():
+            journal = _load_journal(txn_dir) or {
+                "pre_state": {},
+                "mutations": [{"relpath": r} for r, _o, _c in mutations],
+            }
+            _restore_pre_state(flow_dir, journal, txn_dir)
+            _rm_tree(txn_dir)
+        raise ChartError(
+            "io",
+            "chart_transaction_failed",
+            f"Chart transaction failed: {e}",
+            details={"command": command},
+        ) from e
+
+
+def load_chart_sidecar(flow_dir: Path, chart_id: str) -> dict:
+    """Load chart JSON sidecar or raise ChartError not_found/io."""
+    chart_id = canonicalize_chart_id(chart_id)
+    _md_path, json_path = chart_pair_paths(flow_dir, chart_id)
+    if not json_path.is_file():
+        raise ChartError(
+            "not_found",
+            "chart_not_found",
+            f"Chart not found: {chart_id}",
+            details={"id": chart_id},
+        )
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ChartError(
+            "io",
+            "chart_invalid_json",
+            f"Chart sidecar invalid JSON: {chart_id} ({e})",
+            details={"id": chart_id, "path": str(json_path)},
+        ) from e
+    except OSError as e:
+        raise ChartError(
+            "io",
+            "chart_unreadable",
+            f"Chart sidecar unreadable: {chart_id} ({e})",
+            details={"id": chart_id, "path": str(json_path)},
+        ) from e
+    if not isinstance(data, dict):
+        raise ChartError(
+            "io",
+            "chart_invalid_json",
+            f"Chart sidecar must be a JSON object: {chart_id}",
+            details={"id": chart_id},
+        )
+    return data
+
+
+def list_chart_ids(flow_dir: Path) -> list[str]:
+    """Sorted chart ids present as .json sidecars under charts/."""
+    cdir = charts_dir(flow_dir)
+    if not cdir.is_dir():
+        return []
+    ids: list[str] = []
+    try:
+        with os.scandir(cdir) as it:
+            for entry in it:
+                name = entry.name
+                if not name.endswith(".json"):
+                    continue
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                stem = name[: -len(".json")]
+                if _CHART_ID_RE.fullmatch(stem):
+                    ids.append(stem)
+    except OSError:
+        return []
+    return sorted(ids, key=lambda s: int(s.split("-", 1)[1]))
+
+
+# ---------------------------------------------------------------------------
+# Chart graph, parked questions, frontier, claims (fn-135.9)
+# ---------------------------------------------------------------------------
+
+
+def get_chart_max_decisions() -> int:
+    """Configured charting-time decision ceiling (default 12)."""
+    raw = get_config("chart.maxDecisions", CHART_DEFAULT_MAX_DECISIONS)
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return CHART_DEFAULT_MAX_DECISIONS
+    if n < 1:
+        return CHART_DEFAULT_MAX_DECISIONS
+    return n
+
+
+def get_chart_claim_stale_after_hours() -> float:
+    """Configured stale-claim age threshold in hours (default 24)."""
+    raw = get_config(
+        "chart.claimStaleAfter", CHART_DEFAULT_CLAIM_STALE_AFTER_HOURS
+    )
+    try:
+        n = float(raw)
+    except (TypeError, ValueError):
+        return float(CHART_DEFAULT_CLAIM_STALE_AFTER_HOURS)
+    if n < 0:
+        return float(CHART_DEFAULT_CLAIM_STALE_AFTER_HOURS)
+    return n
+
+
+def decision_record_relpaths(chart_id: str, d_num: int) -> tuple[str, str]:
+    """Journal relpaths (under charts/) for decision md/json."""
+    chart_id = canonicalize_chart_id(chart_id)
+    return (f"{chart_id}/{d_num}.md", f"{chart_id}/{d_num}.json")
+
+
+def decision_record_link(chart_id: str, d_num: int) -> str:
+    chart_id = canonicalize_chart_id(chart_id)
+    return f"{FLOW_DIR}/{CHARTS_DIR}/{chart_id}/{d_num}.md"
+
+
+def decision_body_text(question: str) -> str:
+    """Decision markdown body: only the Question section."""
+    q = (question or "").strip()
+    return f"## Question\n{q}\n"
+
+
+def decision_sidecar_data(
+    chart_id: str,
+    d_num: int,
+    title: str,
+    dtype: str,
+    attendance: str,
+    question: str,
+    *,
+    blocked_by: Optional[list[str]] = None,
+    depends_on: Optional[list[str]] = None,
+    created: Optional[str] = None,
+) -> dict:
+    """Full decision JSON sidecar (answer/assets empty until resolution)."""
+    chart_id = canonicalize_chart_id(chart_id)
+    did = f"{chart_id}.D{d_num}"
+    ts = created or now_iso()
+    return {
+        "id": did,
+        "chart": chart_id,
+        "n": d_num,
+        "title": title,
+        "type": dtype,
+        "attendance": attendance,
+        "status": "open",
+        "question": question,
+        "blocked_by": list(blocked_by or []),
+        "depends_on": list(depends_on or []),
+        "supersedes": [],
+        "superseded_by": None,
+        "claimed_by": None,
+        "claimed_at": None,
+        "claim_note": None,
+        "assets": [],
+        "answer": None,
+        "transition_notes": [],
+        "created": ts,
+        "updated_at": ts,
+        "record_path": decision_record_link(chart_id, d_num),
+        # fn-135.5 — optional tracker locator for decision children (not identity).
+        "tracker": {
+            "id": None,
+            "identifier": None,
+            "url": None,
+            "linkState": "unlinked",
+            "depRelations": [],
+        },
+    }
+
+
+def derive_decision_attendance(
+    dtype: str, attendance: Optional[str] = None
+) -> str:
+    """Derive or validate attendance for a decision type.
+
+    Five route types derive attendance; task requires an explicit value.
+    """
+    dtype = (dtype or "").strip().lower()
+    if dtype not in CHART_DECISION_TYPES:
+        raise ChartError(
+            "validation",
+            "invalid_decision_type",
+            f"Invalid decision type '{dtype}' "
+            f"(expected one of {', '.join(sorted(CHART_DECISION_TYPES))})",
+            details={"type": dtype},
+        )
+    if dtype == "task":
+        if attendance is None or not str(attendance).strip():
+            raise ChartError(
+                "validation",
+                "attendance_required",
+                "Decision type 'task' requires --attendance attended|unattended",
+                details={"type": "task"},
+            )
+        att = str(attendance).strip().lower()
+        if att not in CHART_ATTENDANCE_VALUES:
+            raise ChartError(
+                "validation",
+                "invalid_attendance",
+                f"Invalid attendance '{attendance}' (expected attended|unattended)",
+                details={"attendance": attendance},
+            )
+        return att
+    derived = CHART_TYPE_ATTENDANCE[dtype]
+    if attendance is not None and str(attendance).strip():
+        att = str(attendance).strip().lower()
+        if att not in CHART_ATTENDANCE_VALUES:
+            raise ChartError(
+                "validation",
+                "invalid_attendance",
+                f"Invalid attendance '{attendance}' (expected attended|unattended)",
+                details={"attendance": attendance},
+            )
+        if att != derived:
+            raise ChartError(
+                "validation",
+                "attendance_mismatch",
+                f"Type '{dtype}' requires attendance '{derived}', got '{att}'",
+                details={"type": dtype, "expected": derived, "got": att},
+            )
+    return derived
+
+
+def normalize_parked_question_body(body: str) -> str:
+    """Collapse whitespace and strip for stable parked-question identity."""
+    if body is None:
+        return ""
+    text = unicodedata.normalize("NFKC", str(body))
+    text = re.sub(r"\s+", " ", text.strip())
+    return text
+
+
+def parked_question_key(body: str) -> str:
+    """Stable key for a parked question (sha256 of normalized body, 16 hex)."""
+    normalized = normalize_parked_question_body(body)
+    if not normalized:
+        raise ChartError(
+            "validation",
+            "empty_parked_question",
+            "Parked question body must be non-empty",
+        )
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def chart_cost_estimate(decisions: list[dict]) -> dict:
+    """Session-cost estimate from attendance fields (never from prose)."""
+    unattended = 0
+    attended = 0
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        att = d.get("attendance")
+        if att == "unattended":
+            unattended += 1
+        elif att == "attended":
+            attended += 1
+    # Unattended routes run in parallel (~1 session batch); attended are serial.
+    sessions = attended + (1 if unattended else 0)
+    total = unattended + attended
+    cost_line = (
+        f"{total} decisions: {unattended} unattended (parallel, ~1 session), "
+        f"{attended} attended (~{attended} sessions). "
+        f"Estimated {sessions} working sessions with you."
+    )
+    return {
+        "decision_count": total,
+        "unattended_count": unattended,
+        "attended_count": attended,
+        "estimated_sessions": sessions,
+        "cost_line": cost_line,
+    }
+
+
+def _decision_is_blocked(decision: dict, status_index: dict[str, str]) -> bool:
+    """True when any blocked_by target is still open (or missing)."""
+    for bid in decision.get("blocked_by") or []:
+        st = status_index.get(bid)
+        if st is None or st == "open":
+            return True
+    return False
+
+
+def _decision_is_claimed(decision: dict) -> bool:
+    return bool(decision.get("claimed_by"))
+
+
+def chart_completion_predicate(data: dict) -> dict:
+    """Briefable only when no open decisions and no parked questions.
+
+    Stuck charts report why (blocked open, claimed open, parked).
+    """
+    decisions = data.get("decisions") or []
+    if not isinstance(decisions, list):
+        decisions = []
+    parked = data.get("parked_questions") or []
+    if not isinstance(parked, list):
+        parked = []
+    status_index = {
+        d["id"]: d.get("status")
+        for d in decisions
+        if isinstance(d, dict) and d.get("id")
+    }
+    open_decs = [
+        d
+        for d in decisions
+        if isinstance(d, dict) and d.get("status") == "open"
+    ]
+    stuck_reasons: list[str] = []
+    blocked = [d for d in open_decs if _decision_is_blocked(d, status_index)]
+    claimed = [d for d in open_decs if _decision_is_claimed(d)]
+    if blocked:
+        stuck_reasons.append(
+            f"{len(blocked)} open decision(s) blocked: "
+            + ", ".join(d["id"] for d in blocked if d.get("id"))
+        )
+    if claimed:
+        stuck_reasons.append(
+            f"{len(claimed)} open decision(s) claimed: "
+            + ", ".join(
+                f"{d['id']} by {d.get('claimed_by')}"
+                for d in claimed
+                if d.get("id")
+            )
+        )
+    unblocked_unclaimed = [
+        d
+        for d in open_decs
+        if not _decision_is_blocked(d, status_index)
+        and not _decision_is_claimed(d)
+    ]
+    if unblocked_unclaimed:
+        stuck_reasons.append(
+            f"{len(unblocked_unclaimed)} open unblocked unclaimed decision(s): "
+            + ", ".join(d["id"] for d in unblocked_unclaimed if d.get("id"))
+        )
+    if parked:
+        stuck_reasons.append(f"{len(parked)} parked open question(s)")
+    briefable = len(open_decs) == 0 and len(parked) == 0
+    return {
+        "briefable": briefable,
+        "stuck_reasons": stuck_reasons,
+        "open_count": len(open_decs),
+        "parked_count": len(parked),
+        "blocked_open_ids": [d["id"] for d in blocked if d.get("id")],
+        "claimed_open_ids": [d["id"] for d in claimed if d.get("id")],
+        "frontier_ids": [d["id"] for d in unblocked_unclaimed if d.get("id")],
+    }
+
+
+def _parse_edge_list(
+    raw: Optional[str],
+    chart_id: str,
+    *,
+    field_name: str,
+) -> list[str]:
+    """Parse a comma-separated edge list into canonical D-IDs (dedupe later)."""
+    if raw is None or not str(raw).strip():
+        return []
+    parts = [p.strip() for p in str(raw).split(",")]
+    out: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        out.append(canonicalize_decision_id(part, chart_id=chart_id))
+    return out
+
+
+def _normalize_edge_refs(
+    refs: list[Any],
+    chart_id: str,
+    *,
+    field_name: str,
+    local_map: Optional[dict[str, str]] = None,
+) -> list[str]:
+    """Normalize edge refs to canonical D-IDs.
+
+    local_map maps provisional labels (D1, 1, local titles unused) to
+    allocated ids during initial-map create.
+    """
+    out: list[str] = []
+    for ref in refs:
+        if ref is None:
+            continue
+        text = str(ref).strip()
+        if not text:
+            continue
+        if local_map is not None:
+            key = text.lower()
+            if key in local_map:
+                out.append(local_map[key])
+                continue
+            bare = _CHART_DID_BARE_RE.fullmatch(key)
+            if bare and bare.group(1) in local_map:
+                out.append(local_map[bare.group(1)])
+                continue
+            dform = f"d{bare.group(1)}" if bare else None
+            if dform and dform in local_map:
+                out.append(local_map[dform])
+                continue
+        out.append(canonicalize_decision_id(text, chart_id=chart_id))
+    return out
+
+
+def validate_chart_graph(
+    decisions: list[dict],
+    *,
+    chart_id: Optional[str] = None,
+) -> None:
+    """Reject missing targets, self-edges, duplicates, and cycles atomically.
+
+    Validates both blocked_by (readiness) and depends_on (premise) graphs.
+    Raises ChartError(invalid_graph, ...) before any write.
+    """
+    if not isinstance(decisions, list):
+        raise ChartError(
+            "invalid_graph",
+            "invalid_decisions",
+            "Chart decisions must be a list",
+        )
+    ids: set[str] = set()
+    for d in decisions:
+        if not isinstance(d, dict) or not d.get("id"):
+            raise ChartError(
+                "invalid_graph",
+                "invalid_decision_entry",
+                "Every decision entry needs an id",
+            )
+        did = d["id"]
+        if did in ids:
+            raise ChartError(
+                "invalid_graph",
+                "duplicate_decision_id",
+                f"Duplicate decision id {did}",
+                details={"id": did},
+            )
+        ids.add(did)
+
+    def _check_edges(field: str) -> dict[str, list[str]]:
+        adj: dict[str, list[str]] = {i: [] for i in ids}
+        for d in decisions:
+            did = d["id"]
+            raw_edges = d.get(field) or []
+            if not isinstance(raw_edges, list):
+                raise ChartError(
+                    "invalid_graph",
+                    "invalid_edge_list",
+                    f"{field} for {did} must be a list",
+                    details={"id": did, "field": field},
+                )
+            seen: set[str] = set()
+            clean: list[str] = []
+            for edge in raw_edges:
+                if not isinstance(edge, str) or not edge:
+                    raise ChartError(
+                        "invalid_graph",
+                        "invalid_edge",
+                        f"Invalid {field} edge on {did}",
+                        details={"id": did, "field": field, "edge": edge},
+                    )
+                if edge == did:
+                    raise ChartError(
+                        "invalid_graph",
+                        "self_edge",
+                        f"Self-edge not allowed: {did} {field} {edge}",
+                        details={"id": did, "field": field, "edge": edge},
+                    )
+                if edge not in ids:
+                    raise ChartError(
+                        "invalid_graph",
+                        "missing_edge_target",
+                        f"Missing {field} target {edge} from {did}",
+                        details={"id": did, "field": field, "edge": edge},
+                    )
+                if edge in seen:
+                    raise ChartError(
+                        "invalid_graph",
+                        "duplicate_edge",
+                        f"Duplicate {field} edge {edge} on {did}",
+                        details={"id": did, "field": field, "edge": edge},
+                    )
+                seen.add(edge)
+                clean.append(edge)
+            d[field] = clean
+            adj[did] = list(clean)
+        # Cycle detection (DFS white/gray/black) on the directed graph.
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color = {i: WHITE for i in ids}
+
+        def dfs(node: str, stack: list[str]) -> None:
+            color[node] = GRAY
+            stack.append(node)
+            for nxt in adj.get(node) or []:
+                if color[nxt] == GRAY:
+                    cycle = stack[stack.index(nxt) :] + [nxt]
+                    raise ChartError(
+                        "invalid_graph",
+                        "cycle",
+                        f"Cycle in {field}: {' -> '.join(cycle)}",
+                        details={"field": field, "cycle": cycle},
+                    )
+                if color[nxt] == WHITE:
+                    dfs(nxt, stack)
+            stack.pop()
+            color[node] = BLACK
+
+        for node in ids:
+            if color[node] == WHITE:
+                dfs(node, [])
+        return adj
+
+    _check_edges("blocked_by")
+    _check_edges("depends_on")
+
+
+def compute_frontier(data: dict) -> list[dict]:
+    """Open, unblocked, unclaimed decisions in dependency (blocked_by) order."""
+    decisions = [
+        d
+        for d in (data.get("decisions") or [])
+        if isinstance(d, dict) and d.get("id")
+    ]
+    status_index = {d["id"]: d.get("status") for d in decisions}
+    candidates = [
+        d
+        for d in decisions
+        if d.get("status") == "open"
+        and not _decision_is_blocked(d, status_index)
+        and not _decision_is_claimed(d)
+    ]
+    # Topological order among candidates using blocked_by edges that stay
+    # inside the candidate set (usually empty); fall back to allocation order.
+    cand_ids = {d["id"] for d in candidates}
+    indeg = {d["id"]: 0 for d in candidates}
+    adj: dict[str, list[str]] = {d["id"]: [] for d in candidates}
+    for d in candidates:
+        for b in d.get("blocked_by") or []:
+            if b in cand_ids:
+                adj[b].append(d["id"])
+                indeg[d["id"]] += 1
+    # Stable by local number when ties.
+    def _local_n(did: str) -> int:
+        try:
+            return decision_local_number(did)
+        except ChartError:
+            return 0
+
+    ready = sorted(
+        [i for i, deg in indeg.items() if deg == 0],
+        key=_local_n,
+    )
+    ordered_ids: list[str] = []
+    while ready:
+        n = ready.pop(0)
+        ordered_ids.append(n)
+        for m in sorted(adj.get(n) or [], key=_local_n):
+            indeg[m] -= 1
+            if indeg[m] == 0:
+                ready.append(m)
+                ready.sort(key=_local_n)
+    if len(ordered_ids) != len(candidates):
+        # Residual (should not happen after validation); allocation order.
+        ordered_ids = sorted(cand_ids, key=_local_n)
+    by_id = {d["id"]: d for d in candidates}
+    return [
+        {
+            "id": by_id[i]["id"],
+            "title": by_id[i].get("title"),
+            "type": by_id[i].get("type"),
+            "attendance": by_id[i].get("attendance"),
+            "status": by_id[i].get("status"),
+            "blocked_by": list(by_id[i].get("blocked_by") or []),
+            "depends_on": list(by_id[i].get("depends_on") or []),
+            "record_path": by_id[i].get("record_path")
+            or decision_record_link(
+                by_id[i]["id"].rsplit(".", 1)[0],
+                decision_local_number(by_id[i]["id"]),
+            ),
+        }
+        for i in ordered_ids
+        if i in by_id
+    ]
+
+
+def _render_open_questions_section(parked: list[dict]) -> str:
+    """Render ## Open Questions section body (bullets only, no heading)."""
+    if not parked:
+        return ""
+    lines = []
+    for entry in parked:
+        body = entry.get("body") if isinstance(entry, dict) else str(entry)
+        body = normalize_parked_question_body(body or "")
+        if body:
+            lines.append(f"- {body}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _replace_chart_section(body: str, heading: str, new_content: str) -> str:
+    """Replace a ## Section body in a chart map; preserve other sections."""
+    pattern = re.compile(
+        rf"(^##\s+{re.escape(heading)}\s*\n)(.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    content = new_content
+    if content and not content.endswith("\n"):
+        content = content + "\n"
+    # Function replacement: content is literal text, never a template
+    # (a parked question containing backslashes must not expand as backrefs).
+    if pattern.search(body):
+        return pattern.sub(lambda m: m.group(1) + content, body, count=1)
+    # Section missing: append.
+    if not body.endswith("\n"):
+        body += "\n"
+    return body + f"\n## {heading}\n{content}"
+
+
+def load_decision_sidecar(
+    flow_dir: Path, chart_id: str, d_num: int, *, compact: bool = False
+) -> dict:
+    """Load a decision JSON sidecar.
+
+    compact=True still loads the same JSON (metadata lives there) but callers
+    must not request answer/assets fields for navigation; use chart sidecar
+    decisions[] for show/list/frontier instead.
+    """
+    _md, json_path = decision_record_paths(flow_dir, chart_id, d_num)
+    if not json_path.is_file():
+        raise ChartError(
+            "not_found",
+            "decision_not_found",
+            f"Decision not found: {canonicalize_chart_id(chart_id)}.D{d_num}",
+            details={
+                "id": f"{canonicalize_chart_id(chart_id)}.D{d_num}",
+            },
+        )
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ChartError(
+            "io",
+            "decision_invalid_json",
+            f"Decision sidecar invalid JSON: {json_path} ({e})",
+            details={"path": str(json_path)},
+        ) from e
+    except OSError as e:
+        raise ChartError(
+            "io",
+            "decision_unreadable",
+            f"Decision sidecar unreadable: {json_path} ({e})",
+            details={"path": str(json_path)},
+        ) from e
+    if not isinstance(data, dict):
+        raise ChartError(
+            "io",
+            "decision_invalid_json",
+            f"Decision sidecar must be a JSON object: {json_path}",
+            details={"path": str(json_path)},
+        )
+    if compact:
+        return compact_decision_entry(data)
+    return data
+
+
+def _next_decision_number(chart_data: dict) -> int:
+    """Next sequential D-number (max existing + 1); never reuse gaps."""
+    max_n = 0
+    for d in chart_data.get("decisions") or []:
+        if not isinstance(d, dict):
+            continue
+        did = d.get("id")
+        if isinstance(did, str):
+            try:
+                max_n = max(max_n, decision_local_number(did))
+            except ChartError:
+                pass
+        n = d.get("n")
+        if isinstance(n, int):
+            max_n = max(max_n, n)
+    return max_n + 1
+
+
+def _find_decision_entry(chart_data: dict, did: str) -> tuple[int, dict]:
+    decisions = chart_data.get("decisions") or []
+    for i, d in enumerate(decisions):
+        if isinstance(d, dict) and d.get("id") == did:
+            return i, d
+    raise ChartError(
+        "not_found",
+        "decision_not_found",
+        f"Decision not found: {did}",
+        details={"id": did},
+    )
+
+
+def _sidecar_json(data: dict) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def _chart_md_with_parked(
+    chart_id: str, title: str, outcome: str, parked: list, notes: str = ""
+) -> str:
+    body = chart_body_text(chart_id, title, outcome, notes)
+    return _replace_chart_section(
+        body, "Open Questions", _render_open_questions_section(parked)
+    )
+
+
+def _apply_parked_to_chart_body(md_text: str, parked: list) -> str:
+    return _replace_chart_section(
+        md_text, "Open Questions", _render_open_questions_section(parked)
+    )
+
+
+def _parse_iso_ts(raw: Optional[str]) -> Optional[datetime]:
+    if not raw or not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _claim_age_hours(claimed_at: Optional[str]) -> Optional[float]:
+    ts = _parse_iso_ts(claimed_at)
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return max(0.0, (now - ts).total_seconds() / 3600.0)
+
+
+def parse_initial_map_file(path: Path) -> dict:
+    """Load and lightly shape an initial-map JSON file."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ChartError(
+            "io",
+            "initial_map_unreadable",
+            f"Cannot read initial-map file: {path} ({e})",
+            details={"path": str(path)},
+        ) from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ChartError(
+            "validation",
+            "initial_map_invalid_json",
+            f"Initial-map file is not valid JSON: {e}",
+            details={"path": str(path)},
+        ) from e
+    if not isinstance(data, dict):
+        raise ChartError(
+            "validation",
+            "initial_map_invalid",
+            "Initial-map file must be a JSON object",
+            details={"path": str(path)},
+        )
+    decisions = data.get("decisions")
+    if decisions is None:
+        decisions = []
+    if not isinstance(decisions, list):
+        raise ChartError(
+            "validation",
+            "initial_map_invalid_decisions",
+            "initial-map 'decisions' must be a list",
+        )
+    parked = data.get("parked_questions")
+    if parked is None:
+        parked = data.get("parked") or []
+    if not isinstance(parked, list):
+        raise ChartError(
+            "validation",
+            "initial_map_invalid_parked",
+            "initial-map 'parked_questions' must be a list",
+        )
+    notes = data.get("notes")
+    if notes is None:
+        notes = ""
+    if not isinstance(notes, str):
+        raise ChartError(
+            "validation",
+            "initial_map_invalid_notes",
+            "initial-map 'notes' must be a string",
+        )
+    return {
+        "decisions": decisions,
+        "parked_questions": parked,
+        "notes": notes,
+    }
+
+
+def validate_and_build_initial_map(
+    chart_id: str,
+    map_data: dict,
+    *,
+    force_size: bool = False,
+    force_reason: Optional[str] = None,
+) -> dict:
+    """Validate titled decisions/attendance/edges/parked; enforce ceiling.
+
+    Returns a ready-to-persist structure. Refuses over maxDecisions before
+    allocation when force_size is false.
+    """
+    raw_decs = map_data.get("decisions") or []
+    raw_parked = map_data.get("parked_questions") or []
+    ceiling = get_chart_max_decisions()
+    count = len(raw_decs)
+    if count > ceiling and not force_size:
+        raise ChartError(
+            "validation",
+            "max_decisions_exceeded",
+            f"Initial map has {count} decisions; chart.maxDecisions is {ceiling}. "
+            "Narrow the Outcome, split into two charts, or pass "
+            "--force-size --reason after explicit consent.",
+            details={
+                "count": count,
+                "ceiling": ceiling,
+                "maxDecisions": ceiling,
+            },
+        )
+    if count > ceiling and force_size:
+        if not force_reason or not str(force_reason).strip():
+            raise ChartError(
+                "validation",
+                "force_size_reason_required",
+                "--force-size requires --reason",
+                details={"count": count, "ceiling": ceiling},
+            )
+        # The audit reason is git-tracked chart prose like any other entry point.
+        refuse_if_unsafe_prose(str(force_reason), field="--force-size reason")
+
+    # First pass: allocate provisional D-IDs in file order and derive attendance.
+    local_map: dict[str, str] = {}
+    built: list[dict] = []
+    for i, raw in enumerate(raw_decs, start=1):
+        if not isinstance(raw, dict):
+            raise ChartError(
+                "validation",
+                "invalid_initial_decision",
+                f"Initial decision #{i} must be an object",
+                details={"index": i},
+            )
+        title = (raw.get("title") or "").strip()
+        if not title:
+            raise ChartError(
+                "validation",
+                "title_required",
+                f"Initial decision #{i} requires a title",
+                details={"index": i},
+            )
+        dtype = (raw.get("type") or "").strip().lower()
+        attendance = derive_decision_attendance(dtype, raw.get("attendance"))
+        question = (
+            raw.get("question")
+            or raw.get("body")
+            or title
+        )
+        question = str(question).strip()
+        # R20/R48: refuse unsafe prose before any allocation or persistence.
+        refuse_if_unsafe_prose(
+            f"{title}\n{question}", field=f"Initial decision #{i}"
+        )
+        did = f"{chart_id}.D{i}"
+        local_map[str(i)] = did
+        local_map[f"d{i}"] = did
+        local_map[did.lower()] = did
+        # Optional explicit local id in the map file.
+        if raw.get("id"):
+            local_map[str(raw["id"]).strip().lower()] = did
+        built.append(
+            {
+                "n": i,
+                "id": did,
+                "title": title,
+                "type": dtype,
+                "attendance": attendance,
+                "question": question,
+                "raw_blocked_by": raw.get("blocked_by") or [],
+                "raw_depends_on": raw.get("depends_on") or [],
+            }
+        )
+
+    # Second pass: resolve edges against the local map, then validate graph.
+    decisions_for_graph: list[dict] = []
+    for b in built:
+        blocked = _normalize_edge_refs(
+            list(b["raw_blocked_by"]),
+            chart_id,
+            field_name="blocked_by",
+            local_map=local_map,
+        )
+        depends = _normalize_edge_refs(
+            list(b["raw_depends_on"]),
+            chart_id,
+            field_name="depends_on",
+            local_map=local_map,
+        )
+        decisions_for_graph.append(
+            {
+                "id": b["id"],
+                "title": b["title"],
+                "type": b["type"],
+                "attendance": b["attendance"],
+                "status": "open",
+                "blocked_by": blocked,
+                "depends_on": depends,
+                "n": b["n"],
+                "question": b["question"],
+                "claimed_by": None,
+                "claimed_at": None,
+                "record_path": decision_record_link(chart_id, b["n"]),
+            }
+        )
+    validate_chart_graph(decisions_for_graph, chart_id=chart_id)
+
+    parked_out: list[dict] = []
+    seen_keys: set[str] = set()
+    for raw_q in raw_parked:
+        if isinstance(raw_q, dict):
+            body = raw_q.get("body") or raw_q.get("question") or ""
+        else:
+            body = str(raw_q)
+        body_norm = normalize_parked_question_body(body)
+        if not body_norm:
+            raise ChartError(
+                "validation",
+                "empty_parked_question",
+                "Parked question body must be non-empty",
+            )
+        refuse_if_unsafe_prose(body_norm, field="Parked question")
+        key = parked_question_key(body_norm)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        parked_out.append(
+            {
+                "key": key,
+                "body": body_norm,
+                "created": now_iso(),
+            }
+        )
+
+    cost = chart_cost_estimate(decisions_for_graph)
+    force_audit = None
+    if count > ceiling and force_size:
+        force_audit = {
+            "actor": get_actor(),
+            "ceiling": ceiling,
+            "count": count,
+            "timestamp": now_iso(),
+            "reason": str(force_reason).strip(),
+        }
+    notes = str(map_data.get("notes") or "").strip()
+    if notes:
+        # Grounding facts land under `## Notes` with their citations (R52); the
+        # same unsafe-prose refusal as every other chart prose entry point.
+        refuse_if_unsafe_prose(notes, field="chart Notes")
+    return {
+        "decisions": decisions_for_graph,
+        "parked_questions": parked_out,
+        "notes": notes,
+        "cost": cost,
+        "force_size_audit": force_audit,
+        "ceiling": ceiling,
+    }
+
+
+def create_chart_pair(
+    flow_dir: Path,
+    chart_id: str,
+    title: str,
+    outcome: str,
+    *,
+    initial: Optional[dict] = None,
+) -> dict:
+    """Allocate-time publication of a new chart md/json pair.
+
+    Caller must hold the shared native-fn allocation lock and the charts
+    resource lock, and must have already run recovery. Optional `initial` is
+    the output of validate_and_build_initial_map (decisions + parked + audit).
+    """
+    chart_id = canonicalize_chart_id(chart_id)
+    # R20/R48: chart title/outcome are git-tracked prose too (chart md/json
+    # and the tracker parent rollup) - same refusal as decision and
+    # parked-question prose, BEFORE any allocation or persistence.
+    refuse_if_unsafe_prose(title, field="Chart title")
+    refuse_if_unsafe_prose(outcome, field="Chart outcome")
+    md_path, json_path = chart_pair_paths(flow_dir, chart_id)
+    if md_path.exists() or json_path.exists():
+        raise ChartError(
+            "conflict",
+            "chart_exists",
+            f"Refusing to overwrite existing chart {chart_id}",
+            details={"id": chart_id},
+        )
+    data = chart_sidecar_data(chart_id, title, outcome)
+    parked: list[dict] = []
+    mutations: list[tuple[str, str, str]] = []
+    if initial:
+        parked = list(initial.get("parked_questions") or [])
+        data["parked_questions"] = parked
+        compact_decs: list[dict] = []
+        for d in initial.get("decisions") or []:
+            d_num = int(d["n"])
+            full = decision_sidecar_data(
+                chart_id,
+                d_num,
+                d["title"],
+                d["type"],
+                d["attendance"],
+                d.get("question") or d["title"],
+                blocked_by=d.get("blocked_by"),
+                depends_on=d.get("depends_on"),
+            )
+            compact_decs.append(compact_decision_entry(full))
+            md_rel, json_rel = decision_record_relpaths(chart_id, d_num)
+            mutations.append(
+                (md_rel, "create", decision_body_text(full["question"]))
+            )
+            mutations.append((json_rel, "create", _sidecar_json(full)))
+        data["decisions"] = compact_decs
+        if initial.get("force_size_audit"):
+            data["force_size_audit"] = initial["force_size_audit"]
+    md_content = _chart_md_with_parked(
+        chart_id, title, outcome, parked, str((initial or {}).get("notes") or "")
+    )
+    mutations = [
+        (f"{chart_id}.json", "create", _sidecar_json(data)),
+        (f"{chart_id}.md", "create", md_content),
+        *mutations,
+    ]
+    run_chart_transaction(flow_dir, "chart.create", mutations)
+    return data
+
+
+def add_chart_decision(
+    flow_dir: Path,
+    chart_id: str,
+    title: str,
+    dtype: str,
+    *,
+    attendance: Optional[str] = None,
+    question: str = "",
+    blocked_by: Optional[list[str]] = None,
+    depends_on: Optional[list[str]] = None,
+) -> dict:
+    """Allocate next D-ID and publish decision + chart sidecar update."""
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    if chart.get("status") not in (None, "open"):
+        raise ChartError(
+            "invalid_state",
+            "chart_not_open",
+            f"Chart {chart_id} is {chart.get('status')}; cannot add decisions",
+            details={"id": chart_id, "status": chart.get("status")},
+        )
+    att = derive_decision_attendance(dtype, attendance)
+    title = (title or "").strip()
+    if not title:
+        raise ChartError(
+            "validation",
+            "title_required",
+            "add-decision requires --title",
+        )
+    question = (question or title).strip()
+    # R20/R48: refuse unsafe prose before D-ID allocation or persistence.
+    refuse_if_unsafe_prose(f"{title}\n{question}", field="Decision")
+    d_num = _next_decision_number(chart)
+    blocked = list(blocked_by or [])
+    depends = list(depends_on or [])
+    # Canonicalize edges against this chart.
+    blocked = [
+        canonicalize_decision_id(e, chart_id=chart_id) for e in blocked
+    ]
+    depends = [
+        canonicalize_decision_id(e, chart_id=chart_id) for e in depends
+    ]
+    full = decision_sidecar_data(
+        chart_id,
+        d_num,
+        title,
+        dtype.strip().lower(),
+        att,
+        question,
+        blocked_by=blocked,
+        depends_on=depends,
+    )
+    new_entry = compact_decision_entry(full)
+    proposed = list(chart.get("decisions") or []) + [new_entry]
+    validate_chart_graph(proposed, chart_id=chart_id)
+    chart = dict(chart)
+    chart["decisions"] = proposed
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    # Chart body unchanged on add (ledger is resolution-only); still update
+    # sidecar under the transaction with decision files.
+    md_rel, json_rel = decision_record_relpaths(chart_id, d_num)
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (md_rel, "create", decision_body_text(question)),
+        (json_rel, "create", _sidecar_json(full)),
+    ]
+    # Touch chart.md only if present so recovery stays paired; no content change.
+    if md_path.is_file():
+        mutations.insert(
+            1,
+            (
+                f"{chart_id}.md",
+                "update",
+                md_path.read_text(encoding="utf-8"),
+            ),
+        )
+    run_chart_transaction(flow_dir, "chart.add-decision", mutations)
+    return full
+
+
+def park_chart_question(flow_dir: Path, chart_id: str, body: str) -> dict:
+    """Add a normalized parked question; identical key is a no-op."""
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.park-question")
+    body_norm = normalize_parked_question_body(body)
+    # R20/R48: refuse unsafe prose before the no-op/key path can persist it.
+    refuse_if_unsafe_prose(body_norm, field="Parked question")
+    key = parked_question_key(body_norm)
+    parked = list(chart.get("parked_questions") or [])
+    for entry in parked:
+        if isinstance(entry, dict) and entry.get("key") == key:
+            return {
+                "key": key,
+                "body": entry.get("body") or body_norm,
+                "created": entry.get("created"),
+                "noop": True,
+            }
+    entry = {"key": key, "body": body_norm, "created": now_iso()}
+    parked.append(entry)
+    chart = dict(chart)
+    chart["parked_questions"] = parked
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    if not md_path.is_file():
+        raise ChartError(
+            "io",
+            "chart_body_missing",
+            f"Chart body missing for {chart_id}",
+            details={"id": chart_id},
+        )
+    new_md = _apply_parked_to_chart_body(
+        md_path.read_text(encoding="utf-8"), parked
+    )
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (f"{chart_id}.md", "update", new_md),
+    ]
+    run_chart_transaction(flow_dir, "chart.park-question", mutations)
+    return {"key": key, "body": body_norm, "created": entry["created"], "noop": False}
+
+
+def remove_chart_question(
+    flow_dir: Path, chart_id: str, question_key: str
+) -> dict:
+    """Remove a parked question by stable key; fails if absent."""
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.remove-question")
+    key = (question_key or "").strip()
+    if not key:
+        raise ChartError(
+            "validation",
+            "question_key_required",
+            "remove-question requires --question <key>",
+        )
+    parked = list(chart.get("parked_questions") or [])
+    new_parked = [
+        e
+        for e in parked
+        if not (isinstance(e, dict) and e.get("key") == key)
+    ]
+    if len(new_parked) == len(parked):
+        raise ChartError(
+            "not_found",
+            "parked_question_not_found",
+            f"Parked question key not found: {key}",
+            details={"key": key, "chart_id": chart_id},
+        )
+    removed = next(
+        e for e in parked if isinstance(e, dict) and e.get("key") == key
+    )
+    chart = dict(chart)
+    chart["parked_questions"] = new_parked
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    if not md_path.is_file():
+        raise ChartError(
+            "io",
+            "chart_body_missing",
+            f"Chart body missing for {chart_id}",
+            details={"id": chart_id},
+        )
+    new_md = _apply_parked_to_chart_body(
+        md_path.read_text(encoding="utf-8"), new_parked
+    )
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (f"{chart_id}.md", "update", new_md),
+    ]
+    run_chart_transaction(flow_dir, "chart.remove-question", mutations)
+    return {
+        "key": key,
+        "body": removed.get("body"),
+        "removed": True,
+    }
+
+
+def wire_chart_decision(
+    flow_dir: Path,
+    did: str,
+    *,
+    blocked_by: Optional[list[str]] = None,
+    depends_on: Optional[list[str]] = None,
+    replace_blocked: bool = False,
+    replace_depends: bool = False,
+) -> dict:
+    """Atomically replace validated graph edges for one decision."""
+    did = canonicalize_decision_id(did)
+    chart_id = did.rsplit(".", 1)[0]
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.wire-decision")
+    idx, entry = _find_decision_entry(chart, did)
+    d_num = decision_local_number(did)
+    full = load_decision_sidecar(flow_dir, chart_id, d_num)
+    new_blocked = (
+        list(blocked_by)
+        if replace_blocked
+        else list(entry.get("blocked_by") or full.get("blocked_by") or [])
+    )
+    new_depends = (
+        list(depends_on)
+        if replace_depends
+        else list(entry.get("depends_on") or full.get("depends_on") or [])
+    )
+    new_blocked = [
+        canonicalize_decision_id(e, chart_id=chart_id) for e in new_blocked
+    ]
+    new_depends = [
+        canonicalize_decision_id(e, chart_id=chart_id) for e in new_depends
+    ]
+    proposed = [dict(d) if isinstance(d, dict) else d for d in (chart.get("decisions") or [])]
+    proposed[idx] = dict(proposed[idx])
+    proposed[idx]["blocked_by"] = new_blocked
+    proposed[idx]["depends_on"] = new_depends
+    validate_chart_graph(proposed, chart_id=chart_id)
+    chart = dict(chart)
+    chart["decisions"] = proposed
+    full = dict(full)
+    full["blocked_by"] = new_blocked
+    full["depends_on"] = new_depends
+    full["updated_at"] = now_iso()
+    md_rel, json_rel = decision_record_relpaths(chart_id, d_num)
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (json_rel, "update", _sidecar_json(full)),
+    ]
+    run_chart_transaction(flow_dir, "chart.wire-decision", mutations)
+    return compact_decision_entry(full)
+
+
+def claim_chart_decision(flow_dir: Path, did: str) -> dict:
+    """Atomic claim; does not change decision status. Conflicts if owned."""
+    did = canonicalize_decision_id(did)
+    chart_id = did.rsplit(".", 1)[0]
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.claim")
+    idx, entry = _find_decision_entry(chart, did)
+    if entry.get("status") != "open":
+        raise ChartError(
+            "invalid_state",
+            "decision_not_open",
+            f"Cannot claim {did}: status is {entry.get('status')}",
+            details={"id": did, "status": entry.get("status")},
+        )
+    # Blocked decisions are not claimable: a claim on one never reappears on
+    # the frontier (blocked first, then claimed) and wedges the chart until a
+    # manual release. Same predicate as the frontier computation.
+    status_index = {
+        d["id"]: d.get("status")
+        for d in chart.get("decisions") or []
+        if isinstance(d, dict) and d.get("id")
+    }
+    if _decision_is_blocked(entry, status_index):
+        blockers = sorted(
+            bid
+            for bid in entry.get("blocked_by") or []
+            if status_index.get(bid) is None or status_index.get(bid) == "open"
+        )
+        raise ChartError(
+            "invalid_state",
+            "decision_blocked",
+            f"Cannot claim {did}: blocked by open decision(s) "
+            + ", ".join(blockers),
+            details={"id": did, "blocked_by": blockers},
+        )
+    actor = get_actor()
+    existing = entry.get("claimed_by")
+    if existing and existing != actor:
+        raise ChartError(
+            "conflict",
+            "claim_conflict",
+            f"Decision {did} is claimed by '{existing}'",
+            details={
+                "id": did,
+                "claimed_by": existing,
+                "claimed_at": entry.get("claimed_at"),
+                "actor": actor,
+            },
+        )
+    d_num = decision_local_number(did)
+    full = load_decision_sidecar(flow_dir, chart_id, d_num)
+    ts = entry.get("claimed_at") or now_iso()
+    if not existing:
+        ts = now_iso()
+    # Claiming never changes status.
+    entry = dict(entry)
+    entry["claimed_by"] = actor
+    entry["claimed_at"] = ts
+    proposed = list(chart.get("decisions") or [])
+    proposed[idx] = entry
+    chart = dict(chart)
+    chart["decisions"] = proposed
+    full = dict(full)
+    full["claimed_by"] = actor
+    full["claimed_at"] = ts
+    full["updated_at"] = now_iso()
+    # status deliberately untouched
+    status_before = full.get("status")
+    _, json_rel = decision_record_relpaths(chart_id, d_num)
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (json_rel, "update", _sidecar_json(full)),
+    ]
+    run_chart_transaction(flow_dir, "chart.claim", mutations)
+    return {
+        "id": did,
+        "title": entry.get("title"),
+        "status": status_before,
+        "claimed_by": actor,
+        "claimed_at": ts,
+        "record_path": entry.get("record_path")
+        or decision_record_link(chart_id, d_num),
+        "noop": bool(existing),
+    }
+
+
+def release_chart_claim(
+    flow_dir: Path,
+    did: str,
+    *,
+    break_stale: bool = False,
+    reason: Optional[str] = None,
+) -> dict:
+    """Owner release, or age-gated audited stale break."""
+    did = canonicalize_decision_id(did)
+    chart_id = did.rsplit(".", 1)[0]
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    idx, entry = _find_decision_entry(chart, did)
+    actor = get_actor()
+    existing = entry.get("claimed_by")
+    if not existing:
+        raise ChartError(
+            "invalid_state",
+            "not_claimed",
+            f"Decision {did} is not claimed",
+            details={"id": did},
+        )
+    age = _claim_age_hours(entry.get("claimed_at"))
+    audit = None
+    if existing != actor:
+        if not break_stale:
+            raise ChartError(
+                "conflict",
+                "claim_conflict",
+                f"Decision {did} is claimed by '{existing}'; "
+                "owner may release, or use --break-stale --reason after "
+                "chart.claimStaleAfter",
+                details={
+                    "id": did,
+                    "claimed_by": existing,
+                    "claimed_at": entry.get("claimed_at"),
+                    "actor": actor,
+                    "age_hours": age,
+                },
+            )
+        if not reason or not str(reason).strip():
+            raise ChartError(
+                "validation",
+                "break_stale_reason_required",
+                "--break-stale requires --reason",
+                details={"id": did},
+            )
+        # The audit reason lands in claim_events and transition notes.
+        refuse_if_unsafe_prose(str(reason), field="--break-stale reason")
+        threshold = get_chart_claim_stale_after_hours()
+        if age is None or age < threshold:
+            raise ChartError(
+                "stale_claim",
+                "claim_not_stale",
+                f"Claim on {did} is not stale yet "
+                f"(age_hours={age}, claimStaleAfter={threshold})",
+                details={
+                    "id": did,
+                    "claimed_by": existing,
+                    "claimed_at": entry.get("claimed_at"),
+                    "age_hours": age,
+                    "threshold_hours": threshold,
+                    "actor": actor,
+                },
+            )
+        audit = {
+            "actor": actor,
+            "prior_owner": existing,
+            "age_hours": age,
+            "reason": str(reason).strip(),
+            "timestamp": now_iso(),
+            "decision": did,
+            "kind": "break_stale",
+        }
+    elif break_stale:
+        # Owner releasing with break-stale is fine; still require reason if set.
+        if reason and str(reason).strip():
+            audit = {
+                "actor": actor,
+                "prior_owner": existing,
+                "age_hours": age,
+                "reason": str(reason).strip(),
+                "timestamp": now_iso(),
+                "decision": did,
+                "kind": "owner_release",
+            }
+
+    d_num = decision_local_number(did)
+    full = load_decision_sidecar(flow_dir, chart_id, d_num)
+    prior_owner = existing
+    prior_at = entry.get("claimed_at")
+    entry = dict(entry)
+    entry["claimed_by"] = None
+    entry["claimed_at"] = None
+    proposed = list(chart.get("decisions") or [])
+    proposed[idx] = entry
+    chart = dict(chart)
+    chart["decisions"] = proposed
+    events = list(chart.get("claim_events") or [])
+    if audit:
+        events.append(audit)
+        chart["claim_events"] = events
+    full = dict(full)
+    note = None
+    if audit:
+        note = (
+            f"claim released ({audit['kind']}): actor={audit['actor']} "
+            f"prior={audit['prior_owner']} age_hours={audit.get('age_hours')} "
+            f"reason={audit['reason']}"
+        )
+        notes = list(full.get("transition_notes") or [])
+        notes.append(
+            {
+                "at": audit["timestamp"],
+                "kind": audit["kind"],
+                "text": note,
+                "actor": audit["actor"],
+                "prior_owner": audit["prior_owner"],
+                "age_hours": audit.get("age_hours"),
+                "reason": audit["reason"],
+            }
+        )
+        full["transition_notes"] = notes
+        full["claim_note"] = note
+    else:
+        note = f"claim released by owner {actor}"
+        notes = list(full.get("transition_notes") or [])
+        notes.append(
+            {
+                "at": now_iso(),
+                "kind": "owner_release",
+                "text": note,
+                "actor": actor,
+                "prior_owner": prior_owner,
+            }
+        )
+        full["transition_notes"] = notes
+        full["claim_note"] = note
+    full["claimed_by"] = None
+    full["claimed_at"] = None
+    full["updated_at"] = now_iso()
+    # status deliberately untouched
+    status_after = full.get("status")
+    _, json_rel = decision_record_relpaths(chart_id, d_num)
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (json_rel, "update", _sidecar_json(full)),
+    ]
+    run_chart_transaction(flow_dir, "chart.release-claim", mutations)
+    return {
+        "id": did,
+        "title": entry.get("title"),
+        "status": status_after,
+        "released": True,
+        "prior_owner": prior_owner,
+        "prior_claimed_at": prior_at,
+        "actor": actor,
+        "audit": audit,
+        "record_path": entry.get("record_path")
+        or decision_record_link(chart_id, d_num),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Chart resolution, assets, supersession, scope, abandon (fn-135.2)
+# ---------------------------------------------------------------------------
+
+# Asset kinds accepted by attach-asset / resolve --assets.
+CHART_ASSET_KINDS = frozenset(
+    {"path", "git_ref", "branch", "commit", "url", "https"}
+)
+# Safe gist length for the compact ## Decisions ledger line.
+CHART_LEDGER_GIST_MAX = 120
+# Ledger comment preserved under ## Decisions.
+_CHART_LEDGER_COMMENT = (
+    "<!-- the ledger: one line per resolved decision, append-only, "
+    "D-IDs never reused -->"
+)
+
+# Obvious secret shapes. Patterns use FAKE-safe test fixtures (sk-FAKE...,
+# AKIA...EXAMPLE). Never embed real credentials in source or fixtures.
+_CHART_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"(?i)\b(password|passwd|pwd)\s*[=:]\s*\S+"),
+    re.compile(r"(?i)\b(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[=:]\s*\S+"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-]{20,}\b"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"(?i)\bghp_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+)
+# Literal destructive shell shapes that repo guards match on sight.
+_CHART_DESTRUCTIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\brm\s+-[A-Za-z]*[rf][A-Za-z]*\b"),
+    re.compile(r"\bgit\s+clean\b"),
+    re.compile(r"\bgit\s+reset\s+--hard\b"),
+    re.compile(r"\bdd\s+if="),
+    re.compile(r"\bmkfs\."),
+    re.compile(r">\s*/dev/sd[a-z]"),
+)
+
+
+def _require_chart_mutable(chart: dict, *, command: str = "chart") -> None:
+    """Refuse mutations on done/abandoned charts (use chart reopen --reason)."""
+    status = chart.get("status") or "open"
+    if status == "open":
+        return
+    chart_id = chart.get("id") or "?"
+    raise ChartError(
+        "invalid_state",
+        "chart_not_open",
+        f"Chart {chart_id} is {status}; mutations require status open "
+        "(use chart reopen --reason)",
+        details={"id": chart_id, "status": status, "command": command},
+    )
+
+
+def answer_gist(answer: str, *, max_len: int = CHART_LEDGER_GIST_MAX) -> str:
+    """One-line gist for the compact ledger (never the full answer)."""
+    text = (answer or "").strip()
+    if not text:
+        return "(empty)"
+    first = text.splitlines()[0].strip()
+    first = re.sub(r"\s+", " ", first)
+    if len(first) > max_len:
+        # Reserve 3 chars for the ellipsis so total length <= max_len.
+        cut = max(1, max_len - 3)
+        return first[:cut].rstrip() + "..."
+    return first
+
+
+def scan_unsafe_evidence(text: str) -> list[dict]:
+    """Return structured hits for secret/destructive content that must not embed.
+
+    Never rewrites the source. Callers refuse and require a safe redacted
+    summary plus an approved evidence reference.
+    """
+    if not text:
+        return []
+    hits: list[dict] = []
+    for pat in _CHART_SECRET_PATTERNS:
+        m = pat.search(text)
+        if m:
+            hits.append(
+                {
+                    "kind": "secret",
+                    "pattern": pat.pattern,
+                    "span": [m.start(), m.end()],
+                }
+            )
+    for pat in _CHART_DESTRUCTIVE_PATTERNS:
+        m = pat.search(text)
+        if m:
+            hits.append(
+                {
+                    "kind": "destructive_command",
+                    "pattern": pat.pattern,
+                    "span": [m.start(), m.end()],
+                }
+            )
+    return hits
+
+
+def refuse_if_unsafe_answer(answer: str) -> None:
+    """Raise ChartError(validation) when answer would embed unsafe content."""
+    hits = scan_unsafe_evidence(answer or "")
+    if not hits:
+        return
+    kinds = sorted({h["kind"] for h in hits})
+    raise ChartError(
+        "validation",
+        "unsafe_answer_content",
+        "Answer content contains obvious secret or destructive-command shapes "
+        "and must not be embedded. Supply a safe redacted summary as the "
+        "answer body and an approved evidence reference (attach-asset / "
+        "--assets); never silently strip bytes from the source.",
+        details={"kinds": kinds, "hit_count": len(hits)},
+    )
+
+
+def refuse_if_unsafe_prose(text: str, *, field: str) -> None:
+    """Raise ChartError(validation) when decision/question prose would embed
+    unsafe content.
+
+    Same refusal contract as refuse_if_unsafe_answer (R20/R48): every prose
+    field entering a git-tracked chart record - initial-map decisions and
+    parked questions, add-decision title/body, park-question bodies, and
+    sharpen-created decisions - refuses BEFORE any allocation or persistence.
+    """
+    hits = scan_unsafe_evidence(text or "")
+    if not hits:
+        return
+    kinds = sorted({h["kind"] for h in hits})
+    raise ChartError(
+        "validation",
+        "unsafe_prose_content",
+        f"{field} contains obvious secret or destructive-command shapes and "
+        "must not be embedded in git-tracked chart data. Describe the "
+        "credential or command in safe prose (or reference evidence via "
+        "attach-asset / --assets) instead of pasting it verbatim; never "
+        "silently strip bytes from the source.",
+        details={"field": field, "kinds": kinds, "hit_count": len(hits)},
+    )
+
+
+def _git_check_ignored(repo_root: Path, relpath: str) -> bool:
+    """True when git considers relpath ignored (or check fails closed for missing)."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(repo_root), "check-ignore", "-q", "--", relpath],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        return r.returncode == 0
+    except OSError:
+        return False
+
+
+def _normalize_asset_dict(raw: Any, *, repo_root: Optional[Path] = None) -> dict:
+    """Validate and normalize one asset reference to a safe structured entry."""
+    if not isinstance(raw, dict):
+        raise ChartError(
+            "validation",
+            "invalid_asset",
+            "Asset must be a JSON object with kind/reference/display",
+        )
+    kind = str(raw.get("kind") or "").strip().lower()
+    if kind == "https":
+        kind = "url"
+    if kind not in CHART_ASSET_KINDS:
+        raise ChartError(
+            "validation",
+            "invalid_asset_kind",
+            f"Invalid asset kind '{raw.get('kind')}' "
+            f"(expected path|git_ref|branch|commit|url)",
+            details={"kind": raw.get("kind")},
+        )
+    reference = str(raw.get("reference") or raw.get("ref") or "").strip()
+    if not reference:
+        raise ChartError(
+            "validation",
+            "asset_reference_required",
+            "Asset requires a non-empty reference",
+            details={"kind": kind},
+        )
+    display = str(
+        raw.get("display") or raw.get("summary") or raw.get("display_summary") or ""
+    ).strip()
+    if not display:
+        display = reference if len(reference) <= 80 else reference[:77] + "..."
+    revision = raw.get("revision") or raw.get("fingerprint") or raw.get("sha")
+    if revision is not None:
+        revision = str(revision).strip() or None
+    fingerprint = raw.get("fingerprint")
+    if fingerprint is not None:
+        fingerprint = str(fingerprint).strip() or None
+    if revision is None and fingerprint is not None:
+        revision = fingerprint
+
+    if kind == "path":
+        _validate_asset_path(reference, repo_root=repo_root)
+    elif kind == "url":
+        _validate_asset_url(reference)
+    elif kind in ("git_ref", "branch", "commit"):
+        _validate_git_ref_shape(reference, kind=kind)
+
+    # revision/fingerprint are persisted and rendered into immutable
+    # briefings, so they are scanned like every other asset field.
+    refuse_if_unsafe_answer(
+        "\n".join(
+            part for part in (display, reference, revision, fingerprint) if part
+        )
+    )
+
+    out: dict[str, Any] = {
+        "kind": kind,
+        "reference": reference,
+        "display": display,
+    }
+    if revision:
+        out["revision"] = revision
+    if fingerprint and fingerprint != revision:
+        out["fingerprint"] = fingerprint
+    return out
+
+
+def _validate_asset_path(reference: str, *, repo_root: Optional[Path] = None) -> None:
+    """Accept repo-relative paths; reject abs, escapes, missing, ignored, symlinks."""
+    if not reference or reference.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", reference):
+        raise ChartError(
+            "validation",
+            "asset_path_outside_repo",
+            f"Asset path must be repository-relative: {reference}",
+            details={"reference": reference},
+        )
+    if "\\" in reference:
+        raise ChartError(
+            "validation",
+            "asset_path_invalid",
+            f"Asset path must use forward slashes: {reference}",
+            details={"reference": reference},
+        )
+    # Normalize without resolving yet.
+    parts = Path(reference).parts
+    if ".." in parts or reference.startswith("./../"):
+        # Allow only if final resolved stays in repo - still reject explicit ..
+        # for clarity (symlink escape covered below).
+        pass
+    root = repo_root
+    if root is None:
+        try:
+            root = get_repo_root()
+        except Exception:
+            root = Path.cwd()
+    root = root.resolve()
+    candidate = (root / reference).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as e:
+        raise ChartError(
+            "validation",
+            "asset_path_outside_repo",
+            f"Asset path escapes repository: {reference}",
+            details={"reference": reference},
+        ) from e
+    # Symlink escape: any path component that is a symlink outside.
+    probe = root
+    for part in Path(reference).parts:
+        probe = probe / part
+        if probe.is_symlink():
+            target = probe.resolve()
+            try:
+                target.relative_to(root)
+            except ValueError as e:
+                raise ChartError(
+                    "validation",
+                    "asset_path_symlink_escape",
+                    f"Asset path symlink escapes repository: {reference}",
+                    details={"reference": reference},
+                ) from e
+    if not candidate.exists():
+        raise ChartError(
+            "validation",
+            "asset_path_missing",
+            f"Asset path does not exist: {reference}",
+            details={"reference": reference},
+        )
+    # Prefer the unresolved path for ignore check (git wants repo-relative).
+    rel = str(Path(*Path(reference).parts))
+    if _git_check_ignored(root, rel):
+        raise ChartError(
+            "validation",
+            "asset_path_ignored",
+            f"Asset path is gitignored: {reference}",
+            details={"reference": reference},
+        )
+
+
+def _validate_asset_url(reference: str) -> None:
+    """Approved HTTPS only; reject credentials, non-https, and redirect-as-id."""
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(reference)
+    except Exception as e:
+        raise ChartError(
+            "validation",
+            "asset_url_invalid",
+            f"Invalid asset URL: {reference}",
+            details={"reference": reference},
+        ) from e
+    if parsed.scheme.lower() != "https":
+        raise ChartError(
+            "validation",
+            "asset_url_not_https",
+            f"Asset URL must be https: {reference}",
+            details={"reference": reference},
+        )
+    if parsed.username or parsed.password:
+        raise ChartError(
+            "validation",
+            "asset_url_credentials",
+            "Asset URL must not carry credentials",
+            details={"reference": reference},
+        )
+    if "@" in (parsed.netloc or "") and parsed.username is None:
+        # user:pass@host form sometimes lands only in netloc.
+        raise ChartError(
+            "validation",
+            "asset_url_credentials",
+            "Asset URL must not carry credentials",
+            details={"reference": reference},
+        )
+    if not parsed.netloc:
+        raise ChartError(
+            "validation",
+            "asset_url_invalid",
+            f"Invalid asset URL host: {reference}",
+            details={"reference": reference},
+        )
+
+
+def _validate_git_ref_shape(reference: str, *, kind: str) -> None:
+    """Lightweight shape check for branch/commit/git_ref (no network)."""
+    if not reference or any(c.isspace() for c in reference):
+        raise ChartError(
+            "validation",
+            "invalid_git_ref",
+            f"Invalid {kind} reference: {reference!r}",
+            details={"kind": kind, "reference": reference},
+        )
+    if kind == "commit":
+        if not re.fullmatch(r"[0-9a-fA-F]{7,40}", reference):
+            raise ChartError(
+                "validation",
+                "invalid_commit_sha",
+                f"Commit reference must be a hex sha (7-40): {reference}",
+                details={"reference": reference},
+            )
+    if ".." in reference or reference.startswith("-"):
+        raise ChartError(
+            "validation",
+            "invalid_git_ref",
+            f"Invalid {kind} reference: {reference}",
+            details={"kind": kind, "reference": reference},
+        )
+
+
+def _asset_identity_key(asset: dict) -> tuple:
+    """Identity for idempotent attach: kind + reference + revision/fingerprint."""
+    return (
+        asset.get("kind"),
+        asset.get("reference"),
+        asset.get("revision") or asset.get("fingerprint") or "",
+    )
+
+
+def _assets_equivalent(a: dict, b: dict) -> bool:
+    """True when two assets are identical for idempotent retry."""
+    keys = ("kind", "reference", "display", "revision", "fingerprint")
+    for k in keys:
+        if (a.get(k) or None) != (b.get(k) or None):
+            return False
+    return True
+
+
+def _find_matching_asset(assets: list, candidate: dict) -> Optional[dict]:
+    """Return existing asset with same identity key, if any."""
+    key = _asset_identity_key(candidate)
+    for existing in assets:
+        if isinstance(existing, dict) and _asset_identity_key(existing) == key:
+            return existing
+    return None
+
+
+def _parse_assets_json(raw: Any, *, repo_root: Optional[Path] = None) -> list[dict]:
+    """Parse --assets json (list or {assets:[...]}) into normalized assets."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return []
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise ChartError(
+                "validation",
+                "assets_invalid_json",
+                f"--assets is not valid JSON: {e}",
+            ) from e
+    if isinstance(raw, dict) and "assets" in raw:
+        raw = raw["assets"]
+    if not isinstance(raw, list):
+        raise ChartError(
+            "validation",
+            "assets_not_list",
+            "--assets must be a JSON list of asset objects",
+        )
+    return [_normalize_asset_dict(item, repo_root=repo_root) for item in raw]
+
+
+def _render_ledger_line(
+    d_num: int,
+    gist: str,
+    link: str,
+    *,
+    superseded_by: Optional[str] = None,
+) -> str:
+    """One compact ledger bullet. Full answer never appears here."""
+    gist = re.sub(r"\s+", " ", (gist or "").strip()) or "(empty)"
+    # Bare local D-ID in ledger; record link carries chart path.
+    if superseded_by:
+        # Extract bare D form from full or bare id.
+        sup = superseded_by
+        m = re.search(r"D([1-9][0-9]*)$", sup, re.IGNORECASE)
+        sup_label = f"D{m.group(1)}" if m else sup
+        return (
+            f"- ~~**D{d_num}:**~~ {gist} -- superseded by **{sup_label}** "
+            f"-- [record]({link})"
+        )
+    return f"- **D{d_num}:** {gist} -- [record]({link})"
+
+
+def _ledger_section_body(lines: list[str]) -> str:
+    body = _CHART_LEDGER_COMMENT + "\n"
+    if lines:
+        body += "\n" + "\n".join(lines) + "\n"
+    else:
+        body += "\n"
+    return body
+
+
+def _extract_ledger_lines(md_text: str) -> list[str]:
+    """Extract existing decision bullet lines from ## Decisions."""
+    pattern = re.compile(
+        r"(^##\s+Decisions\s*\n)(.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    m = pattern.search(md_text)
+    if not m:
+        return []
+    section = m.group(2)
+    lines: list[str] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- ") and "**D" in stripped:
+            lines.append(stripped)
+    return lines
+
+
+def _ledger_line_d_num(line: str) -> Optional[int]:
+    m = re.search(r"\*\*D([1-9][0-9]*):\*\*", line)
+    if not m:
+        m = re.search(r"~~\*\*D([1-9][0-9]*):\*\*~~", line)
+    if not m:
+        return None
+    return int(m.group(1))
+
+
+def _apply_ledger_lines(md_text: str, lines: list[str]) -> str:
+    return _replace_chart_section(md_text, "Decisions", _ledger_section_body(lines))
+
+
+def _upsert_ledger_line(md_text: str, d_num: int, new_line: str) -> str:
+    lines = _extract_ledger_lines(md_text)
+    found = False
+    for i, line in enumerate(lines):
+        if _ledger_line_d_num(line) == d_num:
+            lines[i] = new_line
+            found = True
+            break
+    if not found:
+        lines.append(new_line)
+    # Stable order by D-number.
+    lines.sort(key=lambda ln: _ledger_line_d_num(ln) or 0)
+    return _apply_ledger_lines(md_text, lines)
+
+
+def _append_boundary_line(md_text: str, d_num: int, reason: str) -> str:
+    """Append one out-of-scope reason under ## Boundaries (no Decisions entry)."""
+    pattern = re.compile(
+        r"(^##\s+Boundaries\s*\n)(.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    reason = re.sub(r"\s+", " ", (reason or "").strip())
+    bullet = f"- **D{d_num}:** out of scope - {reason}"
+    m = pattern.search(md_text)
+    if not m:
+        if not md_text.endswith("\n"):
+            md_text += "\n"
+        return md_text + f"\n## Boundaries\n{bullet}\n"
+    existing = m.group(2)
+    # Idempotent: if same D-num boundary already present with same text, keep.
+    lines = [ln for ln in existing.splitlines() if ln.strip()]
+    for ln in lines:
+        if ln.strip().startswith(f"- **D{d_num}:**"):
+            if ln.strip() == bullet:
+                return md_text
+            # Replace conflicting boundary line for this D-ID.
+            lines = [
+                bullet if x.strip().startswith(f"- **D{d_num}:**") else x
+                for x in lines
+            ]
+            content = "\n".join(lines) + "\n"
+            return pattern.sub(
+                lambda mm, c=content: mm.group(1) + c, md_text, count=1
+            )
+    lines.append(bullet)
+    content = "\n".join(lines) + "\n"
+    return pattern.sub(lambda mm: mm.group(1) + content, md_text, count=1)
+
+
+def _depends_on_reverse_index(decisions: list[dict]) -> dict[str, list[str]]:
+    """Map premise D-ID -> list of decision ids that depend_on it."""
+    rev: dict[str, list[str]] = {}
+    for d in decisions:
+        if not isinstance(d, dict) or not d.get("id"):
+            continue
+        for dep in d.get("depends_on") or []:
+            if not isinstance(dep, str):
+                continue
+            rev.setdefault(dep, []).append(d["id"])
+    return rev
+
+
+def _depends_on_closure(
+    seeds: list[str], decisions: list[dict]
+) -> list[str]:
+    """Direct + transitive dependents via depends_on (excludes seeds)."""
+    rev = _depends_on_reverse_index(decisions)
+    seen: set[str] = set()
+    order: list[str] = []
+    stack = list(seeds)
+    seed_set = set(seeds)
+    while stack:
+        node = stack.pop()
+        for dep in rev.get(node) or []:
+            if dep in seed_set or dep in seen:
+                continue
+            seen.add(dep)
+            order.append(dep)
+            stack.append(dep)
+    # Stable by local number.
+    order.sort(key=lambda did: decision_local_number(did))
+    return order
+
+
+def _transition_note(
+    kind: str,
+    text: str,
+    *,
+    actor: Optional[str] = None,
+    **extra: Any,
+) -> dict:
+    note: dict[str, Any] = {
+        "at": now_iso(),
+        "kind": kind,
+        "text": text,
+    }
+    if actor:
+        note["actor"] = actor
+    for k, v in extra.items():
+        if v is not None:
+            note[k] = v
+    return note
+
+
+def _load_all_decision_sidecars(
+    flow_dir: Path, chart_id: str, decisions: list[dict]
+) -> dict[str, dict]:
+    """Load full decision sidecars keyed by canonical id."""
+    out: dict[str, dict] = {}
+    for d in decisions:
+        if not isinstance(d, dict) or not d.get("id"):
+            continue
+        did = d["id"]
+        n = decision_local_number(did)
+        out[did] = load_decision_sidecar(flow_dir, chart_id, n)
+    return out
+
+
+def attach_chart_asset(
+    flow_dir: Path,
+    did: str,
+    asset_raw: Any,
+    *,
+    repo_root: Optional[Path] = None,
+) -> dict:
+    """Idempotently attach a safe asset while the decision remains open.
+
+    Identical retries are no-ops. Conflicting reuse of the same identity with
+    different display/metadata is conflict. Attach never writes an answer or
+    closes the D-ID.
+    """
+    did = canonicalize_decision_id(did)
+    chart_id = did.rsplit(".", 1)[0]
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.attach-asset")
+    idx, entry = _find_decision_entry(chart, did)
+    if entry.get("status") != "open":
+        raise ChartError(
+            "invalid_state",
+            "decision_not_open",
+            f"Cannot attach-asset to {did}: status is {entry.get('status')}",
+            details={"id": did, "status": entry.get("status")},
+        )
+    if repo_root is None:
+        try:
+            repo_root = get_repo_root()
+        except Exception:
+            repo_root = flow_dir.parent
+    asset = _normalize_asset_dict(asset_raw, repo_root=repo_root)
+    d_num = decision_local_number(did)
+    full = load_decision_sidecar(flow_dir, chart_id, d_num)
+    assets = list(full.get("assets") or [])
+    existing = _find_matching_asset(assets, asset)
+    if existing is not None:
+        if _assets_equivalent(existing, asset):
+            return {
+                "id": did,
+                "asset": existing,
+                "assets": assets,
+                "status": full.get("status"),
+                "noop": True,
+                "record_path": full.get("record_path")
+                or decision_record_link(chart_id, d_num),
+            }
+        raise ChartError(
+            "conflict",
+            "asset_conflict",
+            f"Asset identity already attached to {did} with different metadata",
+            details={
+                "id": did,
+                "existing": existing,
+                "incoming": asset,
+            },
+        )
+    assets.append(asset)
+    full = dict(full)
+    full["assets"] = assets
+    full["updated_at"] = now_iso()
+    # Chart compact entry does not carry assets; leave chart.json unchanged
+    # except updated_at is not on chart for decisions. Touch decision only.
+    _, json_rel = decision_record_relpaths(chart_id, d_num)
+    # Still journal chart.json for recovery pairing when other ops expect it;
+    # content unchanged except we bump nothing - skip chart if no change.
+    mutations = [
+        (json_rel, "update", _sidecar_json(full)),
+    ]
+    run_chart_transaction(flow_dir, "chart.attach-asset", mutations)
+    return {
+        "id": did,
+        "asset": asset,
+        "assets": assets,
+        "status": full.get("status"),
+        "noop": False,
+        "record_path": full.get("record_path")
+        or decision_record_link(chart_id, d_num),
+    }
+
+
+def _parse_sharpen_file(path: Path) -> dict:
+    """Load resolve --sharpen-file JSON: decisions + remove_questions keys."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ChartError(
+            "io",
+            "sharpen_file_unreadable",
+            f"Cannot read --sharpen-file: {path} ({e})",
+            details={"path": str(path)},
+        ) from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ChartError(
+            "validation",
+            "sharpen_file_invalid_json",
+            f"--sharpen-file is not valid JSON: {e}",
+            details={"path": str(path)},
+        ) from e
+    if not isinstance(data, dict):
+        raise ChartError(
+            "validation",
+            "sharpen_file_invalid",
+            "--sharpen-file must be a JSON object",
+            details={"path": str(path)},
+        )
+    decisions = data.get("decisions")
+    if decisions is None:
+        decisions = []
+    if not isinstance(decisions, list):
+        raise ChartError(
+            "validation",
+            "sharpen_file_invalid_decisions",
+            "sharpen-file 'decisions' must be a list",
+        )
+    remove_keys = (
+        data.get("remove_questions")
+        or data.get("remove_parked")
+        or data.get("parked_removals")
+        or []
+    )
+    if not isinstance(remove_keys, list):
+        raise ChartError(
+            "validation",
+            "sharpen_file_invalid_removals",
+            "sharpen-file remove_questions must be a list of keys",
+        )
+    remove_keys = [str(k).strip() for k in remove_keys if str(k).strip()]
+    return {"decisions": decisions, "remove_questions": remove_keys}
+
+
+def resolve_chart_decision(
+    flow_dir: Path,
+    did: str,
+    answer: str,
+    *,
+    assets_raw: Any = None,
+    sharpen: Optional[dict] = None,
+    supersedes: Optional[list[str]] = None,
+    keep_dependents: bool = False,
+    repo_root: Optional[Path] = None,
+) -> dict:
+    """Resolve a decision: write answer once, close, ledger gist, cascades.
+
+    Legal transitions: open -> resolved. Identical retry is idempotent;
+    conflicting retry is invalid_state. Prototype requires >=1 safe asset.
+    """
+    did = canonicalize_decision_id(did)
+    chart_id = did.rsplit(".", 1)[0]
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.resolve")
+    idx, entry = _find_decision_entry(chart, did)
+    d_num = decision_local_number(did)
+    full = load_decision_sidecar(flow_dir, chart_id, d_num)
+    status = entry.get("status") or full.get("status") or "open"
+
+    # Claims are checked before any work: resolving a decision another actor
+    # holds is a conflict, never a silent bypass (cascade claim-clearing on
+    # dependents is the audited exception, not this path).
+    claimant = entry.get("claimed_by") or full.get("claimed_by")
+    if status == "open" and claimant and claimant != get_actor():
+        raise ChartError(
+            "conflict",
+            "claim_conflict",
+            f"Decision {did} is claimed by '{claimant}'; resolve requires the "
+            "claim owner (release-claim or --break-stale first)",
+            details={"id": did, "claimed_by": claimant, "actor": get_actor()},
+        )
+
+    answer_text = answer if answer is not None else ""
+    refuse_if_unsafe_answer(answer_text)
+    gist = answer_gist(answer_text)
+    if repo_root is None:
+        try:
+            repo_root = get_repo_root()
+        except Exception:
+            repo_root = flow_dir.parent
+    incoming_assets = _parse_assets_json(assets_raw, repo_root=repo_root)
+
+    # Idempotent identical retry on already-resolved.
+    if status == "resolved":
+        existing_answer = full.get("answer")
+        existing_gist = full.get("answer_gist") or answer_gist(
+            existing_answer if isinstance(existing_answer, str) else ""
+        )
+        same_answer = existing_answer == answer_text or (
+            isinstance(existing_answer, dict)
+            and existing_answer.get("text") == answer_text
+        )
+        if same_answer or (
+            isinstance(existing_answer, str) and existing_answer == answer_text
+        ):
+            # Also require matching supersedes set if provided.
+            existing_sup = list(full.get("supersedes") or [])
+            want_sup = [
+                canonicalize_decision_id(s, chart_id=chart_id)
+                for s in (supersedes or [])
+            ]
+            # A retry is identical only when its assets are a subset of the
+            # stored set - a new or changed asset is divergent evidence that
+            # can never be attached afterward (attach-asset refuses resolved
+            # decisions), so a silent no-op would drop it.
+            stored_assets = list(full.get("assets") or [])
+            divergent_assets = [
+                a.get("reference") or a.get("display") or a.get("kind")
+                for a in incoming_assets
+                if (
+                    (m := _find_matching_asset(stored_assets, a)) is None
+                    or not _assets_equivalent(m, a)
+                )
+            ]
+            if divergent_assets:
+                raise ChartError(
+                    "invalid_state",
+                    "decision_immutable",
+                    f"Decision {did} is already resolved; retry supplies "
+                    "new or changed assets and resolved decisions are "
+                    "immutable (evidence cannot be attached post-resolve)",
+                    details={
+                        "id": did,
+                        "status": status,
+                        "existing_gist": existing_gist,
+                        "divergent_assets": divergent_assets,
+                    },
+                )
+            # A retry is identical only when it carries NO sharpen content:
+            # resolve-time sharpening creates decisions and removes parked
+            # questions, none of which happened when this decision first
+            # resolved - a silent no-op would drop them. Post-resolve
+            # sharpening belongs to add-decision / wire-decision (and
+            # remove-question for parked cleanup).
+            sharpen_new = list((sharpen or {}).get("decisions") or [])
+            sharpen_removes = list(
+                (sharpen or {}).get("remove_questions") or []
+            )
+            if sharpen_new or sharpen_removes:
+                raise ChartError(
+                    "invalid_state",
+                    "decision_immutable",
+                    f"Decision {did} is already resolved; retry supplies "
+                    "sharpen content (new decisions or parked-question "
+                    "removals) that a no-op would silently ignore. Create "
+                    "follow-up decisions via add-decision/wire-decision "
+                    "and drop parked questions via remove-question.",
+                    details={
+                        "id": did,
+                        "status": status,
+                        "existing_gist": existing_gist,
+                        "ignored_sharpen": {
+                            "decisions": [
+                                (
+                                    d.get("title")
+                                    if isinstance(d, dict)
+                                    else str(d)
+                                )
+                                for d in sharpen_new
+                            ],
+                            "remove_questions": [
+                                str(k) for k in sharpen_removes
+                            ],
+                        },
+                    },
+                )
+            if sorted(existing_sup) == sorted(want_sup) or not want_sup:
+                return {
+                    "id": did,
+                    "status": "resolved",
+                    "answer_gist": existing_gist,
+                    "noop": True,
+                    "affected": [did],
+                    "record_path": full.get("record_path")
+                    or decision_record_link(chart_id, d_num),
+                    "ledger_line": None,
+                    "replacements": [],
+                    "sharpened": [],
+                    "removed_questions": [],
+                }
+        raise ChartError(
+            "invalid_state",
+            "decision_immutable",
+            f"Decision {did} is already resolved; answers are immutable "
+            "(identical retry is a no-op; conflicting retry is refused)",
+            details={
+                "id": did,
+                "status": status,
+                "existing_gist": existing_gist,
+            },
+        )
+    if status != "open":
+        raise ChartError(
+            "invalid_state",
+            "illegal_transition",
+            f"Cannot resolve {did}: legal transition is open->resolved "
+            f"(current status={status})",
+            details={"id": did, "status": status},
+        )
+
+    # Merge assets: existing + incoming; identity conflicts error.
+    assets = list(full.get("assets") or [])
+    for asset in incoming_assets:
+        existing = _find_matching_asset(assets, asset)
+        if existing is not None:
+            if not _assets_equivalent(existing, asset):
+                raise ChartError(
+                    "conflict",
+                    "asset_conflict",
+                    f"Asset identity already attached to {did} with different metadata",
+                    details={"id": did, "existing": existing, "incoming": asset},
+                )
+            continue
+        assets.append(asset)
+
+    dtype = (full.get("type") or entry.get("type") or "").strip().lower()
+    if dtype == "prototype" and not assets:
+        raise ChartError(
+            "validation",
+            "prototype_asset_required",
+            f"Prototype decision {did} cannot resolve without a persisted "
+            "safe artefact reference. attach-asset first, or pass --assets.",
+            details={"id": did, "type": "prototype"},
+        )
+
+    actor = get_actor()
+    ts = now_iso()
+    supersede_ids = [
+        canonicalize_decision_id(s, chart_id=chart_id)
+        for s in (supersedes or [])
+    ]
+    # Dedup while preserving order.
+    seen_sup: set[str] = set()
+    clean_sup: list[str] = []
+    for s in supersede_ids:
+        if s == did:
+            raise ChartError(
+                "invalid_graph",
+                "self_supersede",
+                f"Decision {did} cannot supersede itself",
+                details={"id": did},
+            )
+        if s not in seen_sup:
+            seen_sup.add(s)
+            clean_sup.append(s)
+    supersede_ids = clean_sup
+
+    # Working copies of chart decisions + full sidecars we will mutate.
+    chart_decs: list[dict] = [
+        dict(d) if isinstance(d, dict) else d
+        for d in (chart.get("decisions") or [])
+    ]
+    by_id: dict[str, dict] = {
+        d["id"]: d for d in chart_decs if isinstance(d, dict) and d.get("id")
+    }
+    full_by_id = _load_all_decision_sidecars(flow_dir, chart_id, chart_decs)
+
+    # Validate supersede targets exist and allow resolved->superseded or open->superseded.
+    for s in supersede_ids:
+        if s not in by_id:
+            raise ChartError(
+                "not_found",
+                "decision_not_found",
+                f"Supersede target not found: {s}",
+                details={"id": s},
+            )
+        st = by_id[s].get("status")
+        if st == "superseded":
+            # Idempotent if already superseded by this decision.
+            existing_by = (full_by_id.get(s) or {}).get("superseded_by")
+            if existing_by == did:
+                continue
+            raise ChartError(
+                "invalid_state",
+                "already_superseded",
+                f"Decision {s} is already superseded by {existing_by}",
+                details={"id": s, "superseded_by": existing_by},
+            )
+        if st not in ("open", "resolved"):
+            raise ChartError(
+                "invalid_state",
+                "illegal_transition",
+                f"Cannot supersede {s}: status is {st} "
+                "(legal: open|resolved -> superseded)",
+                details={"id": s, "status": st},
+            )
+        # Direct supersession of an OPEN target another actor holds is a
+        # conflict, matching the primary resolve path - the dependent cascade
+        # keeps its audited claim-clearing, but a named target is terminated
+        # outright and needs the claim owner (or an explicit stale break).
+        if st == "open":
+            s_claim = by_id[s].get("claimed_by") or (
+                full_by_id.get(s) or {}
+            ).get("claimed_by")
+            if s_claim and s_claim != actor:
+                raise ChartError(
+                    "conflict",
+                    "claim_conflict",
+                    f"Supersede target {s} is claimed by '{s_claim}'; "
+                    "superseding an open decision requires the claim owner "
+                    "(release-claim or --break-stale first)",
+                    details={"id": s, "claimed_by": s_claim, "actor": actor},
+                )
+
+    # --- Apply resolution to primary decision ---
+    primary = dict(full)
+    primary["status"] = "resolved"
+    primary["answer"] = answer_text
+    primary["answer_gist"] = gist
+    primary["assets"] = assets
+    primary["supersedes"] = list(supersede_ids)
+    primary["claimed_by"] = None
+    primary["claimed_at"] = None
+    primary["updated_at"] = ts
+    notes = list(primary.get("transition_notes") or [])
+    notes.append(
+        _transition_note(
+            "resolved",
+            f"resolved by {actor}",
+            actor=actor,
+            supersedes=list(supersede_ids),
+            keep_dependents=keep_dependents,
+        )
+    )
+    if keep_dependents and supersede_ids:
+        notes.append(
+            _transition_note(
+                "keep_dependents",
+                f"keep-dependents: cascade suppressed for supersession of "
+                f"{', '.join(supersede_ids)}",
+                actor=actor,
+                supersedes=list(supersede_ids),
+            )
+        )
+    primary["transition_notes"] = notes
+    full_by_id[did] = primary
+    by_id[did] = compact_decision_entry(primary)
+    # Preserve depends/blocked from compact after compact_decision_entry
+    by_id[did]["blocked_by"] = list(primary.get("blocked_by") or [])
+    by_id[did]["depends_on"] = list(primary.get("depends_on") or [])
+
+    affected: list[str] = [did]
+    replacements: list[dict] = []
+    cascade_open: list[str] = []
+    cascade_resolved: list[str] = []
+
+    # --- Supersede named decisions ---
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    if not md_path.is_file():
+        raise ChartError(
+            "io",
+            "chart_body_missing",
+            f"Chart body missing for {chart_id}",
+            details={"id": chart_id},
+        )
+    md_text = md_path.read_text(encoding="utf-8")
+    md_text = _upsert_ledger_line(
+        md_text,
+        d_num,
+        _render_ledger_line(
+            d_num, gist, decision_record_link(chart_id, d_num)
+        ),
+    )
+
+    for s in supersede_ids:
+        s_full = dict(full_by_id[s])
+        s_num = decision_local_number(s)
+        if s_full.get("status") == "superseded" and s_full.get("superseded_by") == did:
+            affected.append(s)
+            continue
+        old_gist = s_full.get("answer_gist") or answer_gist(
+            s_full.get("answer") if isinstance(s_full.get("answer"), str) else ""
+        )
+        if not old_gist or old_gist == "(empty)":
+            old_gist = (s_full.get("title") or s)[:CHART_LEDGER_GIST_MAX]
+        s_full["status"] = "superseded"
+        s_full["superseded_by"] = did
+        s_full["claimed_by"] = None
+        s_full["claimed_at"] = None
+        s_full["updated_at"] = ts
+        s_notes = list(s_full.get("transition_notes") or [])
+        s_notes.append(
+            _transition_note(
+                "superseded",
+                f"superseded by {did}",
+                actor=actor,
+                superseded_by=did,
+            )
+        )
+        s_full["transition_notes"] = s_notes
+        full_by_id[s] = s_full
+        by_id[s] = compact_decision_entry(s_full)
+        by_id[s]["blocked_by"] = list(s_full.get("blocked_by") or [])
+        by_id[s]["depends_on"] = list(s_full.get("depends_on") or [])
+        md_text = _upsert_ledger_line(
+            md_text,
+            s_num,
+            _render_ledger_line(
+                s_num,
+                old_gist,
+                decision_record_link(chart_id, s_num),
+                superseded_by=did,
+            ),
+        )
+        if s not in affected:
+            affected.append(s)
+
+    # --- Dependent cascade (unless --keep-dependents) ---
+    dependent_ids = _depends_on_closure(supersede_ids, list(by_id.values()))
+    # Exclude the resolving decision itself if it somehow depends.
+    dependent_ids = [d for d in dependent_ids if d != did]
+
+    if keep_dependents:
+        for dep in dependent_ids:
+            dep_full = dict(full_by_id[dep])
+            dep_notes = list(dep_full.get("transition_notes") or [])
+            dep_notes.append(
+                _transition_note(
+                    "keep_dependents",
+                    f"keep-dependents: premise supersession by {did} of "
+                    f"{', '.join(supersede_ids)} did not cascade",
+                    actor=actor,
+                    superseded_by_chain=list(supersede_ids),
+                    via=did,
+                )
+            )
+            dep_full["transition_notes"] = dep_notes
+            dep_full["updated_at"] = ts
+            full_by_id[dep] = dep_full
+            if dep not in affected:
+                affected.append(dep)
+    else:
+        next_n = _next_decision_number({"decisions": list(by_id.values())})
+        # Replacement premises must follow the supersession: a replacement
+        # copying depends_on=[D1] after D4 superseded D1 would be invisible
+        # to _depends_on_closure when D4 is itself later superseded, leaving
+        # its resolved conclusion standing on an invalidated premise. Map
+        # every superseded id to its superseding decision (named targets ->
+        # the resolving decision; cascade-superseded dependents -> their own
+        # replacement, added as replacements are minted below).
+        premise_rewrite: dict[str, str] = {s: did for s in supersede_ids}
+        for dep in dependent_ids:
+            dep_entry = by_id[dep]
+            dep_full = dict(full_by_id[dep])
+            dep_status = dep_entry.get("status") or dep_full.get("status")
+            if dep_status == "open":
+                # Stay open; lose claim; premise-invalidated note.
+                prior_claim = dep_full.get("claimed_by")
+                dep_full["claimed_by"] = None
+                dep_full["claimed_at"] = None
+                dep_notes = list(dep_full.get("transition_notes") or [])
+                dep_notes.append(
+                    _transition_note(
+                        "premise_invalidated",
+                        f"premise invalidated: {did} superseded "
+                        f"{', '.join(supersede_ids)}; claim cleared"
+                        + (f" (was {prior_claim})" if prior_claim else ""),
+                        actor=actor,
+                        via=did,
+                        superseded=list(supersede_ids),
+                        prior_claimed_by=prior_claim,
+                    )
+                )
+                dep_full["transition_notes"] = dep_notes
+                dep_full["updated_at"] = ts
+                # status remains open
+                full_by_id[dep] = dep_full
+                by_id[dep] = compact_decision_entry(dep_full)
+                by_id[dep]["blocked_by"] = list(dep_full.get("blocked_by") or [])
+                by_id[dep]["depends_on"] = list(dep_full.get("depends_on") or [])
+                cascade_open.append(dep)
+                if dep not in affected:
+                    affected.append(dep)
+            elif dep_status == "resolved":
+                # Immutable: create replacement D-ID that supersedes this one.
+                rep_n = next_n
+                next_n += 1
+                rep_id = f"{chart_id}.D{rep_n}"
+                reason = (
+                    f"re-evaluate after {did} superseded "
+                    f"{', '.join(supersede_ids)} "
+                    f"(replacement for {dep})"
+                )
+                question = (
+                    dep_full.get("question")
+                    or dep_full.get("title")
+                    or dep_entry.get("title")
+                    or ""
+                )
+                rebound: dict[str, str] = {}
+                rep_deps: list[str] = []
+                for p in dep_full.get("depends_on") or []:
+                    target = premise_rewrite.get(p, p)
+                    if target != p:
+                        rebound[p] = target
+                    if target not in rep_deps:
+                        rep_deps.append(target)
+                rep_full = decision_sidecar_data(
+                    chart_id,
+                    rep_n,
+                    dep_full.get("title") or dep_entry.get("title") or f"Re-evaluate {dep}",
+                    dep_full.get("type") or dep_entry.get("type") or "research",
+                    dep_full.get("attendance")
+                    or dep_entry.get("attendance")
+                    or "unattended",
+                    question,
+                    blocked_by=list(dep_full.get("blocked_by") or []),
+                    depends_on=rep_deps,
+                    created=ts,
+                )
+                rep_full["supersedes"] = [dep]
+                rep_full["transition_notes"] = [
+                    _transition_note(
+                        "replacement_after_supersession",
+                        reason
+                        + (
+                            "; premises rebound: "
+                            + ", ".join(
+                                f"{o}->{n}" for o, n in rebound.items()
+                            )
+                            if rebound
+                            else ""
+                        ),
+                        actor=actor,
+                        replaces=dep,
+                        via=did,
+                        superseded_premises=list(supersede_ids),
+                        rebound_premises=rebound or None,
+                    )
+                ]
+                premise_rewrite[dep] = rep_id
+                # Supersede the old resolved dependent.
+                old_gist = dep_full.get("answer_gist") or answer_gist(
+                    dep_full.get("answer")
+                    if isinstance(dep_full.get("answer"), str)
+                    else ""
+                )
+                dep_full["status"] = "superseded"
+                dep_full["superseded_by"] = rep_id
+                dep_full["claimed_by"] = None
+                dep_full["claimed_at"] = None
+                dep_full["updated_at"] = ts
+                dep_notes = list(dep_full.get("transition_notes") or [])
+                dep_notes.append(
+                    _transition_note(
+                        "superseded",
+                        f"superseded by replacement {rep_id} after premise "
+                        f"invalidation via {did}",
+                        actor=actor,
+                        superseded_by=rep_id,
+                        via=did,
+                    )
+                )
+                dep_full["transition_notes"] = dep_notes
+                full_by_id[dep] = dep_full
+                full_by_id[rep_id] = rep_full
+                by_id[dep] = compact_decision_entry(dep_full)
+                by_id[dep]["blocked_by"] = list(dep_full.get("blocked_by") or [])
+                by_id[dep]["depends_on"] = list(dep_full.get("depends_on") or [])
+                by_id[rep_id] = compact_decision_entry(rep_full)
+                by_id[rep_id]["blocked_by"] = list(rep_full.get("blocked_by") or [])
+                by_id[rep_id]["depends_on"] = list(rep_full.get("depends_on") or [])
+                # Strike old dependent ledger line; no ledger line for open replacement.
+                dep_num = decision_local_number(dep)
+                md_text = _upsert_ledger_line(
+                    md_text,
+                    dep_num,
+                    _render_ledger_line(
+                        dep_num,
+                        old_gist or (dep_full.get("title") or dep),
+                        decision_record_link(chart_id, dep_num),
+                        superseded_by=rep_id,
+                    ),
+                )
+                replacements.append(
+                    {
+                        "id": rep_id,
+                        "replaces": dep,
+                        "title": rep_full.get("title"),
+                        "reason": reason,
+                        "record_path": rep_full.get("record_path"),
+                    }
+                )
+                cascade_resolved.append(dep)
+                if dep not in affected:
+                    affected.append(dep)
+                affected.append(rep_id)
+            else:
+                # superseded / out-of-scope: still report as affected for visibility.
+                if dep not in affected:
+                    affected.append(dep)
+
+    # --- Sharpening: new decisions + parked removals ---
+    sharpened: list[dict] = []
+    removed_questions: list[dict] = []
+    parked = list(chart.get("parked_questions") or [])
+    if sharpen:
+        remove_keys = list(sharpen.get("remove_questions") or [])
+        raw_new = list(sharpen.get("decisions") or [])
+        # Removals first (by key); absent key fails unless already gone in this txn.
+        for key in remove_keys:
+            found = None
+            new_parked = []
+            for e in parked:
+                if isinstance(e, dict) and e.get("key") == key:
+                    found = e
+                else:
+                    new_parked.append(e)
+            if found is None:
+                raise ChartError(
+                    "not_found",
+                    "parked_question_not_found",
+                    f"Parked question key not found for sharpening removal: {key}",
+                    details={"key": key, "chart_id": chart_id},
+                )
+            parked = new_parked
+            removed_questions.append(
+                {"key": key, "body": found.get("body")}
+            )
+        # Allocate new decisions after any cascade replacements.
+        next_n = _next_decision_number({"decisions": list(by_id.values())})
+        # First pass provisional for edge binding among new decisions.
+        local_map: dict[str, str] = {}
+        built_new: list[dict] = []
+        for i, raw in enumerate(raw_new, start=1):
+            if not isinstance(raw, dict):
+                raise ChartError(
+                    "validation",
+                    "invalid_sharpen_decision",
+                    f"Sharpen decision #{i} must be an object",
+                    details={"index": i},
+                )
+            title = (raw.get("title") or "").strip()
+            if not title:
+                raise ChartError(
+                    "validation",
+                    "title_required",
+                    f"Sharpen decision #{i} requires a title",
+                    details={"index": i},
+                )
+            dtype_new = (raw.get("type") or "").strip().lower()
+            att_new = derive_decision_attendance(dtype_new, raw.get("attendance"))
+            question = str(
+                raw.get("question") or raw.get("body") or title
+            ).strip()
+            # R20/R48: sharpening CREATES decisions - same refusal as
+            # initial-map/add-decision, before D-ID allocation.
+            refuse_if_unsafe_prose(
+                f"{title}\n{question}", field=f"Sharpen decision #{i}"
+            )
+            n = next_n
+            next_n += 1
+            new_id = f"{chart_id}.D{n}"
+            local_map[str(i)] = new_id
+            local_map[f"d{i}"] = new_id
+            local_map[f"D{i}".lower()] = new_id
+            local_map[new_id.lower()] = new_id
+            if raw.get("id"):
+                local_map[str(raw["id"]).strip().lower()] = new_id
+            built_new.append(
+                {
+                    "n": n,
+                    "id": new_id,
+                    "title": title,
+                    "type": dtype_new,
+                    "attendance": att_new,
+                    "question": question,
+                    "raw_blocked_by": raw.get("blocked_by") or [],
+                    "raw_depends_on": raw.get("depends_on") or [],
+                }
+            )
+        # Existing decisions also available as edge targets via their ids.
+        for existing_id in by_id:
+            local_map[existing_id.lower()] = existing_id
+            bare = existing_id.rsplit(".", 1)[-1].lower()
+            local_map[bare] = existing_id
+            if bare.startswith("d"):
+                local_map[bare[1:]] = existing_id
+
+        for b in built_new:
+            blocked = _normalize_edge_refs(
+                list(b["raw_blocked_by"]),
+                chart_id,
+                field_name="blocked_by",
+                local_map=local_map,
+            )
+            depends = _normalize_edge_refs(
+                list(b["raw_depends_on"]),
+                chart_id,
+                field_name="depends_on",
+                local_map=local_map,
+            )
+            new_full = decision_sidecar_data(
+                chart_id,
+                b["n"],
+                b["title"],
+                b["type"],
+                b["attendance"],
+                b["question"],
+                blocked_by=blocked,
+                depends_on=depends,
+                created=ts,
+            )
+            new_full["transition_notes"] = [
+                _transition_note(
+                    "sharpened",
+                    f"created by resolve sharpening of {did}",
+                    actor=actor,
+                    via=did,
+                )
+            ]
+            full_by_id[b["id"]] = new_full
+            by_id[b["id"]] = compact_decision_entry(new_full)
+            by_id[b["id"]]["blocked_by"] = blocked
+            by_id[b["id"]]["depends_on"] = depends
+            sharpened.append(
+                {
+                    "id": b["id"],
+                    "title": b["title"],
+                    "type": b["type"],
+                    "attendance": b["attendance"],
+                    "record_path": new_full.get("record_path"),
+                }
+            )
+            if b["id"] not in affected:
+                affected.append(b["id"])
+
+        md_text = _apply_parked_to_chart_body(md_text, parked)
+
+    # Validate entire post-resolution graph before publish.
+    graph_list = list(by_id.values())
+    validate_chart_graph(graph_list, chart_id=chart_id)
+
+    # Rebuild ordered decisions list: preserve original order, append new at end.
+    ordered_ids: list[str] = []
+    seen_ord: set[str] = set()
+    for d in chart.get("decisions") or []:
+        if isinstance(d, dict) and d.get("id") and d["id"] in by_id:
+            ordered_ids.append(d["id"])
+            seen_ord.add(d["id"])
+    for did_k in sorted(by_id.keys(), key=lambda x: decision_local_number(x)):
+        if did_k not in seen_ord:
+            ordered_ids.append(did_k)
+            seen_ord.add(did_k)
+
+    new_chart = dict(chart)
+    new_chart["decisions"] = [by_id[i] for i in ordered_ids]
+    new_chart["parked_questions"] = parked
+    new_chart["updated_at"] = ts
+
+    # Later supersession marks affected produced_specs links stale (fn-135.3)
+    # without rewriting briefings or linked specs.
+    superseded_for_links: list[str] = list(supersede_ids) + list(cascade_resolved)
+    new_links, staled_links = mark_produced_specs_stale_for_superseded(
+        new_chart,
+        superseded_for_links,
+        via=did,
+        actor=actor,
+        ts=ts,
+    )
+    if staled_links:
+        new_chart["produced_specs"] = new_links
+
+    # Build mutations: chart pair + every touched decision sidecar (+ md creates).
+    mutations: list[tuple[str, str, str]] = [
+        (f"{chart_id}.json", "update", _sidecar_json(new_chart)),
+        (f"{chart_id}.md", "update", md_text),
+    ]
+    original_ids = {
+        d["id"]
+        for d in (chart.get("decisions") or [])
+        if isinstance(d, dict) and d.get("id")
+    }
+    for did_k, full_k in full_by_id.items():
+        n = decision_local_number(did_k)
+        md_rel, json_rel = decision_record_relpaths(chart_id, n)
+        if did_k in original_ids:
+            # Update json; md body (question) stays for existing.
+            mutations.append((json_rel, "update", _sidecar_json(full_k)))
+        else:
+            mutations.append(
+                (md_rel, "create", decision_body_text(full_k.get("question") or ""))
+            )
+            mutations.append((json_rel, "create", _sidecar_json(full_k)))
+
+    run_chart_transaction(flow_dir, "chart.resolve", mutations)
+
+    # Dedup affected preserving order.
+    aff_out: list[str] = []
+    aff_seen: set[str] = set()
+    for a in affected:
+        if a not in aff_seen:
+            aff_seen.add(a)
+            aff_out.append(a)
+
+    return {
+        "id": did,
+        "status": "resolved",
+        "answer_gist": gist,
+        "noop": False,
+        "assets": assets,
+        "supersedes": list(supersede_ids),
+        "keep_dependents": keep_dependents,
+        "affected": aff_out,
+        "cascade_open": cascade_open,
+        "cascade_resolved": cascade_resolved,
+        "replacements": replacements,
+        "sharpened": sharpened,
+        "removed_questions": removed_questions,
+        "staled_links": staled_links,
+        "record_path": primary.get("record_path")
+        or decision_record_link(chart_id, d_num),
+        "ledger_line": _render_ledger_line(
+            d_num, gist, decision_record_link(chart_id, d_num)
+        ),
+    }
+
+
+def out_of_scope_chart_decision(
+    flow_dir: Path,
+    did: str,
+    reason: str,
+) -> dict:
+    """Close open decision as out-of-scope; write ## Boundaries line only."""
+    did = canonicalize_decision_id(did)
+    chart_id = did.rsplit(".", 1)[0]
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    _require_chart_mutable(chart, command="chart.out-of-scope")
+    idx, entry = _find_decision_entry(chart, did)
+    d_num = decision_local_number(did)
+    full = load_decision_sidecar(flow_dir, chart_id, d_num)
+    status = entry.get("status") or full.get("status")
+    claimant = entry.get("claimed_by") or full.get("claimed_by")
+    if status == "open" and claimant and claimant != get_actor():
+        raise ChartError(
+            "conflict",
+            "claim_conflict",
+            f"Decision {did} is claimed by '{claimant}'; out-of-scope requires "
+            "the claim owner (release-claim or --break-stale first)",
+            details={"id": did, "claimed_by": claimant, "actor": get_actor()},
+        )
+    reason_text = (reason or "").strip()
+    if not reason_text:
+        raise ChartError(
+            "validation",
+            "reason_required",
+            "out-of-scope requires --reason",
+            details={"id": did},
+        )
+    refuse_if_unsafe_answer(reason_text)
+
+    if status == "out-of-scope":
+        existing_reason = full.get("out_of_scope_reason") or ""
+        if existing_reason == reason_text:
+            return {
+                "id": did,
+                "status": "out-of-scope",
+                "reason": reason_text,
+                "noop": True,
+                "record_path": full.get("record_path")
+                or decision_record_link(chart_id, d_num),
+            }
+        raise ChartError(
+            "invalid_state",
+            "decision_immutable",
+            f"Decision {did} is already out-of-scope with a different reason",
+            details={"id": did, "existing_reason": existing_reason},
+        )
+    if status != "open":
+        raise ChartError(
+            "invalid_state",
+            "illegal_transition",
+            f"Cannot mark {did} out-of-scope: status is {status} "
+            "(legal: open -> out-of-scope)",
+            details={"id": did, "status": status},
+        )
+
+    actor = get_actor()
+    ts = now_iso()
+    full = dict(full)
+    full["status"] = "out-of-scope"
+    full["out_of_scope_reason"] = reason_text
+    full["claimed_by"] = None
+    full["claimed_at"] = None
+    full["updated_at"] = ts
+    notes = list(full.get("transition_notes") or [])
+    notes.append(
+        _transition_note(
+            "out_of_scope",
+            f"out-of-scope: {reason_text}",
+            actor=actor,
+            reason=reason_text,
+        )
+    )
+    full["transition_notes"] = notes
+
+    entry = dict(entry)
+    entry["status"] = "out-of-scope"
+    entry["claimed_by"] = None
+    entry["claimed_at"] = None
+    proposed = list(chart.get("decisions") or [])
+    proposed[idx] = entry
+    chart = dict(chart)
+    chart["decisions"] = proposed
+    chart["updated_at"] = ts
+
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    if not md_path.is_file():
+        raise ChartError(
+            "io",
+            "chart_body_missing",
+            f"Chart body missing for {chart_id}",
+            details={"id": chart_id},
+        )
+    md_text = md_path.read_text(encoding="utf-8")
+    # No ## Decisions ledger entry for out-of-scope.
+    md_text = _append_boundary_line(md_text, d_num, reason_text)
+
+    md_rel, json_rel = decision_record_relpaths(chart_id, d_num)
+    mutations = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+        (f"{chart_id}.md", "update", md_text),
+        (json_rel, "update", _sidecar_json(full)),
+    ]
+    run_chart_transaction(flow_dir, "chart.out-of-scope", mutations)
+    return {
+        "id": did,
+        "status": "out-of-scope",
+        "reason": reason_text,
+        "noop": False,
+        "record_path": full.get("record_path")
+        or decision_record_link(chart_id, d_num),
+    }
+
+
+def abandon_chart(flow_dir: Path, chart_id: str, reason: str) -> dict:
+    """Mark chart abandoned with reason; nothing deleted. Terminal for mutations."""
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    reason_text = (reason or "").strip()
+    if not reason_text:
+        raise ChartError(
+            "validation",
+            "reason_required",
+            "abandon requires --reason",
+            details={"id": chart_id},
+        )
+    refuse_if_unsafe_answer(reason_text)
+    status = chart.get("status") or "open"
+    if status == "abandoned":
+        existing = chart.get("abandon_reason") or ""
+        if existing == reason_text:
+            return {
+                "id": chart_id,
+                "status": "abandoned",
+                "reason": reason_text,
+                "noop": True,
+            }
+        raise ChartError(
+            "invalid_state",
+            "chart_already_abandoned",
+            f"Chart {chart_id} is already abandoned with a different reason",
+            details={"id": chart_id, "existing_reason": existing},
+        )
+    if status != "open":
+        raise ChartError(
+            "invalid_state",
+            "illegal_transition",
+            f"Cannot abandon chart {chart_id}: status is {status} "
+            "(legal: open -> abandoned)",
+            details={"id": chart_id, "status": status},
+        )
+
+    actor = get_actor()
+    ts = now_iso()
+    chart = dict(chart)
+    chart["status"] = "abandoned"
+    chart["abandon_reason"] = reason_text
+    chart["abandoned_at"] = ts
+    chart["abandoned_by"] = actor
+    chart["updated_at"] = ts
+    events = list(chart.get("claim_events") or [])
+    events.append(
+        {
+            "kind": "abandon",
+            "actor": actor,
+            "reason": reason_text,
+            "timestamp": ts,
+            "chart": chart_id,
+        }
+    )
+    chart["claim_events"] = events
+
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    mutations: list[tuple[str, str, str]] = [
+        (f"{chart_id}.json", "update", _sidecar_json(chart)),
+    ]
+    if md_path.is_file():
+        # Preserve body; abandon does not rewrite map sections.
+        mutations.append(
+            (f"{chart_id}.md", "update", md_path.read_text(encoding="utf-8"))
+        )
+    run_chart_transaction(flow_dir, "chart.abandon", mutations)
+    return {
+        "id": chart_id,
+        "status": "abandoned",
+        "reason": reason_text,
+        "abandoned_at": ts,
+        "abandoned_by": actor,
+        "noop": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Chart briefing, reopen, link-spec (fn-135.3)
+# ---------------------------------------------------------------------------
+
+
+def chart_decision_revision(chart: dict) -> str:
+    """Stable content revision of decision/outcome state (excludes briefings).
+
+    Fingerprint input for briefing versioning: identical decision/outcome/parked
+    state yields the same revision; briefings[] and produced_specs[] are not
+    part of this hash so a re-emit of the same proposal on the same map is
+    idempotent.
+    """
+    decisions: list[dict] = []
+    for d in chart.get("decisions") or []:
+        if not isinstance(d, dict) or not d.get("id"):
+            continue
+        decisions.append(
+            {
+                "id": d.get("id"),
+                "status": d.get("status"),
+                "title": d.get("title"),
+                "type": d.get("type"),
+                "blocked_by": list(d.get("blocked_by") or []),
+                "depends_on": list(d.get("depends_on") or []),
+            }
+        )
+    decisions.sort(key=lambda x: str(x.get("id") or ""))
+    parked: list[dict] = []
+    for p in chart.get("parked_questions") or []:
+        if not isinstance(p, dict):
+            continue
+        parked.append(
+            {
+                "key": p.get("key"),
+                "body": p.get("body"),
+            }
+        )
+    parked.sort(key=lambda x: str(x.get("key") or ""))
+    # Deliberately exclude chart.status so a final-briefing -> done
+    # transition does not break identical fingerprint retries.
+    blob = json.dumps(
+        {
+            "id": chart.get("id"),
+            "outcome": chart.get("outcome"),
+            "title": chart.get("title"),
+            "decisions": decisions,
+            "parked_questions": parked,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _briefing_fingerprint(
+    chart_revision: str,
+    normalized_proposal: dict,
+    evidence_digest: str = "",
+    reopened_at: Optional[str] = None,
+) -> str:
+    payload: dict = {
+        "chart_revision": chart_revision,
+        "proposal": normalized_proposal,
+        "evidence": evidence_digest,
+    }
+    # A reopen is a new epoch: `chart reopen` stales every briefing but changes
+    # nothing else this blob hashes, so without the epoch a post-reopen re-brief
+    # over an untouched ledger matches the stale briefing and gets echoed back
+    # instead of minting one (fn-154).
+    #
+    # `reopened_at` and NOT `chart.status`: status also flips on the
+    # final-briefing -> done transition, which chart_decision_revision
+    # deliberately excludes (see the comment above its blob) so an identical
+    # retry against a done chart stays idempotent. `reopened_at` moves on
+    # reopen and only on reopen, which is exactly the epoch we want.
+    #
+    # The key is OMITTED - not hashed as null - when the chart has never been
+    # reopened, so every chart written before this change hashes byte-identically
+    # and its stored B-IDs keep matching an identical retry after the upgrade.
+    if reopened_at:
+        payload["reopened_at"] = reopened_at
+    blob = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _briefing_evidence_digest(all_decision_briefs: list[dict]) -> str:
+    """Digest of the full decision data rendered into briefings.
+
+    chart_decision_revision covers only the compact chart entries; briefing
+    bodies also render sidecar-loaded data (assets, gists, supersession).
+    Hashing the loaded briefs makes the fingerprint change when e.g.
+    attach-asset adds evidence between otherwise identical emissions.
+    """
+    blob = json.dumps(
+        all_decision_briefs,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _next_briefing_id(briefings: list) -> str:
+    max_n = 0
+    for b in briefings:
+        if not isinstance(b, dict):
+            continue
+        bid = str(b.get("id") or "")
+        m = re.fullmatch(r"B([1-9][0-9]*)", bid)
+        if m:
+            max_n = max(max_n, int(m.group(1)))
+    return f"B{max_n + 1}"
+
+
+def _parse_briefing_proposal_file(
+    path: Path,
+    chart_id: str,
+) -> dict:
+    """Load agent-confirmed proposal JSON: clusters + shared_context."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ChartError(
+            "io",
+            "proposal_unreadable",
+            f"Cannot read proposal file: {path} ({e})",
+            details={"path": str(path)},
+        ) from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ChartError(
+            "validation",
+            "proposal_invalid_json",
+            f"Proposal file is not valid JSON: {e}",
+            details={"path": str(path)},
+        ) from e
+    if not isinstance(data, dict):
+        raise ChartError(
+            "validation",
+            "proposal_invalid",
+            "Proposal file must be a JSON object",
+            details={"path": str(path)},
+        )
+    raw_clusters = data.get("clusters")
+    if not isinstance(raw_clusters, list) or not raw_clusters:
+        raise ChartError(
+            "validation",
+            "proposal_clusters_required",
+            "Proposal requires a non-empty clusters array",
+            details={"path": str(path)},
+        )
+    shared_raw = data.get("shared_context") or data.get("shared_context_ids") or []
+    if not isinstance(shared_raw, list):
+        raise ChartError(
+            "validation",
+            "proposal_shared_invalid",
+            "shared_context must be an array of D-IDs",
+            details={"path": str(path)},
+        )
+    shared: list[str] = []
+    shared_seen: set[str] = set()
+    for s in shared_raw:
+        did = canonicalize_decision_id(str(s), chart_id=chart_id)
+        if did not in shared_seen:
+            shared_seen.add(did)
+            shared.append(did)
+
+    clusters: list[dict] = []
+    # Keyed by casefolded key: keys become briefing file names, and on
+    # case-insensitive filesystems (default macOS/Windows) 'api' and 'API'
+    # stage the same artifact path - one body silently overwriting the other.
+    keys_seen: dict[str, str] = {}
+    for i, raw_c in enumerate(raw_clusters, start=1):
+        if not isinstance(raw_c, dict):
+            raise ChartError(
+                "validation",
+                "proposal_cluster_invalid",
+                f"Cluster #{i} must be an object",
+                details={"index": i},
+            )
+        key = str(
+            raw_c.get("key")
+            or raw_c.get("id")
+            or raw_c.get("cluster")
+            or i
+        ).strip()
+        if not key:
+            key = str(i)
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", key):
+            raise ChartError(
+                "validation",
+                "proposal_cluster_key_invalid",
+                f"Cluster key '{key}' is invalid - keys become briefing "
+                "file names and must match [A-Za-z0-9_-]{1,64}",
+                details={"key": key, "index": i, "path": str(path)},
+            )
+        if re.fullmatch(r"[Bb][0-9]+", key):
+            raise ChartError(
+                "validation",
+                "proposal_cluster_key_reserved",
+                f"Cluster key '{key}' is reserved - the B<n> namespace "
+                "names versioned briefing indexes "
+                f"({chart_id}-briefing-B<n>.md)",
+                details={"key": key, "index": i, "path": str(path)},
+            )
+        folded = key.casefold()
+        if folded in keys_seen:
+            prior = keys_seen[folded]
+            suffix = (
+                f" (collides with '{prior}' after case folding - "
+                "case-insensitive filesystems map both keys to the same "
+                "briefing file)"
+                if prior != key
+                else ""
+            )
+            raise ChartError(
+                "validation",
+                "proposal_duplicate_cluster_key",
+                f"Duplicate cluster key '{key}' in proposal - every cluster "
+                "needs a distinct key" + suffix,
+                details={
+                    "key": key,
+                    "collides_with": prior,
+                    "index": i,
+                    "path": str(path),
+                },
+            )
+        keys_seen[folded] = key
+        rationale = (raw_c.get("rationale") or raw_c.get("reason") or "").strip()
+        if not rationale:
+            raise ChartError(
+                "validation",
+                "proposal_rationale_required",
+                f"Cluster '{key}' requires a one-line rationale",
+                details={"key": key, "index": i},
+            )
+        refuse_if_unsafe_answer(rationale)
+        raw_decs = raw_c.get("decisions") or raw_c.get("decision_ids") or []
+        if not isinstance(raw_decs, list) or not raw_decs:
+            raise ChartError(
+                "validation",
+                "proposal_cluster_empty",
+                f"Cluster '{key}' requires a non-empty decisions array",
+                details={"key": key, "index": i},
+            )
+        decs: list[str] = []
+        dec_seen: set[str] = set()
+        for d in raw_decs:
+            did = canonicalize_decision_id(str(d), chart_id=chart_id)
+            if did not in dec_seen:
+                dec_seen.add(did)
+                decs.append(did)
+        clusters.append(
+            {
+                "key": key,
+                "rationale": rationale,
+                "decisions": decs,
+            }
+        )
+    return {"clusters": clusters, "shared_context": shared}
+
+
+def _normalize_briefing_proposal(proposal: dict) -> dict:
+    """Deterministic proposal form for fingerprinting (sorted membership)."""
+    clusters_out = []
+    for c in proposal.get("clusters") or []:
+        clusters_out.append(
+            {
+                "key": str(c.get("key")),
+                "rationale": str(c.get("rationale") or "").strip(),
+                "decisions": sorted(c.get("decisions") or []),
+            }
+        )
+    # Sort by key so reordering alone does not mint a new B-ID.
+    clusters_out.sort(key=lambda x: x["key"])
+    return {
+        "clusters": clusters_out,
+        "shared_context": sorted(proposal.get("shared_context") or []),
+    }
+
+
+def _decision_status(chart: dict, did: str) -> Optional[str]:
+    for d in chart.get("decisions") or []:
+        if isinstance(d, dict) and d.get("id") == did:
+            return d.get("status")
+    return None
+
+
+def _validate_briefing_membership(
+    chart: dict,
+    proposal: dict,
+    chart_id: str,
+) -> None:
+    """Require complete non-conflicting membership of all RESOLVED decisions.
+
+    Shared-context D-IDs may appear in multiple clusters and must be listed
+    under shared_context. Non-shared membership is exclusive.
+    """
+    resolved_ids: set[str] = set()
+    all_ids: set[str] = set()
+    for d in chart.get("decisions") or []:
+        if not isinstance(d, dict) or not d.get("id"):
+            continue
+        all_ids.add(d["id"])
+        if d.get("status") == "resolved":
+            resolved_ids.add(d["id"])
+
+    shared = set(proposal.get("shared_context") or [])
+    for sid in shared:
+        if sid not in all_ids:
+            raise ChartError(
+                "validation",
+                "shared_context_unknown",
+                f"shared_context D-ID not on chart: {sid}",
+                details={"id": sid, "chart_id": chart_id},
+            )
+        if sid not in resolved_ids:
+            raise ChartError(
+                "validation",
+                "shared_context_not_resolved",
+                f"shared_context D-ID is not resolved: {sid}",
+                details={"id": sid, "status": _decision_status(chart, sid)},
+            )
+
+    membership: dict[str, list[str]] = {}
+    for c in proposal.get("clusters") or []:
+        key = c["key"]
+        for did in c.get("decisions") or []:
+            if did not in all_ids:
+                raise ChartError(
+                    "validation",
+                    "proposal_decision_unknown",
+                    f"Cluster '{key}' references unknown D-ID: {did}",
+                    details={"key": key, "id": did},
+                )
+            if did not in resolved_ids:
+                raise ChartError(
+                    "validation",
+                    "proposal_decision_not_resolved",
+                    f"Cluster '{key}' includes non-resolved D-ID: {did}",
+                    details={
+                        "key": key,
+                        "id": did,
+                        "status": _decision_status(chart, did),
+                    },
+                )
+            membership.setdefault(did, []).append(key)
+
+    for did, keys in membership.items():
+        if len(keys) > 1 and did not in shared:
+            raise ChartError(
+                "validation",
+                "proposal_membership_conflict",
+                f"D-ID {did} appears in clusters {keys} but is not listed "
+                "in shared_context",
+                details={"id": did, "clusters": keys},
+            )
+
+    covered = set(membership.keys())
+    missing = sorted(resolved_ids - covered)
+    if missing:
+        raise ChartError(
+            "validation",
+            "proposal_incomplete_membership",
+            "Proposal does not cover all resolved decisions: "
+            + ", ".join(missing),
+            details={"missing": missing, "chart_id": chart_id},
+        )
+
+    for sid in shared:
+        if sid not in covered:
+            raise ChartError(
+                "validation",
+                "shared_context_not_in_cluster",
+                f"shared_context D-ID {sid} is not a member of any cluster",
+                details={"id": sid},
+            )
+
+
+def _extract_chart_section_body(md_text: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"(^##\s+{re.escape(heading)}\s*\n)(.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    m = pattern.search(md_text or "")
+    if not m:
+        return ""
+    return m.group(2).strip()
+
+
+def _unresolved_briefing_inventory(chart: dict) -> dict:
+    """List every open/blocked/claimed decision and parked question for drafts."""
+    completion = chart_completion_predicate(chart)
+    decisions = chart.get("decisions") or []
+    status_index = {
+        d["id"]: d.get("status")
+        for d in decisions
+        if isinstance(d, dict) and d.get("id")
+    }
+    open_items: list[dict] = []
+    for d in decisions:
+        if not isinstance(d, dict) or d.get("status") != "open":
+            continue
+        did = d.get("id")
+        kind = "open"
+        if _decision_is_blocked(d, status_index):
+            kind = "blocked"
+        if _decision_is_claimed(d):
+            kind = "claimed" if kind == "open" else f"{kind}+claimed"
+        open_items.append(
+            {
+                "id": did,
+                "title": d.get("title"),
+                "kind": kind,
+                "claimed_by": d.get("claimed_by"),
+            }
+        )
+    parked = []
+    for p in chart.get("parked_questions") or []:
+        if isinstance(p, dict):
+            parked.append({"key": p.get("key"), "body": p.get("body")})
+    return {
+        "open_decisions": open_items,
+        "parked_questions": parked,
+        "stuck_reasons": list(completion.get("stuck_reasons") or []),
+        "briefable": bool(completion.get("briefable")),
+    }
+
+
+def _load_decision_briefs(
+    flow_dir: Path, chart_id: str, dids: list[str]
+) -> list[dict]:
+    out: list[dict] = []
+    for did in dids:
+        n = decision_local_number(did)
+        try:
+            full = load_decision_sidecar(flow_dir, chart_id, n)
+        except ChartError:
+            full = {"id": did, "title": did, "status": "unknown"}
+        gist = full.get("answer_gist")
+        if not gist and isinstance(full.get("answer"), str):
+            gist = answer_gist(full["answer"])
+        out.append(
+            {
+                "id": did,
+                "title": full.get("title") or did,
+                "status": full.get("status"),
+                "gist": gist or "",
+                "record_path": full.get("record_path")
+                or decision_record_link(chart_id, n),
+                "superseded_by": full.get("superseded_by"),
+                "assets": list(full.get("assets") or []),
+            }
+        )
+    return out
+
+
+def _asset_revision_suffix(asset: dict) -> str:
+    """Pin a mutable reference (path/branch/url) to its evidence version.
+
+    Briefings are immutable; without the stored revision/fingerprint they
+    could not identify which version of the referenced content supported
+    the decision once the reference moves.
+    """
+    rev = asset.get("revision") or asset.get("fingerprint")
+    return f" @ {rev}" if rev else ""
+
+
+def _render_briefing_index_md(
+    chart: dict,
+    *,
+    briefing_id: str,
+    status: str,
+    md_text: str,
+    clusters: list[dict],
+    shared_context: list[str],
+    unresolved: Optional[dict],
+    all_decision_briefs: list[dict],
+) -> str:
+    chart_id = chart.get("id") or "?"
+    title = chart.get("title") or chart_id
+    outcome = chart.get("outcome") or ""
+    lines: list[str] = [
+        f"# {chart_id} briefing {briefing_id}",
+        "",
+        f"**Briefing:** {briefing_id}",
+        f"**Status:** {status}",
+        f"**Chart:** {chart_id} - {title}",
+        f"**Chart status:** {chart.get('status')}",
+        "",
+        "## Outcome",
+        "",
+        outcome.strip() or "(none)",
+        "",
+    ]
+    # Grounding facts (R52) travel with the briefing: capture reads the
+    # briefing artifacts, not the original chart body.
+    chart_notes = _extract_chart_section_body(md_text, "Notes")
+    if chart_notes:
+        lines.extend(["## Notes", "", chart_notes, ""])
+    lines.extend(["## Decisions", ""])
+    resolved = [d for d in all_decision_briefs if d.get("status") == "resolved"]
+    superseded = [
+        d for d in all_decision_briefs if d.get("status") == "superseded"
+    ]
+    if resolved:
+        for d in resolved:
+            lines.append(
+                f"- **{d['id']}:** {d.get('title')} - {d.get('gist') or '(no gist)'} "
+                f"- [record]({d.get('record_path')})"
+            )
+    else:
+        lines.append("(no resolved decisions)")
+    lines.extend(["", "## Superseded decisions", ""])
+    if superseded:
+        for d in superseded:
+            lines.append(
+                f"- ~~**{d['id']}:**~~ {d.get('title')} - {d.get('gist') or ''} "
+                f"- superseded by **{d.get('superseded_by') or '?'}** "
+                f"- [record]({d.get('record_path')})"
+            )
+    else:
+        lines.append("(none)")
+    ledger = _extract_chart_section_body(md_text, "Decisions")
+    if ledger:
+        lines.extend(["", "## Ledger (chart)", "", ledger, ""])
+    boundaries = _extract_chart_section_body(md_text, "Boundaries")
+    lines.extend(["## Boundaries", "", boundaries or "(none)", ""])
+    lines.extend(["## Assets", ""])
+    any_asset = False
+    for d in all_decision_briefs:
+        for a in d.get("assets") or []:
+            if not isinstance(a, dict):
+                continue
+            any_asset = True
+            lines.append(
+                f"- **{d['id']}:** {a.get('kind')} `{a.get('reference')}`"
+                f"{_asset_revision_suffix(a)} "
+                f"- {a.get('display') or ''}"
+            )
+    if not any_asset:
+        lines.append("(none)")
+    lines.extend(["", "## Clusters", ""])
+    for c in clusters:
+        lines.append(
+            f"- **cluster {c['key']}:** {c.get('rationale')} "
+            f"- decisions: {', '.join(c.get('decisions') or [])}"
+        )
+    lines.extend(["", "## Shared context", ""])
+    if shared_context:
+        for sid in shared_context:
+            lines.append(f"- {sid}")
+    else:
+        lines.append("(none)")
+    if status == "draft" and unresolved is not None:
+        lines.extend(
+            [
+                "",
+                "## DRAFT - unresolved inventory",
+                "",
+                "This briefing is **draft-only**. It is not capture-ready. "
+                "A forced draft can never be promoted to final.",
+                "",
+            ]
+        )
+        for item in unresolved.get("open_decisions") or []:
+            lines.append(
+                f"- open decision **{item.get('id')}** ({item.get('kind')}): "
+                f"{item.get('title') or ''}"
+                + (
+                    f" claimed_by={item.get('claimed_by')}"
+                    if item.get("claimed_by")
+                    else ""
+                )
+            )
+        for p in unresolved.get("parked_questions") or []:
+            lines.append(
+                f"- parked question `{p.get('key')}`: {p.get('body') or ''}"
+            )
+        if unresolved.get("stuck_reasons"):
+            lines.extend(["", "Stuck reasons:", ""])
+            for r in unresolved["stuck_reasons"]:
+                lines.append(f"- {r}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_cluster_briefing_md(
+    chart: dict,
+    *,
+    briefing_id: str,
+    status: str,
+    cluster: dict,
+    shared_context: list[str],
+    cluster_briefs: list[dict],
+    shared_briefs: list[dict],
+) -> str:
+    chart_id = chart.get("id") or "?"
+    outcome = chart.get("outcome") or ""
+    key = cluster.get("key")
+    lines: list[str] = [
+        f"# {chart_id} briefing {briefing_id} cluster {key}",
+        "",
+        f"**Briefing:** {briefing_id}",
+        f"**Status:** {status}",
+        f"**Cluster:** {key}",
+        f"**Rationale:** {cluster.get('rationale')}",
+        f"**Chart:** {chart_id}",
+        "",
+        "## Outcome",
+        "",
+        outcome.strip() or "(none)",
+        "",
+        "## Cluster decisions",
+        "",
+    ]
+    for d in cluster_briefs:
+        lines.append(
+            f"- **{d['id']}:** {d.get('title')} - {d.get('gist') or '(no gist)'} "
+            f"- [record]({d.get('record_path')})"
+        )
+        for a in d.get("assets") or []:
+            if isinstance(a, dict):
+                lines.append(
+                    f"  - asset: {a.get('kind')} `{a.get('reference')}`"
+                    f"{_asset_revision_suffix(a)} "
+                    f"- {a.get('display') or ''}"
+                )
+    lines.extend(["", "## Shared context", ""])
+    if shared_briefs:
+        lines.append(
+            "Shared-context D-IDs are attributable evidence for this cluster "
+            "but are not duplicated acceptance requirements by default."
+        )
+        lines.append("")
+        for d in shared_briefs:
+            lines.append(
+                f"- **{d['id']}:** {d.get('title')} - {d.get('gist') or ''} "
+                f"- [record]({d.get('record_path')})"
+            )
+    else:
+        lines.append("(none)")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def emit_chart_briefing(
+    flow_dir: Path,
+    chart_id: str,
+    proposal_path: Path,
+    *,
+    force: bool = False,
+) -> dict:
+    """Validate confirmed proposal and emit immutable versioned briefing.
+
+    No clustering algorithm: agent supplies the proposal; flowctl validates
+    and publishes. First non-draft briefing transitions open->done atomically.
+    """
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    status = chart.get("status") or "open"
+    proposal = _parse_briefing_proposal_file(proposal_path, chart_id)
+    normalized = _normalize_briefing_proposal(proposal)
+    _validate_briefing_membership(chart, proposal, chart_id)
+
+    completion = chart_completion_predicate(chart)
+    unresolved = _unresolved_briefing_inventory(chart)
+    if not completion["briefable"] and not force:
+        raise ChartError(
+            "invalid_state",
+            "chart_not_briefable",
+            f"Chart {chart_id} is not briefable: "
+            + "; ".join(completion.get("stuck_reasons") or ["open work remains"]),
+            details={
+                "id": chart_id,
+                "stuck_reasons": completion.get("stuck_reasons"),
+                "open_count": completion.get("open_count"),
+                "parked_count": completion.get("parked_count"),
+                "blocked_open_ids": completion.get("blocked_open_ids"),
+                "claimed_open_ids": completion.get("claimed_open_ids"),
+            },
+        )
+
+    # Forced incomplete charts are draft-only; complete charts are always final
+    # (force on a complete chart is a no-op force).
+    if force and not completion["briefable"]:
+        briefing_status = "draft"
+    else:
+        briefing_status = "final"
+
+    all_dids = [
+        d["id"]
+        for d in (chart.get("decisions") or [])
+        if isinstance(d, dict) and d.get("id")
+    ]
+    all_briefs = _load_decision_briefs(flow_dir, chart_id, all_dids)
+
+    chart_rev = chart_decision_revision(chart)
+    reopened_at = chart.get("reopened_at")
+    evidence_digest = _briefing_evidence_digest(all_briefs)
+    fingerprint = _briefing_fingerprint(
+        chart_rev,
+        normalized,
+        evidence_digest=evidence_digest,
+        reopened_at=reopened_at,
+    )
+
+    # A chart that was reopened AND re-briefed by a pre-fix binary carries a
+    # live briefing whose stored hash has no epoch in it. Matching only the
+    # epoch-aware fingerprint would make that briefing unreachable on upgrade:
+    # the retry finds nothing and dies on the now-done chart. So the epoch-free
+    # hash stays acceptable - but only for a NON-stale briefing, and since every
+    # reopen stales every briefing, a non-stale one can only have been minted in
+    # the current epoch. A stale legacy match is precisely the defect this task
+    # closes and is refused by the guard below.
+    accepted_fingerprints = {fingerprint}
+    if reopened_at:
+        accepted_fingerprints.add(
+            _briefing_fingerprint(
+                chart_rev, normalized, evidence_digest=evidence_digest
+            )
+        )
+
+    existing = list(chart.get("briefings") or [])
+    for b in existing:
+        if not isinstance(b, dict):
+            continue
+        # Set membership hashes its left operand, so an unhashable stored value
+        # (a JSON array or object in a hand-edited or externally produced
+        # sidecar - load_chart_sidecar validates the root object only) would
+        # raise TypeError here and escape as a bare traceback instead of the
+        # versioned error envelope. Every accepted fingerprint is a sha256
+        # hexdigest, so a non-string is simply not a match - which is exactly
+        # how the equality comparison this set replaced already behaved.
+        stored_fingerprint = b.get("fingerprint")
+        if not isinstance(stored_fingerprint, str):
+            continue
+        if stored_fingerprint in accepted_fingerprints:
+            # Never hand back a stale briefing as the idempotent answer: it is
+            # superseded by definition and has no valid reading as "the
+            # requested outcome". The reopen epoch above makes a stale match
+            # unreachable through the CLI, but a sidecar written by a pre-fix
+            # binary or edited by hand can still present one - so the invariant
+            # is enforced where briefings are read, not only where they are
+            # written. Fall through to the ordinary emission path (which mints
+            # B(n+1)), or, on a done|abandoned chart, to the guard below that
+            # names the remedy.
+            if b.get("status") == "stale":
+                continue
+            return {
+                "id": chart_id,
+                "briefing_id": b.get("id"),
+                "status": b.get("status"),
+                # The matched briefing's own hash, which is what identifies it
+                # on disk. Identical to `fingerprint` on every ordinary match;
+                # on a legacy match it is the epoch-free hash actually stored.
+                "fingerprint": b.get("fingerprint"),
+                "noop": True,
+                "chart_status": chart.get("status"),
+                "clusters": b.get("clusters") or [],
+                "paths": b.get("paths") or {},
+            }
+
+    if status in ("done", "abandoned"):
+        raise ChartError(
+            "invalid_state",
+            "chart_not_open",
+            f"Chart {chart_id} is {status}; new briefings require "
+            "chart reopen --reason (identical fingerprint retries still work)",
+            details={"id": chart_id, "status": status},
+        )
+
+    briefing_id = _next_briefing_id(existing)
+    actor = get_actor()
+    ts = now_iso()
+
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    md_text = md_path.read_text(encoding="utf-8") if md_path.is_file() else ""
+
+    clusters_meta: list[dict] = []
+    cluster_paths: dict[str, str] = {}
+    mutations: list[tuple[str, str, str]] = []
+
+    index_body = _render_briefing_index_md(
+        chart,
+        briefing_id=briefing_id,
+        status=briefing_status,
+        md_text=md_text,
+        clusters=proposal["clusters"],
+        shared_context=list(proposal.get("shared_context") or []),
+        unresolved=unresolved if briefing_status == "draft" else None,
+        all_decision_briefs=all_briefs,
+    )
+    # R41/R45: each B-ID gets an immutable per-version artifact; the fixed
+    # fn-N-briefing[-<cluster>].md paths are always-latest convenience copies
+    # rewritten on every emission. Recorded metadata points at the versioned
+    # copies so B1's paths still carry B1 content after B2 is emitted.
+    index_rel = f"{chart_id}-briefing.md"
+    version_index_rel = f"{chart_id}-briefing-{briefing_id}.md"
+    for rel in (version_index_rel, index_rel):
+        p = charts_dir(flow_dir) / rel
+        mutations.append((rel, "update" if p.is_file() else "create", index_body))
+
+    n_clusters = len(proposal["clusters"])
+    shared_ids = list(proposal.get("shared_context") or [])
+    shared_briefs = _load_decision_briefs(flow_dir, chart_id, shared_ids)
+
+    if n_clusters > 1:
+        for c in proposal["clusters"]:
+            key = str(c["key"])
+            c_briefs = _load_decision_briefs(
+                flow_dir, chart_id, list(c.get("decisions") or [])
+            )
+            c_body = _render_cluster_briefing_md(
+                chart,
+                briefing_id=briefing_id,
+                status=briefing_status,
+                cluster=c,
+                shared_context=shared_ids,
+                cluster_briefs=c_briefs,
+                shared_briefs=shared_briefs,
+            )
+            c_rel = f"{chart_id}-briefing-{key}.md"
+            version_c_rel = f"{chart_id}-briefing-{briefing_id}-{key}.md"
+            for rel in (version_c_rel, c_rel):
+                p = charts_dir(flow_dir) / rel
+                mutations.append(
+                    (rel, "update" if p.is_file() else "create", c_body)
+                )
+            cluster_paths[key] = f".flow/charts/{version_c_rel}"
+            clusters_meta.append(
+                {
+                    "key": key,
+                    "rationale": c.get("rationale"),
+                    "decisions": list(c.get("decisions") or []),
+                    "path": f".flow/charts/{version_c_rel}",
+                    "latest_path": f".flow/charts/{c_rel}",
+                }
+            )
+    else:
+        c0 = proposal["clusters"][0]
+        clusters_meta.append(
+            {
+                "key": str(c0["key"]),
+                "rationale": c0.get("rationale"),
+                "decisions": list(c0.get("decisions") or []),
+                "path": f".flow/charts/{version_index_rel}",
+                "latest_path": f".flow/charts/{index_rel}",
+            }
+        )
+
+    new_chart = dict(chart)
+    briefing_rec = {
+        "id": briefing_id,
+        "fingerprint": fingerprint,
+        "status": briefing_status,
+        "created": ts,
+        "created_by": actor,
+        "chart_revision": chart_rev,
+        "clusters": clusters_meta,
+        "shared_context": shared_ids,
+        "paths": {
+            "index": f".flow/charts/{version_index_rel}",
+            "latest_index": f".flow/charts/{index_rel}",
+            **{f"cluster_{k}": v for k, v in cluster_paths.items()},
+        },
+        "force": bool(force and briefing_status == "draft"),
+    }
+    new_briefings = list(existing) + [briefing_rec]
+    new_chart["briefings"] = new_briefings
+    new_chart["updated_at"] = ts
+
+    transitioned_done = False
+    if briefing_status == "final" and status == "open":
+        prior_final = any(
+            isinstance(b, dict) and b.get("status") == "final"
+            for b in existing
+        )
+        if not prior_final:
+            new_chart["status"] = "done"
+            new_chart["done_at"] = ts
+            new_chart["done_by"] = actor
+            new_chart["done_via_briefing"] = briefing_id
+            transitioned_done = True
+            events = list(new_chart.get("claim_events") or [])
+            events.append(
+                {
+                    "kind": "briefing_done",
+                    "actor": actor,
+                    "briefing": briefing_id,
+                    "timestamp": ts,
+                    "chart": chart_id,
+                }
+            )
+            new_chart["claim_events"] = events
+
+    mutations.insert(
+        0, (f"{chart_id}.json", "update", _sidecar_json(new_chart))
+    )
+    if md_path.is_file():
+        mutations.insert(1, (f"{chart_id}.md", "update", md_text))
+
+    # Belt-and-braces after reserved-key validation: generated relpaths must
+    # be pairwise distinct - a collision would stage one path twice and let a
+    # cluster body overwrite the immutable versioned index. Compared after
+    # case folding: case-insensitive filesystems (default macOS/Windows)
+    # treat 'api' and 'API' as the same path.
+    rels = [m[0] for m in mutations]
+    folded_rels = [r.casefold() for r in rels]
+    if len(set(folded_rels)) != len(folded_rels):
+        dupes = sorted(
+            {r for r in rels if folded_rels.count(r.casefold()) > 1}
+        )
+        raise ChartError(
+            "validation",
+            "briefing_path_collision",
+            "Briefing artifact paths collide: " + ", ".join(dupes),
+            details={"paths": dupes, "briefing_id": briefing_id},
+        )
+
+    run_chart_transaction(flow_dir, "chart.briefing", mutations)
+
+    result = {
+        "id": chart_id,
+        "briefing_id": briefing_id,
+        "status": briefing_status,
+        "fingerprint": fingerprint,
+        "noop": False,
+        "chart_status": new_chart.get("status"),
+        "transitioned_done": transitioned_done,
+        "clusters": clusters_meta,
+        "shared_context": shared_ids,
+        "paths": briefing_rec["paths"],
+        "unresolved": unresolved if briefing_status == "draft" else None,
+    }
+    # fn-154: say what this invocation did when it supersedes stale predecessors
+    # (the post-reopen case). PRESENCE is the discriminator - a consumer keys on
+    # the field existing - so the key is omitted, never emitted empty, on every
+    # other path: idempotent retries, first emissions, and error envelopes stay
+    # byte-identical to what they were before this change.
+    #
+    # Not named `outcome`: that term is already bound to the chart's stated goal
+    # (`chart create --outcome`, the `## Outcome` heading).
+    #
+    # This reports the invocation, it does NOT replace per-briefing `status` in
+    # the sidecar, which stays the single source of truth for capture-readiness.
+    superseded_stale = [
+        str(b["id"])
+        for b in existing
+        if isinstance(b, dict) and b.get("status") == "stale" and b.get("id")
+    ]
+    if superseded_stale:
+        result["supersedes_stale"] = superseded_stale
+    return result
+
+
+def reopen_chart(flow_dir: Path, chart_id: str, reason: str) -> dict:
+    """Transition done|abandoned -> open; stale all briefings and produced_specs."""
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    reason_text = (reason or "").strip()
+    if not reason_text:
+        raise ChartError(
+            "validation",
+            "reason_required",
+            "reopen requires --reason",
+            details={"id": chart_id},
+        )
+    refuse_if_unsafe_answer(reason_text)
+    status = chart.get("status") or "open"
+    if status == "open":
+        raise ChartError(
+            "invalid_state",
+            "chart_already_open",
+            f"Chart {chart_id} is already open",
+            details={"id": chart_id, "status": status},
+        )
+    if status not in ("done", "abandoned"):
+        raise ChartError(
+            "invalid_state",
+            "illegal_transition",
+            f"Cannot reopen chart {chart_id}: status is {status} "
+            "(legal: done|abandoned -> open)",
+            details={"id": chart_id, "status": status},
+        )
+
+    actor = get_actor()
+    ts = now_iso()
+    new_chart = dict(chart)
+    new_chart["status"] = "open"
+    new_chart["reopened_at"] = ts
+    new_chart["reopened_by"] = actor
+    new_chart["reopen_reason"] = reason_text
+    new_chart["updated_at"] = ts
+
+    staled_briefings: list[str] = []
+    briefings = []
+    for b in chart.get("briefings") or []:
+        if not isinstance(b, dict):
+            continue
+        nb = dict(b)
+        if nb.get("status") != "stale":
+            nb["status"] = "stale"
+            nb["staled_at"] = ts
+            nb["stale_reason"] = f"chart reopened: {reason_text}"
+            staled_briefings.append(str(nb.get("id") or "?"))
+        briefings.append(nb)
+    new_chart["briefings"] = briefings
+
+    staled_links: list[dict] = []
+    links = []
+    for link in chart.get("produced_specs") or []:
+        if not isinstance(link, dict):
+            continue
+        nl = dict(link)
+        if nl.get("status") != "stale":
+            nl["status"] = "stale"
+            nl["staled_at"] = ts
+            nl["stale_note"] = f"chart reopened: {reason_text}"
+            staled_links.append(
+                {
+                    "briefing": nl.get("briefing"),
+                    "cluster": nl.get("cluster"),
+                    "spec": nl.get("spec"),
+                }
+            )
+        links.append(nl)
+    new_chart["produced_specs"] = links
+
+    events = list(new_chart.get("claim_events") or [])
+    events.append(
+        {
+            "kind": "reopen",
+            "actor": actor,
+            "reason": reason_text,
+            "timestamp": ts,
+            "chart": chart_id,
+            "prior_status": status,
+            "staled_briefings": staled_briefings,
+            "staled_links": staled_links,
+        }
+    )
+    new_chart["claim_events"] = events
+
+    mutations: list[tuple[str, str, str]] = [
+        (f"{chart_id}.json", "update", _sidecar_json(new_chart)),
+    ]
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    if md_path.is_file():
+        mutations.append(
+            (f"{chart_id}.md", "update", md_path.read_text(encoding="utf-8"))
+        )
+    run_chart_transaction(flow_dir, "chart.reopen", mutations)
+    return {
+        "id": chart_id,
+        "status": "open",
+        "prior_status": status,
+        "reason": reason_text,
+        "reopened_at": ts,
+        "reopened_by": actor,
+        "staled_briefings": staled_briefings,
+        "staled_links": staled_links,
+        "noop": False,
+    }
+
+
+def _produced_spec_identity(
+    briefing: str, cluster: Optional[str], spec: str
+) -> tuple[str, Optional[str], str]:
+    return (str(briefing), str(cluster) if cluster is not None else None, str(spec))
+
+
+def link_chart_spec(
+    flow_dir: Path,
+    chart_id: str,
+    *,
+    briefing: str,
+    spec: str,
+    decisions: list[str],
+    cluster: Optional[str] = None,
+) -> dict:
+    """Idempotently record a successful capture handoff in produced_specs[].
+
+    Stable identity: briefing + cluster + spec. Identical retry is a no-op.
+    """
+    chart_id = canonicalize_chart_id(chart_id)
+    chart = load_chart_sidecar(flow_dir, chart_id)
+    briefing_id = (briefing or "").strip()
+    if not re.fullmatch(r"B[1-9][0-9]*", briefing_id):
+        raise ChartError(
+            "validation",
+            "invalid_briefing_id",
+            f"Invalid briefing id '{briefing}' (expected B1, B2, ...)",
+            details={"briefing": briefing},
+        )
+    spec_id = (spec or "").strip()
+    if not spec_id:
+        raise ChartError(
+            "validation",
+            "spec_required",
+            "link-spec requires --spec",
+            details={"chart_id": chart_id},
+        )
+    briefings = chart.get("briefings") or []
+    brief_rec = None
+    for b in briefings:
+        if isinstance(b, dict) and b.get("id") == briefing_id:
+            brief_rec = b
+            break
+    if brief_rec is None:
+        raise ChartError(
+            "not_found",
+            "briefing_not_found",
+            f"Briefing {briefing_id} not found on chart {chart_id}",
+            details={"id": chart_id, "briefing": briefing_id},
+        )
+
+    cluster_key = (
+        str(cluster).strip()
+        if cluster is not None and str(cluster).strip()
+        else None
+    )
+    decs: list[str] = []
+    seen: set[str] = set()
+    for raw in decisions or []:
+        did = canonicalize_decision_id(str(raw), chart_id=chart_id)
+        if did not in seen:
+            seen.add(did)
+            decs.append(did)
+    # A link without decision provenance is untrustworthy AND unmaintainable:
+    # later supersession staling matches on decision membership, so an empty
+    # set can never be marked stale. Validated before the identity/no-op path.
+    if not decs:
+        raise ChartError(
+            "validation",
+            "link_decisions_required",
+            "link-spec requires at least one decision id (--decisions)",
+            details={"id": chart_id, "briefing": briefing_id, "spec": spec_id},
+        )
+
+    identity = _produced_spec_identity(briefing_id, cluster_key, spec_id)
+    existing_links = list(chart.get("produced_specs") or [])
+    matched_link: Optional[dict] = None
+    for link in existing_links:
+        if not isinstance(link, dict):
+            continue
+        lid = _produced_spec_identity(
+            str(link.get("briefing") or ""),
+            str(link["cluster"]) if link.get("cluster") is not None else None,
+            str(link.get("spec") or ""),
+        )
+        if lid == identity:
+            matched_link = link
+            break
+    # Identical retry (same identity AND set-equal canonical decisions) is a
+    # no-op. A changed decision set on the same identity is NOT: silently
+    # keeping the stored set would freeze stale provenance, so supersession
+    # staling could never match the corrected D-IDs. Set-mismatch handling
+    # happens below, AFTER membership validation, so unknown ids fail as
+    # validation rather than conflict.
+    if matched_link is not None and (
+        set(matched_link.get("decisions") or []) == set(decs)
+    ):
+        return {
+            "id": chart_id,
+            "briefing": briefing_id,
+            "cluster": cluster_key,
+            "spec": spec_id,
+            "decisions": list(matched_link.get("decisions") or decs),
+            "status": matched_link.get("status") or "linked",
+            "noop": True,
+            "link": matched_link,
+        }
+
+    # R50: a durable link must only cite evidence the named briefing actually
+    # carries. When the briefing has clusters metadata, --cluster MUST name
+    # one of its keys (a typo silently validated against the briefing-wide
+    # union would persist a nonexistent cluster identity); the matching
+    # cluster's decisions plus shared_context are then the allowed set.
+    # Without --cluster, validate against the union across the briefing's
+    # clusters. Runs after the identity no-op check so identical retries of
+    # historical links stay no-ops.
+    allowed: set[str] = set(brief_rec.get("shared_context") or [])
+    matched_cluster = None
+    cluster_keys: list[str] = []
+    for c in brief_rec.get("clusters") or []:
+        if not isinstance(c, dict):
+            continue
+        if c.get("key") is not None:
+            cluster_keys.append(str(c.get("key")))
+        if cluster_key is not None and str(c.get("key")) == cluster_key:
+            matched_cluster = c
+        allowed.update(c.get("decisions") or [])
+    if cluster_key is not None and cluster_keys and matched_cluster is None:
+        raise ChartError(
+            "validation",
+            "link_unknown_cluster",
+            f"Cluster '{cluster_key}' not found on briefing {briefing_id}; "
+            "valid clusters: " + ", ".join(cluster_keys),
+            details={
+                "id": chart_id,
+                "briefing": briefing_id,
+                "cluster": cluster_key,
+                "valid_clusters": cluster_keys,
+            },
+        )
+    if matched_cluster is not None:
+        allowed = set(brief_rec.get("shared_context") or [])
+        allowed.update(matched_cluster.get("decisions") or [])
+    unknown = sorted(d for d in decs if d not in allowed)
+    if unknown:
+        scope = (
+            f"cluster '{cluster_key}' of briefing {briefing_id}"
+            if matched_cluster is not None
+            else f"briefing {briefing_id}"
+        )
+        raise ChartError(
+            "validation",
+            "link_decisions_not_in_briefing",
+            f"D-ID(s) not part of {scope}: " + ", ".join(unknown),
+            details={
+                "id": chart_id,
+                "briefing": briefing_id,
+                "cluster": cluster_key,
+                "unknown": unknown,
+                "allowed": sorted(allowed),
+            },
+        )
+
+    if matched_link is not None:
+        stored = sorted(set(matched_link.get("decisions") or []))
+        raise ChartError(
+            "conflict",
+            "link_decisions_mismatch",
+            f"Link {briefing_id}"
+            + (f"/{cluster_key}" if cluster_key is not None else "")
+            + f" -> {spec_id} already exists with a different decision set. "
+            f"Stored: {', '.join(stored) or '(none)'}. "
+            f"Incoming: {', '.join(sorted(set(decs)))}. A retry must supply "
+            "the identical set; a genuinely corrected set needs a new link "
+            "identity (or human review of the stored provenance).",
+            details={
+                "id": chart_id,
+                "briefing": briefing_id,
+                "cluster": cluster_key,
+                "spec": spec_id,
+                "stored": stored,
+                "incoming": sorted(set(decs)),
+            },
+        )
+
+    actor = get_actor()
+    ts = now_iso()
+    link_rec = {
+        "briefing": briefing_id,
+        "cluster": cluster_key,
+        "spec": spec_id,
+        "decisions": decs,
+        "status": "linked",
+        "linked_at": ts,
+        "linked_by": actor,
+    }
+    new_chart = dict(chart)
+    new_chart["produced_specs"] = existing_links + [link_rec]
+    new_chart["updated_at"] = ts
+    mutations: list[tuple[str, str, str]] = [
+        (f"{chart_id}.json", "update", _sidecar_json(new_chart)),
+    ]
+    md_path, _ = chart_pair_paths(flow_dir, chart_id)
+    if md_path.is_file():
+        mutations.append(
+            (f"{chart_id}.md", "update", md_path.read_text(encoding="utf-8"))
+        )
+    run_chart_transaction(flow_dir, "chart.link-spec", mutations)
+    return {
+        "id": chart_id,
+        "briefing": briefing_id,
+        "cluster": cluster_key,
+        "spec": spec_id,
+        "decisions": decs,
+        "status": "linked",
+        "noop": False,
+        "link": link_rec,
+    }
+
+
+def mark_produced_specs_stale_for_superseded(
+    chart: dict,
+    superseded_ids: list[str],
+    *,
+    via: str,
+    actor: Optional[str] = None,
+    ts: Optional[str] = None,
+) -> tuple[list[dict], list[dict]]:
+    """Mark produced_specs links containing superseded D-IDs as stale.
+
+    Does not rewrite briefings or specs. Returns (new_links, staled_entries).
+    """
+    if not superseded_ids:
+        return list(chart.get("produced_specs") or []), []
+    supersede_set = set(superseded_ids)
+    actor = actor or get_actor()
+    ts = ts or now_iso()
+    new_links: list[dict] = []
+    staled: list[dict] = []
+    for link in chart.get("produced_specs") or []:
+        if not isinstance(link, dict):
+            continue
+        nl = dict(link)
+        link_decs = list(nl.get("decisions") or [])
+        hit = [d for d in link_decs if d in supersede_set]
+        if hit and nl.get("status") != "stale":
+            nl["status"] = "stale"
+            nl["staled_at"] = ts
+            nl["stale_note"] = (
+                f"superseded D-ID(s) {', '.join(hit)} via {via}"
+            )
+            staled.append(
+                {
+                    "briefing": nl.get("briefing"),
+                    "cluster": nl.get("cluster"),
+                    "spec": nl.get("spec"),
+                    "superseded": hit,
+                }
+            )
+        new_links.append(nl)
+    return new_links, staled
+
+
+def human_decision_line(decision: dict) -> str:
+    """Always pair title + full D-ID + record link."""
+    did = decision.get("id") or ""
+    title = decision.get("title") or ""
+    link = decision.get("record_path") or ""
+    if not link and did:
+        try:
+            chart_id = did.rsplit(".", 1)[0]
+            n = decision_local_number(did)
+            link = decision_record_link(chart_id, n)
+        except ChartError:
+            link = ""
+    return f"{did}  {title}  {link}".rstrip()
 
 
 def get_specs_json_write_dir(flow_dir: Path) -> Path:
@@ -8473,7 +16166,7 @@ def _section_title_variant_re(section: str) -> "re.Pattern[str]":
     return re.compile(rf"^##\s+{re.escape(word)}{criteria}\s*([(:—-].*)?$")
 
 
-def _iter_fence_aware(lines: list) -> "Iterator[tuple[str, bool]]":
+def _iter_fence_aware(lines: list) -> Iterator[tuple[str, bool]]:
     """Yield (line, in_fence) pairs tracking fenced-code-block state.
 
     `in_fence` is True for lines inside a ``` / ~~~ fenced code block
@@ -8806,6 +16499,9 @@ FLOW_GITIGNORE_AUTO_PATTERNS = [
     # fn-52 tracker-sync per-run receipts (proof-of-work; accumulate per sync,
     # same class as receipts/ — runtime artifacts, not durable repo state)
     "sync-runs/",
+    # fn-139.3 shared config-writer lock directory (per-run state; a committed
+    # lock would deadlock every fresh clone until stale-reclaim kicked in)
+    ".locks/",
     # fn-99 setup-block serialization locks (runtime artifacts, never repo state)
     "locks/",
     # fn-68 pilot backlog-mode decision-log rows (per-tick triage/advance/ask
@@ -9078,26 +16774,39 @@ def cmd_init(args: argparse.Namespace) -> None:
         atomic_write_json(meta_path, meta)
         actions.append("created meta.json")
 
-    # Config: create or upgrade (merge missing defaults)
+    # Config: create or upgrade (merge missing defaults). Routed through the
+    # shared config-writer lock (fn-139.3, R8b): init on an existing repo is a
+    # read-modify-write like any other and can race a resolve transaction.
     config_path = flow_dir / CONFIG_FILE
-    if not config_path.exists():
-        atomic_write_json(config_path, _init_persisted_defaults())
-        actions.append("created config.json")
-    else:
-        # Load raw config, compare with merged (which includes new defaults)
-        try:
-            raw = json.loads(config_path.read_text(encoding="utf-8"))
-            if not isinstance(raw, dict):
+    # fn-138.3 (R3): both init write paths stamp "$schema" pointing at the
+    # published schema URL. First-key placement is enforced by
+    # atomic_write_json's sort_keys=True ("$" sorts before every letter); the
+    # construction order below is readability, not the mechanism. Seeding it into the
+    # deep_merge BASE means an existing "$schema" in the file always wins
+    # (override side), so a user-pinned URL survives re-init; a missing one is
+    # added on the refresh rewrite. No other write path touches it: set_config
+    # is a raw read-modify-write, so `config set` round-trips it untouched.
+    stamped_defaults = {"$schema": FLOW_CONFIG_SCHEMA_URL}
+    stamped_defaults.update(_init_persisted_defaults())
+    with _shared_config_lock(flow_dir):
+        if not config_path.exists():
+            atomic_write_json(config_path, stamped_defaults)
+            actions.append("created config.json")
+        else:
+            # Load raw config, compare with merged (which includes new defaults)
+            try:
+                raw = json.loads(config_path.read_text(encoding="utf-8"))
+                if not isinstance(raw, dict):
+                    raw = {}
+            except (json.JSONDecodeError, Exception):
                 raw = {}
-        except (json.JSONDecodeError, Exception):
-            raw = {}
-        # The 1.1.11 pre-merge crossEpic→crossSpec mirror was removed in
-        # 2.0.0 along with the `planSync.crossEpic` alias: a leftover legacy
-        # key in the file is now inert (preserved by the merge, never read).
-        merged = deep_merge(_init_persisted_defaults(), raw)
-        if merged != raw:
-            atomic_write_json(config_path, merged)
-            actions.append("upgraded config.json (added missing keys)")
+            # The 1.1.11 pre-merge crossEpic→crossSpec mirror was removed in
+            # 2.0.0 along with the `planSync.crossEpic` alias: a leftover legacy
+            # key in the file is now inert (preserved by the merge, never read).
+            merged = deep_merge(stamped_defaults, raw)
+            if merged != raw:
+                atomic_write_json(config_path, merged)
+                actions.append("upgraded config.json (added missing keys)")
 
     # Output
     if actions:
@@ -9530,6 +17239,20 @@ def cmd_config_set(args: argparse.Namespace) -> None:
                 f"Invalid tracker.specIds value {raw_val!r}. "
                 f"Expected one of: flow, tracker. "
                 f"Use: flowctl config set tracker.specIds flow|tracker",
+                use_json=args.json,
+            )
+
+    if canonical_key == "tracker.conflictTiebreak":
+        raw_val = args.value
+        if (
+            not isinstance(raw_val, str)
+            or raw_val not in TRACKER_CONFLICT_TIEBREAK_VALUES
+        ):
+            error_exit(
+                f"Invalid tracker.conflictTiebreak value {raw_val!r}. "
+                f"Expected one of: always-ask, flow-wins, tracker-wins. "
+                "Use: flowctl config set tracker.conflictTiebreak "
+                "always-ask|flow-wins|tracker-wins",
                 use_json=args.json,
             )
 
@@ -10420,7 +18143,7 @@ def write_prospect_artifact(
             # rename() on POSIX is atomic but overwrites — re-check existence
             # to keep the contract.
             if path.exists():
-                raise FileExistsError(str(path))
+                raise FileExistsError(str(path)) from None
             os.replace(tmp_path, path)
             return
     finally:
@@ -12202,8 +19925,8 @@ def _memory_score_search(
         "body": 1.5,
         "misc": 1.0,
     }
-    for field, weight in field_weights.items():
-        tokens = entry_tokens.get(field, [])
+    for field_name, weight in field_weights.items():
+        tokens = entry_tokens.get(field_name, [])
         if not tokens:
             continue
         token_set = set(tokens)
@@ -14610,6 +22333,235 @@ def cmd_glossary_remove(args: argparse.Namespace) -> None:
     error_exit(f"term '{term}' not found", use_json=use_json, code=1)
 
 
+# --- Global acceptance criteria (fn-137.1) ---
+#
+# `.flow/criteria.md` is a plain markdown file of standing, project-wide
+# acceptance criteria, one per bullet, mirroring the R-ID grammar with a
+# G- prefix:
+#
+#     - **G1:** Every route change regenerates the contract.
+#     - **G2:** No new dependency without a health check (scope: package.json).
+#
+# Non-bullet lines (headings, prose) are ignored. Absence of the file is a
+# silent no-op everywhere. flowctl only parses + validates; judgment about
+# compliance is the completion-review skill's job.
+
+CRITERIA_FILE = "criteria.md"
+
+# Canonical marker heading for the criteria block in assembled review prompts.
+# fn-137.2's completion-review injection MUST use this constant (tests grep the
+# constant, not a re-typed literal) so absent-file zero-cost is provable.
+GLOBAL_CRITERIA_HEADING = "## Global acceptance criteria"
+
+_CRITERIA_LINE_RE = re.compile(r"^-\s+\*\*G([1-9][0-9]*):\*\*\s*(.*)$")
+# Looks-like probe for malformed criterion bullets: a top-level bullet that
+# clearly intends a G-ID (e.g. `- **G1**: prose`, `- G1: prose`) but fails the
+# strict grammar above. Such lines are validation ERRORS, not ignorable prose -
+# an all-typo file must fail closed, never silently disable standing policy.
+# Digit required, so the template's fenced `- **G<N>:**` grammar line never
+# matches; commented examples start with `<!--` and are never probed.
+# Two intent shapes: any G-number bullet WITH a colon (`- G1: x`, `- **G1**: x`),
+# or a BOLD G-number bullet even without one (`- **G2** must lint`) - an
+# unbolded colon-less bullet (`- G20 railway station`) stays ordinary prose.
+# All three Markdown bullet markers (`-`, `*`, `+`) are probed; the strict
+# grammar itself stays `-`-only, so `* **G1:** x` fails closed as malformed.
+_CRITERIA_LOOKSLIKE_RE = re.compile(r"^[-*+]\s+(\*\*G[0-9]\S*|\**G[0-9]+\**\s*:)")
+
+
+def get_criteria_path() -> Path:
+    """Path to the project's global criteria file (.flow/criteria.md)."""
+    return get_flow_dir() / CRITERIA_FILE
+
+
+def _criteria_parse(text: str) -> tuple[list[dict], list[str]]:
+    """Parse criteria markdown into ([{id, text}], [error strings]).
+
+    Grammar: `- **G<N>:** <criterion prose>`. Non-matching lines are
+    ignored (headings, prose, blank lines) - EXCEPT bullets that look like a
+    G-ID criterion but fail the grammar (e.g. `- **G1**: x`), which are
+    validation errors so an all-typo file fails closed. Validation: unique ids,
+    non-empty prose, at most _REVIEW_CRITERIA_MAX_ENTRIES active criteria
+    (the receipt-side cap in parse_review_criteria - an oversized source
+    file could never produce the authoritative receipt compliance array,
+    so it is rejected here where the author can see it). Sequential
+    numbering NOT required.
+    """
+    entries: list[dict] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    dup_reported: set[str] = set()
+
+    for line in text.splitlines():
+        m = _CRITERIA_LINE_RE.match(line)
+        if not m:
+            if _CRITERIA_LOOKSLIKE_RE.match(line):
+                errors.append(
+                    f"malformed criterion bullet (expected `- **G<N>:** <prose>`): {line.strip()[:80]}"
+                )
+            continue
+        cid = f"G{m.group(1)}"
+        prose = m.group(2).strip()
+
+        if cid in seen:
+            if cid not in dup_reported:
+                errors.append(f"duplicate id {cid}")
+                dup_reported.add(cid)
+            continue
+
+        if not prose:
+            errors.append(f"empty criterion text for {cid}")
+            continue
+
+        seen.add(cid)
+        entries.append({"id": cid, "text": prose})
+
+    if len(entries) > _REVIEW_CRITERIA_MAX_ENTRIES:
+        errors.append(
+            f"too many criteria: {len(entries)} active criteria exceed the "
+            f"limit of {_REVIEW_CRITERIA_MAX_ENTRIES}"
+        )
+
+    return entries, errors
+
+
+def cmd_criteria_list(args: argparse.Namespace) -> None:
+    """List global acceptance criteria from .flow/criteria.md.
+
+    Absent file -> empty list, ok exit (absence is a silent no-op
+    everywhere). Validation failure -> error exit listing every problem.
+    """
+    use_json = bool(getattr(args, "json", False))
+    path = get_criteria_path()
+
+    if not path.exists():
+        if os.path.lexists(path):
+            error_exit(
+                "invalid .flow/criteria.md: broken symlink",
+                use_json=use_json,
+            )
+        if use_json:
+            json_output({"criteria": [], "count": 0, "path": None})
+        else:
+            print("no global criteria (.flow/criteria.md absent or empty)")
+        return
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        error_exit(
+            f"invalid .flow/criteria.md: unreadable ({exc})",
+            use_json=use_json,
+        )
+    entries, errors = _criteria_parse(text)
+    if errors:
+        error_exit(
+            "invalid .flow/criteria.md: " + "; ".join(errors),
+            use_json=use_json,
+        )
+
+    if use_json:
+        json_output(
+            {
+                "criteria": entries,
+                "count": len(entries),
+                "path": str(path),
+            }
+        )
+        return
+
+    if not entries:
+        print("no global criteria (.flow/criteria.md absent or empty)")
+        return
+
+    for entry in entries:
+        print(f"{entry['id']}: {entry['text']}")
+
+
+# Static instruction wrapper for the completion-review criteria injection.
+# Rendered ONLY when .flow/criteria.md exists and parses (zero-cost-absent).
+# Prompt text: pinned in test_prompt_text_pinned.py. Composed from the shared
+# heading constants so injection, parser, and .1's zero-cost test cannot drift.
+_GLOBAL_CRITERIA_BLOCK_TEMPLATE = GLOBAL_CRITERIA_HEADING + """
+
+This project defines standing, project-wide acceptance criteria in
+`.flow/criteria.md`. Judge each one against this spec's implementation, in
+addition to the spec's own requirements:
+
+{criteria_bullets}
+
+Assign each criterion exactly one status:
+- `met` - the implementation complies with the criterion
+- `violated` - the implementation breaks the criterion. Report every violation
+  ALSO as a normal gap/finding (severity per your judgment); the findings list
+  stays the single findings surface
+- `n/a` - the criterion does not apply to this change
+
+Then add a `""" + GLOBAL_CRITERIA_OUTPUT_HEADING + """` section to your review output, one line per
+criterion, exactly this grammar (ids from the list above):
+
+G<N>: met|violated|n/a - <one-line note>
+
+"""
+
+
+def build_global_criteria_block() -> str:
+    """Render the completion-review global-criteria injection block.
+
+    Returns "" when `.flow/criteria.md` is absent or valid-but-empty -
+    criteria-less repos pay zero criteria content in assembled prompts
+    (fn-137 R1). An EXISTING file that is unreadable or fails validation
+    raises ValueError (fail closed: configured standing criteria must never
+    be silently dropped from a review).
+    """
+    path = get_criteria_path()
+    if not path.exists():
+        # A dangling/self-referential symlink fails exists() but lexists() -
+        # that is an EXISTING broken config entry, not absence: fail closed.
+        if os.path.lexists(path):
+            raise ValueError(
+                "invalid .flow/criteria.md: broken symlink "
+                "(run `flowctl criteria list` to diagnose)"
+            )
+        return ""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(
+            f"unreadable .flow/criteria.md: {exc} "
+            "(run `flowctl criteria list` to diagnose)"
+        ) from exc
+    entries, errors = _criteria_parse(text)
+    if errors:
+        raise ValueError(
+            "invalid .flow/criteria.md: " + "; ".join(errors)
+            + " (run `flowctl criteria list` to diagnose)"
+        )
+    if not entries:
+        return ""
+    bullets = "\n".join(f"- **{e['id']}:** {e['text']}" for e in entries)
+    return _GLOBAL_CRITERIA_BLOCK_TEMPLATE.format(criteria_bullets=bullets)
+
+
+def cmd_criteria_prompt_block(args: argparse.Namespace) -> None:
+    """Print the criteria injection block (empty output when absent/empty).
+
+    Used by the rp/host completion-review workflows to compose the same
+    block the subprocess backends get from build_completion_review_prompt.
+    An existing-but-invalid `.flow/criteria.md` exits nonzero with the
+    validation errors on stderr (stdout stays empty so a careless append
+    cannot inject the error text into a prompt file).
+    """
+    try:
+        block = build_global_criteria_block()
+    except ValueError as exc:
+        error_exit(str(exc), use_json=False)
+        return
+    if block:
+        sys.stdout.write(block)
+
+
 # --- Strategy subcommands (fn-39.1) ---
 
 
@@ -15233,7 +23185,8 @@ def cmd_spec_create(args: argparse.Namespace) -> None:
 
     # fn-52.10 (R16): origin-branched id generator.
     #   - flow-first (default): native sequential `fn-NN-slug`, allocated from
-    #     `fn-*` specs ONLY (tracker-key specs never bump the native counter).
+    #     the shared native fn-N domain (specs + charts; tracker-key specs
+    #     never bump the counter).
     #   - tracker-first (`--tracker-first` + `--tracker-identifier WOR-17`):
     #     canonical id derived from the LOWERCASE tracker key + number +
     #     slug → `wor-17-slug`; tasks become `wor-17-slug.M` via the unchanged
@@ -15244,6 +23197,94 @@ def cmd_spec_create(args: argparse.Namespace) -> None:
     # Use slugified title as suffix, fallback to random if empty/invalid.
     slug = slugify(args.title)
     suffix = slug if slug else generate_epic_suffix()
+
+    # fn-43.1: Resolve write target. Fresh / migrated repos -> .flow/specs/;
+    # alias-mode 0.x repos (no sentinel + epics/ exists) -> .flow/epics/.
+    spec_json_dir = get_specs_json_write_dir(flow_dir)
+    spec_json_dir.mkdir(parents=True, exist_ok=True)
+    spec_md_dir = flow_dir / SPECS_DIR
+    spec_md_dir.mkdir(parents=True, exist_ok=True)
+
+    def _publish_spec(spec_id: str, tracker_first_flag: bool, tracker_id_val) -> dict:
+        # Double-check no collision across BOTH dirs (shouldn't happen with
+        # scan-based allocation + no-clobber create).
+        canonical_json_path = flow_dir / SPECS_JSON_DIR / f"{spec_id}.json"
+        legacy_json_path = flow_dir / EPICS_DIR / f"{spec_id}.json"
+        spec_md_path = spec_md_dir / f"{spec_id}.md"
+        if (
+            canonical_json_path.exists()
+            or legacy_json_path.exists()
+            or spec_md_path.exists()
+        ):
+            error_exit(
+                f"Refusing to overwrite existing spec {spec_id}. "
+                f"This shouldn't happen - check for orphaned files.",
+                use_json=args.json,
+            )
+
+        spec_json_path = spec_json_dir / f"{spec_id}.json"
+
+        # Create spec JSON. depends_on_epics field name kept (reads accept both
+        # names through 1.x; T2 layers the read-compat). Field rename is internal
+        # only and deferred so external tooling reading the file keeps working.
+        spec_data = {
+            "id": spec_id,
+            "title": args.title,
+            "status": "open",
+            "plan_review_status": "unknown",
+            "plan_reviewed_at": None,
+            "branch_name": args.branch if args.branch else spec_id,
+            "depends_on_epics": [],
+            "spec_path": f"{FLOW_DIR}/{SPECS_DIR}/{spec_id}.md",
+            "next_task": 1,
+            # fn-52.1 (R4): per-item tracker sync state. `id` is the durable UUID
+            # dedupe key; `identifier` the display key (WOR-17); merge-base stored
+            # in BOTH flow-form and tracker-form so the agentic 3-way merge (.4)
+            # has a base comparable to each side, plus content hashes for the
+            # echo-fence (a post-push hash match on the next pull = flow's own
+            # echo, not a real conflict).
+            "tracker": default_spec_tracker_state(),
+            "created_at": now_iso(),
+            "updated_at": now_iso(),
+        }
+        # fn-52.10: tracker-first specs store the DISPLAY identifier (WOR-17) so the
+        # alias index resolves the bare handle. The canonical id already carries the
+        # lowercase key; the full UUID / url land later on link (fn-52.2).
+        if tracker_first_flag and tracker_id_val:
+            spec_data["tracker"]["identifier"] = tracker_id_val
+        json_content = json.dumps(spec_data, indent=2, sort_keys=True) + "\n"
+        spec_content = create_epic_spec(spec_id, args.title)
+
+        # No-clobber publication under the allocation lock (fn-135): concurrent
+        # chart/spec creates cannot reserve the same number then overwrite.
+        published: list[Path] = []
+        try:
+            atomic_create(spec_json_path, json_content)
+            published.append(spec_json_path)
+            atomic_create(spec_md_path, spec_content)
+            published.append(spec_md_path)
+        except FileExistsError:
+            for published_path in reversed(published):
+                try:
+                    published_path.unlink()
+                except OSError:
+                    pass
+            error_exit(
+                f"Refusing to overwrite existing spec {spec_id}. "
+                f"This shouldn't happen - check for orphaned files.",
+                use_json=args.json,
+            )
+        except (OSError, ValueError) as e:
+            for published_path in reversed(published):
+                try:
+                    published_path.unlink()
+                except OSError:
+                    pass
+            error_exit(
+                f"Failed to create spec {spec_id}: {e}",
+                use_json=args.json,
+            )
+        return spec_data
 
     if tracker_first:
         # fn-134.2: KEY-N (Linear/Jira) OR synthetic gh/gl from #N / project#N
@@ -15259,74 +23300,35 @@ def cmd_spec_create(args: argparse.Namespace) -> None:
             display=tracker_identifier, use_json=args.json,
         )
         spec_id = f"{key}-{number}-{suffix}"
+        # Tracker-first ids are not from the native counter; still serialize
+        # publication against the shared lock so a concurrent native allocate
+        # cannot race a colliding path write (defensive; schemes differ).
+        try:
+            with cross_process_lock(native_fn_alloc_lock_path(flow_dir)):
+                spec_data = _publish_spec(spec_id, True, tracker_identifier)
+        except CrossProcessLockError as e:
+            error_exit(
+                f"Native id allocation lock unavailable: {e}",
+                use_json=args.json,
+            )
     else:
         # Flow-first specs may still carry a tracker identifier later, but at
         # create time only the reserved-key guard applies (no identifier set).
         reject_reserved_tracker_key(tracker_identifier, use_json=args.json)
-        # MU-1: Scan-based allocation for merge safety. NATIVE-`fn`-ONLY so a
-        # tracker-key spec never pushes the next flow-first spec's number.
-        max_spec = scan_max_native_fn_spec_id(flow_dir)
-        spec_num = max_spec + 1
-        spec_id = f"fn-{spec_num}-{suffix}"
-
-    # fn-43.1: Resolve write target. Fresh / migrated repos -> .flow/specs/;
-    # alias-mode 0.x repos (no sentinel + epics/ exists) -> .flow/epics/.
-    spec_json_dir = get_specs_json_write_dir(flow_dir)
-    spec_json_dir.mkdir(parents=True, exist_ok=True)
-    spec_md_dir = flow_dir / SPECS_DIR
-    spec_md_dir.mkdir(parents=True, exist_ok=True)
-
-    # Double-check no collision across BOTH dirs (shouldn't happen with
-    # scan-based allocation).
-    canonical_json_path = flow_dir / SPECS_JSON_DIR / f"{spec_id}.json"
-    legacy_json_path = flow_dir / EPICS_DIR / f"{spec_id}.json"
-    spec_md_path = spec_md_dir / f"{spec_id}.md"
-    if (
-        canonical_json_path.exists()
-        or legacy_json_path.exists()
-        or spec_md_path.exists()
-    ):
-        error_exit(
-            f"Refusing to overwrite existing spec {spec_id}. "
-            f"This shouldn't happen - check for orphaned files.",
-            use_json=args.json,
-        )
-
-    spec_json_path = spec_json_dir / f"{spec_id}.json"
-
-    # Create spec JSON. depends_on_epics field name kept (reads accept both
-    # names through 1.x; T2 layers the read-compat). Field rename is internal
-    # only and deferred so external tooling reading the file keeps working.
-    spec_data = {
-        "id": spec_id,
-        "title": args.title,
-        "status": "open",
-        "plan_review_status": "unknown",
-        "plan_reviewed_at": None,
-        "branch_name": args.branch if args.branch else spec_id,
-        "depends_on_epics": [],
-        "spec_path": f"{FLOW_DIR}/{SPECS_DIR}/{spec_id}.md",
-        "next_task": 1,
-        # fn-52.1 (R4): per-item tracker sync state. `id` is the durable UUID
-        # dedupe key; `identifier` the display key (WOR-17); merge-base stored
-        # in BOTH flow-form and tracker-form so the agentic 3-way merge (.4)
-        # has a base comparable to each side, plus content hashes for the
-        # echo-fence (a post-push hash match on the next pull = flow's own
-        # echo, not a real conflict).
-        "tracker": default_spec_tracker_state(),
-        "created_at": now_iso(),
-        "updated_at": now_iso(),
-    }
-    # fn-52.10: tracker-first specs store the DISPLAY identifier (WOR-17) so the
-    # alias index resolves the bare handle. The canonical id already carries the
-    # lowercase key; the full UUID / url land later on link (fn-52.2).
-    if tracker_first and tracker_identifier:
-        spec_data["tracker"]["identifier"] = tracker_identifier
-    atomic_write_json(spec_json_path, spec_data)
-
-    # Create spec markdown.
-    spec_content = create_epic_spec(spec_id, args.title)
-    atomic_write(spec_md_path, spec_content)
+        # fn-135: shared cross-kind allocation lock with chart create. Scan +
+        # no-clobber reserve under one lock so concurrent kinds never select
+        # the same fn-N.
+        try:
+            with cross_process_lock(native_fn_alloc_lock_path(flow_dir)):
+                max_spec = scan_max_native_fn_spec_id(flow_dir)
+                spec_num = max_spec + 1
+                spec_id = f"fn-{spec_num}-{suffix}"
+                spec_data = _publish_spec(spec_id, False, tracker_identifier)
+        except CrossProcessLockError as e:
+            error_exit(
+                f"Native id allocation lock unavailable: {e}",
+                use_json=args.json,
+            )
 
     # NOTE: We no longer update meta["next_spec"] since scan-based allocation
     # is the source of truth. This reduces merge conflicts.
@@ -15344,6 +23346,2367 @@ def cmd_spec_create(args: argparse.Namespace) -> None:
         json_output(out)
     else:
         print(f"Spec {spec_id} created: {args.title}")
+
+
+def _chart_ensure_flow(use_json: bool, command: str) -> Path:
+    if not ensure_flow_exists():
+        chart_fail(
+            command,
+            use_json,
+            "invalid_state",
+            "flow_missing",
+            ".flow/ does not exist. Run 'flowctl init' first.",
+        )
+    return get_flow_dir()
+
+
+def cmd_chart_create(args: argparse.Namespace) -> None:
+    """Create a chart; optional --initial-map-file validates/enforces ceiling first."""
+    command = "chart.create"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+
+    title = (getattr(args, "title", None) or "").strip()
+    outcome = (getattr(args, "outcome", None) or "").strip()
+    if not title:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "title_required",
+            "Chart create requires --title",
+        )
+    if not outcome:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "outcome_required",
+            "Chart create requires --outcome",
+        )
+
+    initial_path = getattr(args, "initial_map_file", None)
+    force_size = bool(getattr(args, "force_size", False))
+    force_reason = getattr(args, "reason", None)
+    if force_size and not initial_path:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "force_size_needs_map",
+            "--force-size applies only with --initial-map-file",
+        )
+
+    try:
+        # Validate initial map BEFORE allocation so over-ceiling creates
+        # reserve no chart id.
+        built_initial = None
+        if initial_path:
+            map_data = parse_initial_map_file(Path(initial_path))
+            # Provisional chart id for edge canonicalization; rewritten after alloc.
+            # Edges use local D1/D2 labels resolved inside validate_and_build.
+            # Must be a valid fn-N shape (fn-0 is rejected by canonicalize_chart_id).
+            # Discarded after allocation; real ids are rebound below.
+            _PROVISIONAL_CHART_ID = "fn-999999999"
+            provisional = validate_and_build_initial_map(
+                _PROVISIONAL_CHART_ID,
+                map_data,
+                force_size=force_size,
+                force_reason=force_reason,
+            )
+            built_initial = provisional
+
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            with cross_process_lock(native_fn_alloc_lock_path(flow_dir)):
+                next_n = scan_max_native_fn_spec_id(flow_dir) + 1
+                chart_id = f"fn-{next_n}"
+                initial_for_create = None
+                if built_initial is not None:
+                    # Re-bind provisional placeholder ids to the allocated chart id.
+                    rebound = validate_and_build_initial_map(
+                        chart_id,
+                        map_data,
+                        force_size=force_size,
+                        force_reason=force_reason,
+                    )
+                    initial_for_create = rebound
+                data = create_chart_pair(
+                    flow_dir,
+                    chart_id,
+                    title,
+                    outcome,
+                    initial=initial_for_create,
+                )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart allocation lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+
+    meta = compact_chart_metadata(data)
+    projection = _maybe_project_chart(
+        flow_dir, data["id"], event="chart.create",
+        revision=chart_decision_revision(data),
+    )
+    result = {
+        "id": data["id"],
+        "title": data["title"],
+        "outcome": data["outcome"],
+        "status": data["status"],
+        "created": data["created"],
+        "chart_path": f"{FLOW_DIR}/{CHARTS_DIR}/{data['id']}.md",
+        "decision_count": meta["decision_count"],
+        "parked_count": meta["parked_count"],
+        "unattended_count": meta["unattended_count"],
+        "attended_count": meta["attended_count"],
+        "estimated_sessions": meta["estimated_sessions"],
+        "cost_line": meta["cost_line"],
+        "tracker_projection": projection,
+        "decisions": [
+            {
+                "id": d.get("id"),
+                "title": d.get("title"),
+                "type": d.get("type"),
+                "attendance": d.get("attendance"),
+                "record_path": d.get("record_path"),
+            }
+            for d in (data.get("decisions") or [])
+            if isinstance(d, dict)
+        ],
+        "parked_questions": [
+            {"key": p.get("key"), "body": p.get("body")}
+            for p in (data.get("parked_questions") or [])
+            if isinstance(p, dict)
+        ],
+    }
+    if data.get("force_size_audit"):
+        result["force_size_audit"] = data["force_size_audit"]
+    if use_json:
+        chart_json_success(command, result)
+    else:
+        print(f"Chart {data['id']} created: {data['title']}")
+        print(meta["cost_line"])
+        for d in data.get("decisions") or []:
+            if isinstance(d, dict):
+                print(human_decision_line(d))
+
+
+def cmd_chart_show(args: argparse.Namespace) -> None:
+    """Show compact chart metadata + map body (no decision answer/assets)."""
+    command = "chart.show"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            chart_id = canonicalize_chart_id(raw_id)
+            data = load_chart_sidecar(flow_dir, chart_id)
+            meta = compact_chart_metadata(data)
+            md_path, _json_path = chart_pair_paths(flow_dir, chart_id)
+            body = ""
+            if md_path.is_file():
+                try:
+                    body = md_path.read_text(encoding="utf-8")
+                except OSError as e:
+                    raise ChartError(
+                        "io",
+                        "chart_body_unreadable",
+                        f"Chart body unreadable: {chart_id} ({e})",
+                        details={"id": chart_id},
+                    ) from e
+            # Compact decision list from sidecar only - never open decision files.
+            decisions_out = [
+                compact_decision_entry(d)
+                for d in (data.get("decisions") or [])
+                if isinstance(d, dict)
+            ]
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+
+    result = {
+        **meta,
+        "chart_path": f"{FLOW_DIR}/{CHARTS_DIR}/{meta['id']}.md",
+        "body": body,
+        "decisions": decisions_out,
+        "parked_questions": [
+            {"key": p.get("key"), "body": p.get("body")}
+            for p in (data.get("parked_questions") or [])
+            if isinstance(p, dict)
+        ],
+    }
+    if use_json:
+        chart_json_success(command, result)
+    else:
+        print(f"{meta['id']}  {meta['title']}  [{meta['status']}]")
+        print(f"Outcome: {meta['outcome']}")
+        print(
+            f"Decisions: {meta['decision_count']} "
+            f"(open={meta['open_count']} blocked={meta['blocked_count']} "
+            f"claimed={meta['claimed_count']} parked={meta['parked_count']})"
+        )
+        print(meta["cost_line"])
+        if not meta["briefable"]:
+            print("Not briefable:")
+            for reason in meta["stuck_reasons"]:
+                print(f"  - {reason}")
+        for d in decisions_out:
+            print(human_decision_line(d))
+        if body:
+            print()
+            sys.stdout.write(body if body.endswith("\n") else body + "\n")
+
+
+def cmd_chart_list(args: argparse.Namespace) -> None:
+    """List charts with compact progress + remaining attended cost."""
+    command = "chart.list"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            charts_out: list[dict] = []
+            for chart_id in list_chart_ids(flow_dir):
+                try:
+                    data = load_chart_sidecar(flow_dir, chart_id)
+                    charts_out.append(compact_chart_metadata(data))
+                except ChartError:
+                    # Skip unreadable entries rather than failing the whole list.
+                    continue
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+
+    if use_json:
+        chart_json_success(command, {"charts": charts_out, "count": len(charts_out)})
+    else:
+        if not charts_out:
+            print("No charts.")
+            return
+        for c in charts_out:
+            print(
+                f"{c['id']}  {c['title']}  [{c['status']}]  "
+                f"decisions={c['decision_count']} "
+                f"open={c['open_count']} attended_left={c['attended_count']}"
+            )
+
+
+def cmd_chart_add_decision(args: argparse.Namespace) -> None:
+    """Allocate the next D-ID under a chart."""
+    command = "chart.add-decision"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    title = (getattr(args, "title", None) or "").strip()
+    dtype = (getattr(args, "type", None) or "").strip()
+    attendance = getattr(args, "attendance", None)
+    body_file = getattr(args, "body_file", None)
+    question = ""
+    if body_file:
+        try:
+            question = Path(body_file).read_text(encoding="utf-8")
+        except OSError as e:
+            chart_fail(
+                command,
+                use_json,
+                "io",
+                "body_file_unreadable",
+                f"Cannot read --body-file: {e}",
+                details={"path": str(body_file)},
+            )
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            chart_id = canonicalize_chart_id(raw_id)
+            blocked = _parse_edge_list(
+                getattr(args, "blocked_by", None),
+                chart_id,
+                field_name="blocked_by",
+            )
+            depends = _parse_edge_list(
+                getattr(args, "depends_on", None),
+                chart_id,
+                field_name="depends_on",
+            )
+            full = add_chart_decision(
+                flow_dir,
+                chart_id,
+                title,
+                dtype,
+                attendance=attendance,
+                question=question,
+                blocked_by=blocked,
+                depends_on=depends,
+            )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+
+    result = {
+        "id": full["id"],
+        "title": full["title"],
+        "type": full["type"],
+        "attendance": full["attendance"],
+        "status": full["status"],
+        "blocked_by": full.get("blocked_by") or [],
+        "depends_on": full.get("depends_on") or [],
+        "record_path": full.get("record_path"),
+        "chart": full.get("chart"),
+    }
+    result = _attach_tracker_projection(
+        result, flow_dir, full.get("chart"), "chart.wire",
+    )
+    if use_json:
+        chart_json_success(command, result)
+    else:
+        print(human_decision_line(result))
+        print(f"type={result['type']} attendance={result['attendance']}")
+
+
+def cmd_chart_park_question(args: argparse.Namespace) -> None:
+    command = "chart.park-question"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    body_file = getattr(args, "body_file", None)
+    if not body_file:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "body_file_required",
+            "park-question requires --body-file",
+        )
+    try:
+        body = Path(body_file).read_text(encoding="utf-8")
+    except OSError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "body_file_unreadable",
+            f"Cannot read --body-file: {e}",
+            details={"path": str(body_file)},
+        )
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            chart_id = canonicalize_chart_id(raw_id)
+            out = park_chart_question(flow_dir, chart_id, body)
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    result = {
+        "chart_id": canonicalize_chart_id(raw_id),
+        "key": out["key"],
+        "body": out["body"],
+        "created": out.get("created"),
+        "noop": out.get("noop", False),
+    }
+    # Parked counts feed the parent rollup - refresh it post-commit.
+    result = _attach_tracker_projection(
+        result, flow_dir, result["chart_id"], "chart.wire",
+    )
+    if use_json:
+        chart_json_success(command, result)
+    else:
+        print(f"Parked question key={result['key']}")
+        print(result["body"])
+
+
+def cmd_chart_remove_question(args: argparse.Namespace) -> None:
+    command = "chart.remove-question"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    qkey = getattr(args, "question", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            chart_id = canonicalize_chart_id(raw_id)
+            out = remove_chart_question(flow_dir, chart_id, qkey)
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    result = {
+        "chart_id": canonicalize_chart_id(raw_id),
+        "key": out["key"],
+        "body": out.get("body"),
+        "removed": True,
+    }
+    # Parked counts feed the parent rollup - refresh it post-commit.
+    result = _attach_tracker_projection(
+        result, flow_dir, result["chart_id"], "chart.wire",
+    )
+    if use_json:
+        chart_json_success(command, result)
+    else:
+        print(f"Removed parked question key={result['key']}")
+
+
+def cmd_chart_wire_decision(args: argparse.Namespace) -> None:
+    command = "chart.wire-decision"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_did = getattr(args, "decision_id", None) or getattr(args, "id", None)
+    # Replace only the edge sets the caller supplied (None = leave unchanged).
+    blocked_raw = getattr(args, "blocked_by", None)
+    depends_raw = getattr(args, "depends_on", None)
+    replace_blocked = blocked_raw is not None
+    replace_depends = depends_raw is not None
+    if not replace_blocked and not replace_depends:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "edges_required",
+            "wire-decision requires --blocked-by and/or --depends-on "
+            "(pass empty string to clear)",
+        )
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            did = canonicalize_decision_id(raw_did)
+            chart_id = did.rsplit(".", 1)[0]
+            blocked = (
+                _parse_edge_list(blocked_raw, chart_id, field_name="blocked_by")
+                if replace_blocked
+                else None
+            )
+            depends = (
+                _parse_edge_list(depends_raw, chart_id, field_name="depends_on")
+                if replace_depends
+                else None
+            )
+            out = wire_chart_decision(
+                flow_dir,
+                did,
+                blocked_by=blocked,
+                depends_on=depends,
+                replace_blocked=replace_blocked,
+                replace_depends=replace_depends,
+            )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, _chart_id_from_decision_result(out), "chart.wire",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(human_decision_line(out))
+        print(
+            f"blocked_by={','.join(out.get('blocked_by') or []) or '-'} "
+            f"depends_on={','.join(out.get('depends_on') or []) or '-'}"
+        )
+
+
+def cmd_chart_frontier(args: argparse.Namespace) -> None:
+    command = "chart.frontier"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            chart_id = canonicalize_chart_id(raw_id)
+            data = load_chart_sidecar(flow_dir, chart_id)
+            # Frontier from compact sidecar only - never open decision files.
+            frontier = compute_frontier(data)
+            completion = chart_completion_predicate(data)
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    result = {
+        "chart_id": chart_id,
+        "frontier": frontier,
+        "count": len(frontier),
+        "briefable": completion["briefable"],
+        "stuck_reasons": completion["stuck_reasons"],
+    }
+    if use_json:
+        chart_json_success(command, result)
+    else:
+        if not frontier:
+            print(f"Frontier empty for {chart_id}")
+            if completion["stuck_reasons"]:
+                print("Stuck:")
+                for reason in completion["stuck_reasons"]:
+                    print(f"  - {reason}")
+            elif completion["briefable"]:
+                print("Chart is briefable (no open decisions or parked questions).")
+            return
+        for d in frontier:
+            print(human_decision_line(d))
+
+
+def cmd_chart_claim(args: argparse.Namespace) -> None:
+    command = "chart.claim"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_did = getattr(args, "decision_id", None) or getattr(args, "id", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = claim_chart_decision(flow_dir, raw_did)
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, _chart_id_from_decision_result(out), "chart.claim",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(human_decision_line(out))
+        print(f"claimed_by={out['claimed_by']} claimed_at={out['claimed_at']}")
+
+
+def cmd_chart_release_claim(args: argparse.Namespace) -> None:
+    command = "chart.release-claim"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_did = getattr(args, "decision_id", None) or getattr(args, "id", None)
+    break_stale = bool(getattr(args, "break_stale", False))
+    reason = getattr(args, "reason", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = release_chart_claim(
+                flow_dir,
+                raw_did,
+                break_stale=break_stale,
+                reason=reason,
+            )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, _chart_id_from_decision_result(out), "chart.release",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(human_decision_line(out))
+        print(f"released prior_owner={out.get('prior_owner')}")
+        if out.get("audit"):
+            print(f"audit={json.dumps(out['audit'], default=str)}")
+
+
+def cmd_chart_attach_asset(args: argparse.Namespace) -> None:
+    command = "chart.attach-asset"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_did = getattr(args, "decision_id", None) or getattr(args, "id", None)
+    asset_file = getattr(args, "asset_file", None)
+    if not asset_file:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "asset_file_required",
+            "attach-asset requires --asset-file",
+        )
+    try:
+        asset_raw = json.loads(Path(asset_file).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "asset_file_invalid_json",
+            f"--asset-file is not valid JSON: {e}",
+            details={"path": str(asset_file)},
+        )
+    except OSError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "asset_file_unreadable",
+            f"Cannot read --asset-file: {e}",
+            details={"path": str(asset_file)},
+        )
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = attach_chart_asset(flow_dir, raw_did, asset_raw)
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    # Evidence on an open decision must reach the tracker child now - a
+    # prototype awaiting human reaction gets no later resolve event.
+    out = _attach_tracker_projection(
+        out, flow_dir, _chart_id_from_decision_result(out), "chart.attachAsset",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(human_decision_line(out))
+        asset = out.get("asset") or {}
+        print(
+            f"asset kind={asset.get('kind')} ref={asset.get('reference')} "
+            f"noop={out.get('noop')}"
+        )
+
+
+def cmd_chart_resolve(args: argparse.Namespace) -> None:
+    command = "chart.resolve"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_did = getattr(args, "decision_id", None) or getattr(args, "id", None)
+    answer_file = getattr(args, "answer_file", None)
+    if not answer_file:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "answer_file_required",
+            "resolve requires --answer-file",
+        )
+    try:
+        answer = Path(answer_file).read_text(encoding="utf-8")
+    except OSError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "answer_file_unreadable",
+            f"Cannot read --answer-file: {e}",
+            details={"path": str(answer_file)},
+        )
+    assets_raw = getattr(args, "assets", None)
+    sharpen_path = getattr(args, "sharpen_file", None)
+    supersedes_raw = getattr(args, "supersedes", None)
+    keep_dependents = bool(getattr(args, "keep_dependents", False))
+    try:
+        sharpen = None
+        if sharpen_path:
+            sharpen = _parse_sharpen_file(Path(sharpen_path))
+        supersedes = None
+        if supersedes_raw is not None and str(supersedes_raw).strip():
+            supersedes = [
+                p.strip()
+                for p in str(supersedes_raw).split(",")
+                if p.strip()
+            ]
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = resolve_chart_decision(
+                flow_dir,
+                raw_did,
+                answer,
+                assets_raw=assets_raw,
+                sharpen=sharpen,
+                supersedes=supersedes,
+                keep_dependents=keep_dependents,
+            )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    proj_event = (
+        "chart.supersede"
+        if supersedes
+        else "chart.resolve"
+    )
+    out = _attach_tracker_projection(
+        out, flow_dir, _chart_id_from_decision_result(out), proj_event,
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(human_decision_line(out))
+        print(f"status={out.get('status')} gist={out.get('answer_gist')}")
+        if out.get("affected"):
+            print(f"affected={','.join(out['affected'])}")
+        if out.get("replacements"):
+            for rep in out["replacements"]:
+                print(
+                    f"replacement {rep.get('id')} replaces {rep.get('replaces')}"
+                )
+
+
+def cmd_chart_out_of_scope(args: argparse.Namespace) -> None:
+    command = "chart.out-of-scope"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_did = getattr(args, "decision_id", None) or getattr(args, "id", None)
+    reason = getattr(args, "reason", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = out_of_scope_chart_decision(flow_dir, raw_did, reason or "")
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, _chart_id_from_decision_result(out), "chart.outOfScope",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(human_decision_line(out))
+        print(f"status=out-of-scope reason={out.get('reason')}")
+
+
+def cmd_chart_abandon(args: argparse.Namespace) -> None:
+    command = "chart.abandon"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    reason = getattr(args, "reason", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = abandon_chart(flow_dir, raw_id, reason or "")
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, out.get("id") or raw_id, "chart.abandon",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(f"{out.get('id')} abandoned: {out.get('reason')}")
+
+
+def cmd_chart_briefing(args: argparse.Namespace) -> None:
+    command = "chart.briefing"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    proposal = getattr(args, "proposal_file", None)
+    force = bool(getattr(args, "force", False))
+    if not proposal:
+        chart_fail(
+            command,
+            use_json,
+            "validation",
+            "proposal_file_required",
+            "chart briefing requires --proposal-file",
+        )
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = emit_chart_briefing(
+                flow_dir,
+                raw_id,
+                Path(proposal),
+                force=force,
+            )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, out.get("id") or raw_id, "chart.briefing",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        bid = out.get("briefing_id")
+        st = out.get("status")
+        noop = " (noop)" if out.get("noop") else ""
+        # A superseding emission says so on the same line: without it a terminal
+        # user reading `status=final` after a reopen cannot tell a fresh briefing
+        # from the stale echo this fix removed (fn-154). Absent on every other
+        # path, so ordinary output is unchanged.
+        stale_ids = out.get("supersedes_stale") or []
+        sup = f" (supersedes stale {', '.join(stale_ids)})" if stale_ids else ""
+        print(f"{out.get('id')} briefing {bid} status={st}{noop}{sup}")
+        if out.get("transitioned_done"):
+            print(f"chart status -> done via {bid}")
+        paths = out.get("paths") or {}
+        if paths.get("index"):
+            print(f"index={paths['index']}")
+
+
+def cmd_chart_reopen(args: argparse.Namespace) -> None:
+    command = "chart.reopen"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    reason = getattr(args, "reason", None)
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = reopen_chart(flow_dir, raw_id, reason or "")
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    out = _attach_tracker_projection(
+        out, flow_dir, out.get("id") or raw_id, "chart.reopen",
+    )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        print(
+            f"{out.get('id')} reopened (was {out.get('prior_status')}): "
+            f"{out.get('reason')}"
+        )
+        if out.get("staled_briefings"):
+            print(f"staled briefings: {', '.join(out['staled_briefings'])}")
+
+
+def cmd_chart_locate(args: argparse.Namespace) -> None:
+    """Resolve chart/D-ID, stored tracker id, or stored URL via local ledger.
+
+    Zero mutation. No network. Strict host/credential/ambiguity rejection.
+    """
+    command = "chart.locate"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    selector = getattr(args, "selector", None) or ""
+    try:
+        from flowctl_tracker.facade.chart_projection import (  # noqa: PLC0415
+            locate_selector,
+        )
+        from flowctl_tracker.types import TrackerError  # noqa: PLC0415
+    except ImportError:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "facade_unavailable",
+            "flowctl_tracker package is not available",
+        )
+        return
+    # Locate is read-only against the ledger; recover journals so sidecars are
+    # consistent, then never write.
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+    except CrossProcessLockError:
+        pass
+    out = locate_selector(flow_dir, selector)
+    if isinstance(out, TrackerError):
+        code = (out.details or {}).get("code") or out.subtype or "unresolved_locator"
+        # Map tracker ErrorClass onto the chart v1 envelope classes.
+        cls_val = out.cls.value if hasattr(out.cls, "value") else str(out.cls)
+        chart_class = {
+            "not_found": "not_found",
+            "unresolved": "not_found",
+            "conflict": "conflict",
+            "stale_id": "conflict",
+            "invalid_input": "validation",
+            "capability": "validation",
+            "inactive": "invalid_state",
+        }.get(cls_val, "validation")
+        chart_fail(
+            command,
+            use_json,
+            chart_class,
+            str(code),
+            out.message,
+            details=out.details,
+            exit_code=out.exit_code if hasattr(out, "exit_code") else 1,
+        )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        kind = out.get("kind")
+        if kind == "chart":
+            print(
+                f"chart {out.get('chart_id')} - {out.get('title')} "
+                f"[{out.get('status')}] {out.get('record_path')}"
+            )
+        else:
+            print(
+                f"decision {out.get('decision_id')} - {out.get('title')} "
+                f"[{out.get('status')}] {out.get('record_path')}"
+            )
+            if out.get("history"):
+                hist = out["history"]
+                print(
+                    f"history status={hist.get('status')} "
+                    f"superseded_by={hist.get('superseded_by') or '-'}"
+                )
+                if out.get("frontier") is not None:
+                    fr = out.get("frontier") or []
+                    print(
+                        "frontier: "
+                        + (
+                            ", ".join(
+                                f"{f.get('id')}({f.get('title')})" for f in fr
+                            )
+                            if fr
+                            else "(empty)"
+                        )
+                    )
+
+
+def cmd_chart_link_spec(args: argparse.Namespace) -> None:
+    command = "chart.link-spec"
+    use_json = bool(getattr(args, "json", False))
+    flow_dir = _chart_ensure_flow(use_json, command)
+    raw_id = getattr(args, "chart_id", None) or getattr(args, "id", None)
+    briefing = getattr(args, "briefing", None)
+    spec = getattr(args, "spec", None)
+    cluster = getattr(args, "cluster", None)
+    decisions_raw = getattr(args, "decisions", None) or ""
+    decisions = [p.strip() for p in str(decisions_raw).split(",") if p.strip()]
+    try:
+        with cross_process_lock(charts_resource_lock_path(flow_dir)):
+            recover_chart_transactions(flow_dir)
+            out = link_chart_spec(
+                flow_dir,
+                raw_id,
+                briefing=briefing or "",
+                spec=spec or "",
+                decisions=decisions,
+                cluster=cluster,
+            )
+    except CrossProcessLockError as e:
+        chart_fail(
+            command,
+            use_json,
+            "io",
+            "lock_unavailable",
+            f"Chart resource lock unavailable: {e}",
+        )
+    except ChartError as e:
+        chart_fail(
+            command,
+            use_json,
+            e.error_class,
+            e.code,
+            e.message,
+            details=e.details,
+            exit_code=e.exit_code,
+        )
+    if use_json:
+        chart_json_success(command, out)
+    else:
+        noop = " (noop)" if out.get("noop") else ""
+        cl = out.get("cluster")
+        cl_part = f" cluster={cl}" if cl else ""
+        print(
+            f"{out.get('id')} link-spec {out.get('briefing')}{cl_part} "
+            f"-> {out.get('spec')} status={out.get('status')}{noop}"
+        )
+
+
+# ---------- PR cognitive-aid artifact (fn-136.6) ------------------------
+
+PR_COGNITIVE_AID_SCHEMA_VERSION = 1
+PR_COGNITIVE_AID_MAX_BYTES = 512 * 1024
+PR_COGNITIVE_AID_SOURCE_KINDS = frozenset(
+    {"spec", "task", "rid", "review_receipt", "qa_receipt", "diff_metadata", "commit"}
+)
+PR_COGNITIVE_AID_GROUP_KINDS = ("problem", "principle", "step", "kept", "verify")
+PR_COGNITIVE_AID_CHANGE_TYPES = frozenset(
+    {"added", "modified", "deleted", "renamed", "copied"}
+)
+PR_COGNITIVE_AID_ATTENTION_CLASSES = frozenset(
+    {"canonical", "generated", "mechanical"}
+)
+_PR_COGNITIVE_AID_SHA_RE = re.compile(r"^[0-9a-f]{40,64}$")
+_PR_COGNITIVE_AID_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$")
+_PR_COGNITIVE_AID_RID_RE = re.compile(r"^R[1-9][0-9]*$")
+_PR_COGNITIVE_AID_WINDOWS_RESERVED = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
+)
+
+
+class PrCognitiveAidValidationError(ValueError):
+    """The portable PR cognitive-aid contract was violated."""
+
+
+def _pr_aid_fail(path: str, message: str) -> None:
+    raise PrCognitiveAidValidationError(f"{path}: {message}")
+
+
+def _pr_aid_object(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _pr_aid_fail(path, "must be an object")
+    return value
+
+
+def _pr_aid_keys(
+    value: dict[str, Any],
+    path: str,
+    *,
+    required: set[str],
+    optional: set[str] = frozenset(),
+) -> None:
+    missing = required - set(value)
+    if missing:
+        _pr_aid_fail(path, f"missing fields: {', '.join(sorted(missing))}")
+    unknown = set(value) - required - optional
+    if unknown:
+        _pr_aid_fail(path, f"unknown fields: {', '.join(sorted(unknown))}")
+
+
+def _pr_aid_array(
+    value: Any, path: str, *, maximum: int, minimum: int = 0
+) -> list[Any]:
+    if not isinstance(value, list):
+        _pr_aid_fail(path, "must be an array")
+    if not minimum <= len(value) <= maximum:
+        _pr_aid_fail(path, f"must contain {minimum}-{maximum} entries")
+    return value
+
+
+def _pr_aid_string(
+    value: Any, path: str, *, maximum: int, allow_empty: bool = False
+) -> str:
+    if not isinstance(value, str):
+        _pr_aid_fail(path, "must be a string")
+    if not allow_empty and not value:
+        _pr_aid_fail(path, "must not be empty")
+    if len(value) > maximum:
+        _pr_aid_fail(path, f"exceeds {maximum} characters")
+    if any(ord(char) < 32 and char not in "\t\n" for char in value):
+        _pr_aid_fail(path, "contains a control character")
+    return value
+
+
+def _pr_aid_identifier(value: Any, path: str) -> str:
+    result = _pr_aid_string(value, path, maximum=160)
+    if not _PR_COGNITIVE_AID_ID_RE.fullmatch(result):
+        _pr_aid_fail(path, "must be a portable identifier")
+    return result
+
+
+def _pr_aid_artifact_id(value: Any, path: str) -> str:
+    result = _pr_aid_identifier(value, path)
+    basename = result.split(".", 1)[0].upper()
+    if basename in _PR_COGNITIVE_AID_WINDOWS_RESERVED:
+        _pr_aid_fail(path, "must not use a Windows reserved filename")
+    return result
+
+
+def _pr_aid_sha(value: Any, path: str) -> str:
+    result = _pr_aid_string(value, path, maximum=64)
+    if not _PR_COGNITIVE_AID_SHA_RE.fullmatch(result):
+        _pr_aid_fail(path, "must be a lowercase 40-64 character Git SHA")
+    return result
+
+
+def _pr_aid_repo_path(value: Any, path: str) -> str:
+    result = _pr_aid_string(value, path, maximum=1024)
+    if (
+        result.startswith(("/", "\\"))
+        or "\\" in result
+        or result.endswith("/")
+        or "//" in result
+    ):
+        _pr_aid_fail(path, "must be a normalized repository-relative path")
+    if any(part in ("", ".", "..") for part in result.split("/")):
+        _pr_aid_fail(path, "must not contain empty, dot, or traversal segments")
+    return result
+
+
+def _pr_aid_url(value: Any, path: str) -> str:
+    result = _pr_aid_string(value, path, maximum=2048)
+    if any(char.isspace() for char in result) or any(
+        char in result for char in ("(", ")", "[", "]", "|", "<", ">")
+    ):
+        _pr_aid_fail(path, "contains unsafe URL characters")
+    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", result):
+        if not re.match(r"^https://[^/\s]+(?:/|$)", result):
+            _pr_aid_fail(path, "must use HTTPS")
+    elif result.startswith("//") or any(part == ".." for part in result.split("/")):
+        _pr_aid_fail(path, "must be HTTPS or repository-relative")
+    return result
+
+
+def _pr_aid_string_array(value: Any, path: str) -> list[str]:
+    values = _pr_aid_array(value, path, maximum=32)
+    result = [
+        _pr_aid_string(item, f"{path}[{index}]", maximum=160)
+        for index, item in enumerate(values)
+    ]
+    if len(set(result)) != len(result):
+        _pr_aid_fail(path, "must not contain duplicates")
+    return result
+
+
+def _pr_aid_nonnegative_int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        _pr_aid_fail(path, "must be a non-negative integer")
+    return value
+
+
+def _pr_aid_serialized_text(artifact: Any) -> str:
+    """Return the one canonical representation used for limits and persistence."""
+    return json.dumps(artifact, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def validate_pr_cognitive_aid(
+    artifact: Any,
+    *,
+    expected_spec_id: Optional[str] = None,
+    expected_base_sha: Optional[str] = None,
+    expected_head_sha: Optional[str] = None,
+    expected_diff_files: Optional[dict[str, tuple[str, int, int]]] = None,
+) -> dict[str, Any]:
+    """Validate one v1 artifact without coercion, truncation, or I/O."""
+    artifact = _pr_aid_object(artifact, "pr_cognitive_aid")
+    _pr_aid_keys(
+        artifact,
+        "pr_cognitive_aid",
+        required={
+            "schemaVersion",
+            "artifactId",
+            "specId",
+            "baseSha",
+            "headSha",
+            "generatedAt",
+            "sources",
+            "changeWalkthrough",
+        },
+        optional={"supersedesArtifactId"},
+    )
+    encoded = _pr_aid_serialized_text(artifact).encode("utf-8")
+    if len(encoded) > PR_COGNITIVE_AID_MAX_BYTES:
+        _pr_aid_fail(
+            "pr_cognitive_aid",
+            f"encoded payload exceeds {PR_COGNITIVE_AID_MAX_BYTES} bytes",
+        )
+    schema_version = artifact.get("schemaVersion")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != PR_COGNITIVE_AID_SCHEMA_VERSION
+    ):
+        _pr_aid_fail("schemaVersion", "unsupported schema version")
+    artifact_id = _pr_aid_artifact_id(artifact.get("artifactId"), "artifactId")
+    spec_id = _pr_aid_string(artifact.get("specId"), "specId", maximum=160)
+    if not is_spec_id(spec_id):
+        _pr_aid_fail("specId", "must be a canonical Flow spec ID")
+    base_sha = _pr_aid_sha(artifact.get("baseSha"), "baseSha")
+    head_sha = _pr_aid_sha(artifact.get("headSha"), "headSha")
+    generated_at = _pr_aid_string(
+        artifact.get("generatedAt"), "generatedAt", maximum=160
+    )
+    try:
+        parsed_generated_at = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        _pr_aid_fail("generatedAt", "must be an ISO-8601 timestamp")
+    if parsed_generated_at.tzinfo is None:
+        _pr_aid_fail("generatedAt", "must include a timezone")
+    supersedes = artifact.get("supersedesArtifactId")
+    if supersedes is not None:
+        supersedes = _pr_aid_artifact_id(supersedes, "supersedesArtifactId")
+        if supersedes == artifact_id:
+            _pr_aid_fail("supersedesArtifactId", "must not reference itself")
+    if expected_spec_id is not None and spec_id != expected_spec_id:
+        _pr_aid_fail("specId", f"does not match expected {expected_spec_id}")
+    if expected_base_sha is not None and base_sha != expected_base_sha:
+        _pr_aid_fail("baseSha", "does not match the current merge base")
+    if expected_head_sha is not None and head_sha != expected_head_sha:
+        _pr_aid_fail("headSha", "does not match the current PR head")
+
+    sources = _pr_aid_array(
+        artifact.get("sources"), "sources", minimum=1, maximum=128
+    )
+    source_by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_source in enumerate(sources):
+        source_path = f"sources[{index}]"
+        source = _pr_aid_object(raw_source, source_path)
+        _pr_aid_keys(
+            source,
+            source_path,
+            required={"id", "kind", "ref"},
+            optional={"digest"},
+        )
+        source_id = _pr_aid_identifier(source.get("id"), f"{source_path}.id")
+        if source_id in source_by_id:
+            _pr_aid_fail(f"{source_path}.id", "duplicate source ID")
+        kind = _pr_aid_string(source.get("kind"), f"{source_path}.kind", maximum=160)
+        if kind not in PR_COGNITIVE_AID_SOURCE_KINDS:
+            _pr_aid_fail(f"{source_path}.kind", "unsupported source kind")
+        source_ref = _pr_aid_string(
+            source.get("ref"), f"{source_path}.ref", maximum=1024
+        )
+        if kind == "spec" and source_ref != spec_id:
+            _pr_aid_fail(f"{source_path}.ref", "must identify artifact.specId")
+        if kind == "task":
+            if not is_task_id(source_ref) or spec_id_from_task(source_ref) != spec_id:
+                _pr_aid_fail(
+                    f"{source_path}.ref", "must identify a task of artifact.specId"
+                )
+        if kind == "rid" and not _PR_COGNITIVE_AID_RID_RE.fullmatch(source_ref):
+            _pr_aid_fail(f"{source_path}.ref", "must be a canonical R-ID")
+        if kind == "diff_metadata" and source_ref != f"{base_sha}..{head_sha}":
+            _pr_aid_fail(
+                f"{source_path}.ref", "must identify artifact baseSha..headSha"
+            )
+        if kind == "commit":
+            _pr_aid_sha(source_ref, f"{source_path}.ref")
+        digest = source.get("digest")
+        if digest is not None:
+            digest = _pr_aid_string(digest, f"{source_path}.digest", maximum=160)
+            if not re.fullmatch(r"(?:sha256:)?[0-9a-f]{64}", digest):
+                _pr_aid_fail(f"{source_path}.digest", "must be a SHA-256 digest")
+        source_by_id[source_id] = source
+
+    walkthrough = _pr_aid_object(
+        artifact.get("changeWalkthrough"), "changeWalkthrough"
+    )
+    _pr_aid_keys(
+        walkthrough,
+        "changeWalkthrough",
+        required={"thesis", "proof", "groups"},
+    )
+    _pr_aid_string(
+        walkthrough.get("thesis"), "changeWalkthrough.thesis", maximum=4000
+    )
+
+    def validate_refs(
+        record: dict[str, Any], record_path: str, *, require_grounding: bool
+    ) -> tuple[list[str], list[str], list[str]]:
+        refs = _pr_aid_string_array(
+            record.get("sourceRefs"), f"{record_path}.sourceRefs"
+        )
+        if require_grounding and not refs:
+            _pr_aid_fail(
+                f"{record_path}.sourceRefs", "must ground the semantic summary"
+            )
+        for ref_index, source_id in enumerate(refs):
+            if source_id not in source_by_id:
+                _pr_aid_fail(
+                    f"{record_path}.sourceRefs[{ref_index}]",
+                    "does not resolve to sources[]",
+                )
+        r_ids = _pr_aid_string_array(
+            record.get("rIds", []), f"{record_path}.rIds"
+        )
+        task_ids = _pr_aid_string_array(
+            record.get("taskIds", []), f"{record_path}.taskIds"
+        )
+        for r_index, r_id in enumerate(r_ids):
+            if not _PR_COGNITIVE_AID_RID_RE.fullmatch(r_id):
+                _pr_aid_fail(
+                    f"{record_path}.rIds[{r_index}]", "must be a canonical R-ID"
+                )
+        for task_index, task_id in enumerate(task_ids):
+            if not is_task_id(task_id) or spec_id_from_task(task_id) != spec_id:
+                _pr_aid_fail(
+                    f"{record_path}.taskIds[{task_index}]",
+                    "must identify a task of artifact.specId",
+                )
+        referenced_sources = [source_by_id[source_id] for source_id in refs]
+        for r_id in r_ids:
+            if not any(
+                source.get("kind") == "rid" and source.get("ref") == r_id
+                for source in referenced_sources
+            ):
+                _pr_aid_fail(
+                    f"{record_path}.rIds",
+                    f"{r_id} lacks a same-record rid sourceRef",
+                )
+        for task_id in task_ids:
+            if not any(
+                source.get("kind") == "task" and source.get("ref") == task_id
+                for source in referenced_sources
+            ):
+                _pr_aid_fail(
+                    f"{record_path}.taskIds",
+                    f"{task_id} lacks a same-record task sourceRef",
+                )
+        return refs, r_ids, task_ids
+
+    proof = _pr_aid_array(
+        walkthrough.get("proof"), "changeWalkthrough.proof", maximum=16
+    )
+    for index, raw_cell in enumerate(proof):
+        cell_path = f"changeWalkthrough.proof[{index}]"
+        cell = _pr_aid_object(raw_cell, cell_path)
+        _pr_aid_keys(
+            cell,
+            cell_path,
+            required={"label", "value", "sourceRefs"},
+        )
+        _pr_aid_string(cell.get("label"), f"{cell_path}.label", maximum=160)
+        _pr_aid_string(cell.get("value"), f"{cell_path}.value", maximum=160)
+        validate_refs(cell, cell_path, require_grounding=True)
+
+    groups = _pr_aid_array(
+        walkthrough.get("groups"),
+        "changeWalkthrough.groups",
+        minimum=1,
+        maximum=11,
+    )
+    kind_positions = {
+        kind: index for index, kind in enumerate(PR_COGNITIVE_AID_GROUP_KINDS)
+    }
+    kind_counts = {kind: 0 for kind in PR_COGNITIVE_AID_GROUP_KINDS}
+    last_kind_position = -1
+    last_ordinal = -1
+    ordinals: set[int] = set()
+    files_seen: dict[str, tuple[Any, ...]] = {}
+    for group_index, raw_group in enumerate(groups):
+        group_path = f"changeWalkthrough.groups[{group_index}]"
+        group = _pr_aid_object(raw_group, group_path)
+        _pr_aid_keys(
+            group,
+            group_path,
+            required={
+                "ordinal",
+                "kind",
+                "title",
+                "summary",
+                "sourceRefs",
+                "rIds",
+                "taskIds",
+                "files",
+            },
+        )
+        ordinal = _pr_aid_nonnegative_int(
+            group.get("ordinal"), f"{group_path}.ordinal"
+        )
+        if ordinal in ordinals:
+            _pr_aid_fail(f"{group_path}.ordinal", "duplicate ordinal")
+        if ordinal <= last_ordinal:
+            _pr_aid_fail(f"{group_path}.ordinal", "must increase in render order")
+        last_ordinal = ordinal
+        ordinals.add(ordinal)
+        kind = _pr_aid_string(group.get("kind"), f"{group_path}.kind", maximum=160)
+        if kind not in kind_positions:
+            _pr_aid_fail(f"{group_path}.kind", "unsupported group kind")
+        if kind_positions[kind] < last_kind_position:
+            _pr_aid_fail(f"{group_path}.kind", "violates logical group order")
+        last_kind_position = kind_positions[kind]
+        kind_counts[kind] += 1
+        _pr_aid_string(group.get("title"), f"{group_path}.title", maximum=160)
+        summary = _pr_aid_string(
+            group.get("summary"), f"{group_path}.summary", maximum=1000
+        )
+        validate_refs(group, group_path, require_grounding=bool(summary))
+        files = _pr_aid_array(
+            group.get("files", []), f"{group_path}.files", maximum=200
+        )
+        for file_index, raw_file in enumerate(files):
+            file_path = f"{group_path}.files[{file_index}]"
+            file_record = _pr_aid_object(raw_file, file_path)
+            _pr_aid_keys(
+                file_record,
+                file_path,
+                required={
+                    "path",
+                    "changeType",
+                    "attentionClass",
+                    "summary",
+                    "sourceRefs",
+                    "rIds",
+                    "taskIds",
+                },
+                optional={"additions", "deletions", "diffUrl"},
+            )
+            repo_path = _pr_aid_repo_path(
+                file_record.get("path"), f"{file_path}.path"
+            )
+            change_type = _pr_aid_string(
+                file_record.get("changeType"),
+                f"{file_path}.changeType",
+                maximum=160,
+            )
+            if change_type not in PR_COGNITIVE_AID_CHANGE_TYPES:
+                _pr_aid_fail(f"{file_path}.changeType", "unsupported Git change type")
+            attention = _pr_aid_string(
+                file_record.get("attentionClass"),
+                f"{file_path}.attentionClass",
+                maximum=160,
+            )
+            if attention not in PR_COGNITIVE_AID_ATTENTION_CLASSES:
+                _pr_aid_fail(
+                    f"{file_path}.attentionClass", "unsupported attention class"
+                )
+            file_summary = _pr_aid_string(
+                file_record.get("summary"), f"{file_path}.summary", maximum=500
+            )
+            file_refs, _, _ = validate_refs(
+                file_record, file_path, require_grounding=bool(file_summary)
+            )
+            if not any(
+                source_by_id[source_id]["kind"] == "diff_metadata"
+                for source_id in file_refs
+            ):
+                _pr_aid_fail(
+                    f"{file_path}.sourceRefs",
+                    "must cite the artifact diff_metadata source",
+                )
+            additions = file_record.get("additions")
+            deletions = file_record.get("deletions")
+            if additions is not None:
+                additions = _pr_aid_nonnegative_int(
+                    additions, f"{file_path}.additions"
+                )
+            if deletions is not None:
+                deletions = _pr_aid_nonnegative_int(
+                    deletions, f"{file_path}.deletions"
+                )
+            diff_url = file_record.get("diffUrl")
+            if diff_url is not None:
+                _pr_aid_url(diff_url, f"{file_path}.diffUrl")
+            membership = (
+                ordinal,
+                change_type,
+                attention,
+                additions,
+                deletions,
+                diff_url,
+            )
+            if repo_path in files_seen:
+                if files_seen[repo_path] != membership:
+                    _pr_aid_fail(
+                        f"{file_path}.path", "conflicts with duplicate file membership"
+                    )
+                _pr_aid_fail(f"{file_path}.path", "duplicate file membership")
+            files_seen[repo_path] = membership
+            if expected_diff_files is not None:
+                expected_file = expected_diff_files.get(repo_path)
+                actual_file = (change_type, additions, deletions)
+                if expected_file is None:
+                    _pr_aid_fail(
+                        f"{file_path}.path", "does not belong to the bound Git diff"
+                    )
+                if actual_file != expected_file:
+                    _pr_aid_fail(
+                        file_path,
+                        "changeType/additions/deletions do not match the bound Git diff",
+                    )
+            if len(files_seen) > 500:
+                _pr_aid_fail("changeWalkthrough.groups", "exceeds 500 unique files")
+    if not 1 <= kind_counts["step"] <= 7:
+        _pr_aid_fail("changeWalkthrough.groups", "must contain exactly 1-7 step groups")
+    for optional_kind in ("problem", "principle", "kept", "verify"):
+        if kind_counts[optional_kind] > 1:
+            _pr_aid_fail(
+                "changeWalkthrough.groups",
+                f"must contain at most one {optional_kind} group",
+            )
+    if expected_diff_files is not None and set(files_seen) != set(expected_diff_files):
+        _pr_aid_fail(
+            "changeWalkthrough.groups",
+            "file membership does not cover the bound Git diff exactly",
+        )
+    return artifact
+
+
+def _pr_aid_live_diff_files(
+    repo_root: Path, base_sha: str, head_sha: str
+) -> dict[str, tuple[str, int, int]]:
+    materialized = _export_materialize_diff(base_sha, repo_root)
+    if materialized.head_sha != head_sha:
+        _pr_aid_fail("headSha", "does not match repository HEAD")
+    if materialized.numstat_rc != 0 or materialized.name_status_rc != 0:
+        _pr_aid_fail("diff_metadata", "cannot read the bound Git diff")
+    summary = _export_diff_summary(
+        base_sha, base_sha, repo_root, materialized=materialized
+    )
+    status_names = {
+        "A": "added",
+        "M": "modified",
+        "D": "deleted",
+        "R": "renamed",
+        "C": "copied",
+    }
+    return {
+        item["path"]: (
+            status_names.get(item["status"], "modified"),
+            item["additions"],
+            item["deletions"],
+        )
+        for item in summary["files"]
+    }
+
+
+def _pr_cognitive_aid_home(flow_dir: Path, spec_id: str) -> Path:
+    return flow_dir / "artifacts" / spec_id / "pr-cognitive-aid"
+
+
+def _load_pr_cognitive_aid_records(
+    flow_dir: Path,
+    spec_id: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Load and structurally validate every immutable generation."""
+    records: list[dict[str, Any]] = []
+    rejected: list[str] = []
+    home = _pr_cognitive_aid_home(flow_dir, spec_id)
+    if not home.is_dir():
+        return records, rejected
+    for path in sorted(home.glob("*.json")):
+        try:
+            with path.open("rb") as handle:
+                raw_bytes = handle.read(PR_COGNITIVE_AID_MAX_BYTES + 1)
+            if len(raw_bytes) > PR_COGNITIVE_AID_MAX_BYTES:
+                _pr_aid_fail(
+                    path.name,
+                    f"encoded payload exceeds {PR_COGNITIVE_AID_MAX_BYTES} bytes",
+                )
+            raw = json.loads(raw_bytes.decode("utf-8"))
+            record = validate_pr_cognitive_aid(
+                raw,
+                expected_spec_id=spec_id,
+            )
+            if path.name != f"{record['artifactId']}.json":
+                _pr_aid_fail(
+                    path.name, "filename must equal <artifactId>.json"
+                )
+            records.append(record)
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            PrCognitiveAidValidationError,
+        ) as exc:
+            rejected.append(f"{path.name}: {exc}")
+    return records, rejected
+
+
+def _pr_aid_chain_tip(records: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Validate one linear, connected generation chain and return its sole tip."""
+    if not records:
+        return None
+    by_id: dict[str, dict[str, Any]] = {}
+    for record in records:
+        artifact_id = record["artifactId"]
+        if artifact_id in by_id:
+            _pr_aid_fail("artifact home", f"duplicate artifactId {artifact_id}")
+        by_id[artifact_id] = record
+    genesis = [
+        record for record in records if not record.get("supersedesArtifactId")
+    ]
+    if len(genesis) != 1:
+        _pr_aid_fail("artifact home", "must contain exactly one genesis")
+    children: dict[str, list[str]] = {artifact_id: [] for artifact_id in by_id}
+    for record in records:
+        parent = record.get("supersedesArtifactId")
+        if not parent:
+            continue
+        if parent not in by_id:
+            _pr_aid_fail(
+                "artifact home", f"dangling supersedesArtifactId {parent}"
+            )
+        children[parent].append(record["artifactId"])
+        if len(children[parent]) > 1:
+            _pr_aid_fail("artifact home", f"fork at artifactId {parent}")
+    visited: set[str] = set()
+    cursor = genesis[0]["artifactId"]
+    while True:
+        if cursor in visited:
+            _pr_aid_fail("artifact home", "supersedes cycle")
+        visited.add(cursor)
+        next_ids = children[cursor]
+        if not next_ids:
+            break
+        cursor = next_ids[0]
+    if len(visited) != len(records):
+        _pr_aid_fail("artifact home", "contains a cycle or disconnected generation")
+    tips = [artifact_id for artifact_id, next_ids in children.items() if not next_ids]
+    if len(tips) != 1 or tips[0] != cursor:
+        _pr_aid_fail("artifact home", "must contain exactly one chain tip")
+    return by_id[cursor]
+
+
+def select_current_pr_cognitive_aid(
+    flow_dir: Path,
+    spec_id: str,
+    *,
+    base_sha: str,
+    head_sha: str,
+    expected_diff_files: Optional[dict[str, tuple[str, int, int]]] = None,
+) -> dict[str, Any]:
+    """Project the matching chain tip; never merge stale or legacy fields."""
+    home = _pr_cognitive_aid_home(flow_dir, spec_id)
+    if not home.is_dir():
+        return {
+            "status": "absent",
+            "artifact": None,
+            "latestArtifactId": None,
+            "rejected": [],
+        }
+    try:
+        with cross_process_lock(home / ".write.lock"):
+            records, rejected = _load_pr_cognitive_aid_records(
+                flow_dir,
+                spec_id,
+            )
+            return _select_current_pr_cognitive_aid_records(
+                records,
+                rejected,
+                base_sha=base_sha,
+                head_sha=head_sha,
+                expected_diff_files=expected_diff_files,
+            )
+    except CrossProcessLockError as exc:
+        return {
+            "status": "invalid",
+            "artifact": None,
+            "latestArtifactId": None,
+            "rejected": [f"artifact home: cannot acquire reader lock: {exc}"],
+        }
+
+
+def _select_current_pr_cognitive_aid_records(
+    records: list[dict[str, Any]],
+    rejected: list[str],
+    *,
+    base_sha: str,
+    head_sha: str,
+    expected_diff_files: Optional[dict[str, tuple[str, int, int]]] = None,
+) -> dict[str, Any]:
+    """Select from one writer-locked home snapshot."""
+    if rejected:
+        unsupported = all("unsupported schema version" in item for item in rejected)
+        return {
+            "status": "unsupported" if unsupported else "invalid",
+            "artifact": None,
+            "latestArtifactId": None,
+            "rejected": rejected,
+        }
+    try:
+        latest = _pr_aid_chain_tip(records)
+    except PrCognitiveAidValidationError as exc:
+        return {
+            "status": "invalid",
+            "artifact": None,
+            "latestArtifactId": None,
+            "rejected": [str(exc)],
+        }
+    latest_artifact_id = latest["artifactId"] if latest else None
+    if (
+        latest is None
+        or latest["baseSha"] != base_sha
+        or latest["headSha"] != head_sha
+    ):
+        return {
+            "status": "stale" if records else ("invalid" if rejected else "absent"),
+            "artifact": None,
+            "latestArtifactId": latest_artifact_id,
+            "rejected": rejected,
+        }
+    try:
+        latest = validate_pr_cognitive_aid(
+            latest,
+            expected_spec_id=latest["specId"],
+            expected_base_sha=base_sha,
+            expected_head_sha=head_sha,
+            expected_diff_files=expected_diff_files,
+        )
+    except PrCognitiveAidValidationError as exc:
+        return {
+            "status": "invalid",
+            "artifact": None,
+            "latestArtifactId": latest_artifact_id,
+            "rejected": [str(exc)],
+        }
+    return {
+        "status": "current",
+        "artifact": latest,
+        "latestArtifactId": latest_artifact_id,
+        "rejected": rejected,
+    }
+
+
+def write_pr_cognitive_aid(
+    flow_dir: Path,
+    artifact: Any,
+    *,
+    spec_id: str,
+    base_sha: str,
+    head_sha: str,
+    expected_diff_files: Optional[dict[str, tuple[str, int, int]]] = None,
+) -> Path:
+    """Validate and atomically create one immutable generation."""
+    artifact = validate_pr_cognitive_aid(
+        artifact,
+        expected_spec_id=spec_id,
+        expected_base_sha=base_sha,
+        expected_head_sha=head_sha,
+        expected_diff_files=expected_diff_files,
+    )
+    home = _pr_cognitive_aid_home(flow_dir, spec_id)
+    target = home / f"{artifact['artifactId']}.json"
+    try:
+        with cross_process_lock(home / ".write.lock"):
+            existing, rejected = _load_pr_cognitive_aid_records(flow_dir, spec_id)
+            if rejected:
+                _pr_aid_fail(
+                    "artifact home", "contains invalid or unsupported generations"
+                )
+            existing_tip = _pr_aid_chain_tip(existing)
+            by_id = {record["artifactId"]: record for record in existing}
+            if artifact["artifactId"] in by_id or target.exists():
+                _pr_aid_fail("artifactId", f"generation already exists at {target}")
+            supersedes = artifact.get("supersedesArtifactId")
+            if existing and not supersedes:
+                _pr_aid_fail(
+                    "supersedesArtifactId", "is required after the first generation"
+                )
+            if not existing and supersedes:
+                _pr_aid_fail(
+                    "supersedesArtifactId",
+                    "cannot reference a generation outside this home",
+                )
+            if supersedes and supersedes not in by_id:
+                _pr_aid_fail(
+                    "supersedesArtifactId",
+                    "does not identify an existing generation",
+                )
+            if supersedes:
+                if existing_tip is None or supersedes != existing_tip["artifactId"]:
+                    _pr_aid_fail(
+                        "supersedesArtifactId",
+                        "must extend an existing chain tip",
+                    )
+            serialized = _pr_aid_serialized_text(artifact)
+            if len(serialized.encode("utf-8")) > PR_COGNITIVE_AID_MAX_BYTES:
+                _pr_aid_fail(
+                    "pr_cognitive_aid",
+                    f"encoded payload exceeds {PR_COGNITIVE_AID_MAX_BYTES} bytes",
+                )
+            atomic_create(target, serialized)
+    except FileExistsError as exc:
+        raise PrCognitiveAidValidationError(
+            f"artifactId: generation already exists at {target}"
+        ) from exc
+    except CrossProcessLockError as exc:
+        raise PrCognitiveAidValidationError(
+            f"artifact home: cannot acquire writer lock: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise PrCognitiveAidValidationError(
+            f"artifact home: cannot publish generation: {exc}"
+        ) from exc
+    return target
+
+
+def _pr_aid_plain_text(value: Any) -> str:
+    escaped = html.escape(str(value), quote=True).replace("`", "&#96;")
+    for character in ("\\", "*", "[", "]", ">"):
+        escaped = escaped.replace(character, f"\\{character}")
+    return escaped.replace("\n", " ")
+
+
+def _pr_aid_prose(value: Any) -> str:
+    escaped = _pr_aid_plain_text(value)
+    if re.match(
+        r"^\s*(?:#{1,6}\s|[-+*]\s|\d+[.)]\s|`{3,}|~{3,}|-{3,}\s*$|"
+        r"\*{3,}\s*$|_{3,}\s*$)",
+        escaped,
+    ):
+        first = len(escaped) - len(escaped.lstrip())
+        escaped = (
+            escaped[:first]
+            + "&#"
+            + str(ord(escaped[first]))
+            + ";"
+            + escaped[first + 1 :]
+        )
+    return escaped
+
+
+def _pr_aid_markdown_cell(value: Any) -> str:
+    return _pr_aid_plain_text(value).replace("|", "\\|")
+
+
+def _pr_aid_links(record: dict[str, Any]) -> str:
+    parts = [
+        *(f"source:{item}" for item in record.get("sourceRefs", [])),
+        *(f"R-ID:{item}" for item in record.get("rIds", [])),
+        *(f"task:{item}" for item in record.get("taskIds", [])),
+    ]
+    return _pr_aid_markdown_cell(", ".join(parts) or "—")
+
+
+def _pr_aid_file_row(file_record: dict[str, Any]) -> str:
+    additions = file_record.get("additions")
+    deletions = file_record.get("deletions")
+    stats = (
+        "—"
+        if additions is None and deletions is None
+        else f"+{additions or 0}/-{deletions or 0}"
+    )
+    diff_url = file_record.get("diffUrl")
+    diff = (
+        f"[diff]({html.escape(diff_url, quote=True)})" if diff_url else "—"
+    )
+    change_badges = {
+        "added": "NEW",
+        "modified": "MODIFIED",
+        "deleted": "DELETED",
+        "renamed": "RENAMED",
+        "copied": "COPIED",
+    }
+    return (
+        f"| `{change_badges[file_record['changeType']]}` | "
+        f"`{file_record['attentionClass'].upper()}` | "
+        f"`{_pr_aid_markdown_cell(file_record['path'])}` | "
+        f"{_pr_aid_markdown_cell(file_record['summary'])} | {stats} | {diff} | "
+        f"{_pr_aid_links(file_record)} |"
+    )
+
+
+def render_pr_cognitive_aid_markdown(artifact: Any) -> str:
+    """Render the validated v1 object with deterministic compact/full rules."""
+    artifact = validate_pr_cognitive_aid(artifact)
+    walkthrough = artifact["changeWalkthrough"]
+    groups = walkthrough["groups"]
+    files = [file_record for group in groups for file_record in group.get("files", [])]
+    canonical_files = [
+        file_record
+        for file_record in files
+        if file_record["attentionClass"] == "canonical"
+    ]
+    human_review_lines = sum(
+        (file_record.get("additions") or 0) + (file_record.get("deletions") or 0)
+        for file_record in canonical_files
+    )
+    full = human_review_lines >= 200 or len(canonical_files) >= 6
+    lines = [
+        "## The change, top to bottom",
+        "",
+        _pr_aid_prose(walkthrough["thesis"]),
+        "",
+        "| Proof | Value | Sources |",
+        "|---|---|---|",
+        f"| Artifact | `{artifact['artifactId']}` | artifact identity |",
+        f"| Base commit | `{artifact['baseSha']}` | artifact currentness |",
+        f"| Head commit | `{artifact['headSha']}` | artifact identity |",
+        f"| Human-review lines | {human_review_lines} | deterministic file stats |",
+        f"| Canonical files | {len(canonical_files)} | deterministic membership |",
+        f"| Total files | {len(files)} | deterministic membership |",
+    ]
+    if walkthrough["proof"]:
+        for cell in walkthrough["proof"]:
+            lines.append(
+                f"| {_pr_aid_markdown_cell(cell['label'])} | "
+                f"{_pr_aid_markdown_cell(cell['value'])} | "
+                f"{_pr_aid_links(cell)} |"
+            )
+    lines.append("")
+    if not full:
+        lines.extend(
+            [
+                "| Change | Attention | File | Purpose | +/- | Diff | Evidence |",
+                "|---|---|---|---|---:|---|---|",
+                *(_pr_aid_file_row(file_record) for file_record in canonical_files),
+                "",
+            ]
+        )
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend(
+        [
+            "**Legend:** `WHY` `PRINCIPLE` `STEP` `KEPT` `VERIFY` · "
+            "`NEW` `MODIFIED` `DELETED` `RENAMED` `COPIED` · "
+            "`CANONICAL` `GENERATED` `MECHANICAL`",
+            "",
+        ]
+    )
+    first_open_step = next(
+        (
+            group["ordinal"]
+            for group in groups
+            if group["kind"] == "step"
+            and any(
+                file_record["attentionClass"] == "canonical"
+                for file_record in group.get("files", [])
+            )
+        ),
+        None,
+    )
+    kind_badges = {
+        "problem": "WHY",
+        "principle": "PRINCIPLE",
+        "step": "STEP",
+        "kept": "KEPT",
+        "verify": "VERIFY",
+    }
+    for group in groups:
+        open_attr = " open" if group["ordinal"] == first_open_step else ""
+        lines.extend(
+            [
+                f"<details{open_attr}>",
+                f"<summary><code>{kind_badges[group['kind']]}</code> "
+                f"{group['ordinal']}. {_pr_aid_plain_text(group['title'])} — "
+                f"{_pr_aid_plain_text(group['summary'])}</summary>",
+                "",
+                f"Evidence: {_pr_aid_links(group)}",
+                "",
+            ]
+        )
+        group_files = group.get("files", [])
+        run_start = 0
+        while run_start < len(group_files):
+            secondary = (
+                group_files[run_start]["attentionClass"] != "canonical"
+            )
+            run_end = run_start + 1
+            while (
+                run_end < len(group_files)
+                and (
+                    group_files[run_end]["attentionClass"] != "canonical"
+                )
+                == secondary
+            ):
+                run_end += 1
+            run = group_files[run_start:run_end]
+            if secondary:
+                lines.extend(
+                    [
+                        "<details>",
+                        f"<summary>Generated/mechanical files ({len(run)})</summary>",
+                        "",
+                    ]
+                )
+            lines.extend(
+                [
+                    "| Change | Attention | File | Purpose | +/- | Diff | Evidence |",
+                    "|---|---|---|---|---:|---|---|",
+                    *(_pr_aid_file_row(file_record) for file_record in run),
+                    "",
+                ]
+            )
+            if secondary:
+                lines.extend(["</details>", ""])
+            run_start = run_end
+        lines.extend(["</details>", ""])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _pr_aid_read_input(path_arg: str) -> Any:
+    try:
+        if path_arg == "-":
+            raw_bytes = sys.stdin.buffer.read(PR_COGNITIVE_AID_MAX_BYTES + 1)
+        else:
+            with Path(path_arg).open("rb") as handle:
+                raw_bytes = handle.read(PR_COGNITIVE_AID_MAX_BYTES + 1)
+    except OSError as exc:
+        error_exit(
+            f"Cannot read PR cognitive-aid artifact: {exc}", use_json=True, code=2
+        )
+    if len(raw_bytes) > PR_COGNITIVE_AID_MAX_BYTES:
+        error_exit(
+            f"PR cognitive-aid artifact exceeds {PR_COGNITIVE_AID_MAX_BYTES} bytes",
+            use_json=True,
+            code=2,
+        )
+    try:
+        return json.loads(raw_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        error_exit(
+            f"PR cognitive-aid artifact invalid JSON: {exc}", use_json=True, code=2
+        )
+
+
+def _pr_aid_cli_shas(args: argparse.Namespace) -> tuple[str, str]:
+    try:
+        return (
+            _pr_aid_sha(args.base_sha, "--base-sha"),
+            _pr_aid_sha(args.head_sha, "--head-sha"),
+        )
+    except PrCognitiveAidValidationError as exc:
+        error_exit(str(exc), use_json=bool(getattr(args, "json", False)), code=2)
+
+
+def cmd_pr_cognitive_aid_validate(args: argparse.Namespace) -> None:
+    artifact = _pr_aid_read_input(args.file)
+    try:
+        artifact = _pr_aid_object(artifact, "pr_cognitive_aid")
+        base_sha = _pr_aid_sha(artifact.get("baseSha"), "baseSha")
+        head_sha = _pr_aid_sha(artifact.get("headSha"), "headSha")
+        artifact = validate_pr_cognitive_aid(
+            artifact,
+            expected_diff_files=_pr_aid_live_diff_files(
+                get_repo_root(), base_sha, head_sha
+            ),
+        )
+    except PrCognitiveAidValidationError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
+    if args.json:
+        json_output({"valid": True, "artifact": artifact})
+    else:
+        print("valid")
+
+
+def cmd_pr_cognitive_aid_write(args: argparse.Namespace) -> None:
+    flow_dir = get_flow_dir()
+    spec_id = resolve_spec_id_arg(flow_dir, args.id, use_json=args.json)
+    base_sha, head_sha = _pr_aid_cli_shas(args)
+    artifact = _pr_aid_read_input(args.file)
+    try:
+        expected_diff_files = _pr_aid_live_diff_files(
+            get_repo_root(), base_sha, head_sha
+        )
+        path = write_pr_cognitive_aid(
+            flow_dir,
+            artifact,
+            spec_id=spec_id,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            expected_diff_files=expected_diff_files,
+        )
+    except PrCognitiveAidValidationError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
+    result = {"path": path.as_posix(), "artifactId": artifact["artifactId"]}
+    if args.json:
+        json_output(result)
+    else:
+        print(result["path"])
+
+
+def cmd_pr_cognitive_aid_current(args: argparse.Namespace) -> None:
+    flow_dir = get_flow_dir()
+    spec_id = resolve_spec_id_arg(flow_dir, args.id, use_json=args.json)
+    base_sha, head_sha = _pr_aid_cli_shas(args)
+    try:
+        expected_diff_files = _pr_aid_live_diff_files(
+            get_repo_root(), base_sha, head_sha
+        )
+        result = select_current_pr_cognitive_aid(
+            flow_dir,
+            spec_id,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            expected_diff_files=expected_diff_files,
+        )
+    except PrCognitiveAidValidationError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
+    if args.json:
+        json_output(result)
+    elif result["artifact"] is not None:
+        print(
+            _pr_cognitive_aid_home(flow_dir, spec_id)
+            / f"{result['artifact']['artifactId']}.json"
+        )
+    else:
+        print(result["status"])
+
+
+def cmd_pr_cognitive_aid_render(args: argparse.Namespace) -> None:
+    if args.file:
+        artifact = _pr_aid_read_input(args.file)
+        try:
+            artifact = _pr_aid_object(artifact, "pr_cognitive_aid")
+            base_sha = _pr_aid_sha(artifact.get("baseSha"), "baseSha")
+            head_sha = _pr_aid_sha(artifact.get("headSha"), "headSha")
+            artifact = validate_pr_cognitive_aid(
+                artifact,
+                expected_diff_files=_pr_aid_live_diff_files(
+                    get_repo_root(), base_sha, head_sha
+                ),
+            )
+            print(render_pr_cognitive_aid_markdown(artifact), end="")
+        except PrCognitiveAidValidationError as exc:
+            error_exit(str(exc), use_json=False, code=2)
+        return
+    if not args.id or not args.base_sha or not args.head_sha:
+        error_exit(
+            "render requires either --file or ID with --base-sha and --head-sha",
+            use_json=False,
+            code=2,
+        )
+    flow_dir = get_flow_dir()
+    spec_id = resolve_spec_id_arg(flow_dir, args.id, use_json=False)
+    base_sha, head_sha = _pr_aid_cli_shas(args)
+    try:
+        expected_diff_files = _pr_aid_live_diff_files(
+            get_repo_root(), base_sha, head_sha
+        )
+        result = select_current_pr_cognitive_aid(
+            flow_dir,
+            spec_id,
+            base_sha=base_sha,
+            head_sha=head_sha,
+            expected_diff_files=expected_diff_files,
+        )
+    except PrCognitiveAidValidationError as exc:
+        error_exit(str(exc), use_json=False, code=2)
+    if result["artifact"] is None:
+        error_exit(
+            f"No supported current PR cognitive-aid artifact ({result['status']})",
+            use_json=False,
+            code=3,
+        )
+    print(render_pr_cognitive_aid_markdown(result["artifact"]), end="")
+
+
+def render_pr_cognitive_aid_html_input(artifact: Any) -> str:
+    """Return an HTML-safe, lossless semantic carrier for the validated v1 object."""
+    artifact = validate_pr_cognitive_aid(artifact)
+    encoded = json.dumps(
+        artifact, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    encoded = (
+        encoded.replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+    )
+    return (
+        '<script id="flow-next-pr-cognitive-aid" '
+        'type="application/json">'
+        f"{encoded}</script>\n"
+    )
+
+
+def cmd_pr_cognitive_aid_html_input(args: argparse.Namespace) -> None:
+    artifact = _pr_aid_read_input(args.file)
+    try:
+        artifact = _pr_aid_object(artifact, "pr_cognitive_aid")
+        base_sha = _pr_aid_sha(artifact.get("baseSha"), "baseSha")
+        head_sha = _pr_aid_sha(artifact.get("headSha"), "headSha")
+        artifact = validate_pr_cognitive_aid(
+            artifact,
+            expected_diff_files=_pr_aid_live_diff_files(
+                get_repo_root(), base_sha, head_sha
+            ),
+        )
+        print(render_pr_cognitive_aid_html_input(artifact), end="")
+    except PrCognitiveAidValidationError as exc:
+        error_exit(str(exc), use_json=False, code=2)
 
 
 # Backward-compat alias (T2 layers the deprecation warning).
@@ -16544,7 +26907,7 @@ def cmd_spec_set_title(args: argparse.Namespace) -> None:
 
     # Update task JSON content
     task_id_map = dict(task_files)  # old_task_id -> new_task_id
-    for old_task_id, new_task_id in task_files:
+    for _old_task_id, new_task_id in task_files:
         task_path = tasks_dir / f"{new_task_id}.json"
         if task_path.exists():
             task_data = normalize_task(load_json(task_path))
@@ -16794,7 +27157,7 @@ def cmd_spec_set_backend(args: argparse.Namespace) -> None:
 
     # Validate each non-empty spec up front — reject bad specs before we touch
     # disk. Empty string is a clear-signal and skips validation.
-    for field, value in (
+    for _field_name, value in (
         ("--impl", args.impl),
         ("--review", args.review),
         ("--sync", args.sync),
@@ -17055,18 +27418,31 @@ def _export_materialize_diff(
         [
             "diff",
             "--numstat",
-            "-M",
-            "--diff-filter=AMRD",
+            "-C",
+            "--find-copies-harder",
+            "--diff-filter=AMRDC",
             f"{merge_base_sha}..HEAD",
         ],
         cwd=repo_root,
     )
     name_status_rc, name_status, _ = _export_run_git(
-        ["diff", "--name-status", "-M", f"{merge_base_sha}..HEAD"],
+        [
+            "diff",
+            "--name-status",
+            "-C",
+            "--find-copies-harder",
+            f"{merge_base_sha}..HEAD",
+        ],
         cwd=repo_root,
     )
     unified_rc, unified, _ = _export_run_git(
-        ["diff", "-M", "--unified=0", f"{merge_base_sha}..HEAD"],
+        [
+            "diff",
+            "-C",
+            "--find-copies-harder",
+            "--unified=0",
+            f"{merge_base_sha}..HEAD",
+        ],
         cwd=repo_root,
     )
     return _ExportDiffMaterialization(
@@ -17170,7 +27546,7 @@ def _export_parse_boundaries(spec_text: str) -> list[str]:
     bullets: list[str] = []
     for line in body.splitlines():
         line = line.strip()
-        if line.startswith("- ") or line.startswith("* "):
+        if line.startswith(("- ", "* ")):
             bullets.append(line[2:].strip())
     return bullets
 
@@ -17186,7 +27562,7 @@ def _export_parse_open_questions(spec_text: str) -> list[str]:
     items: list[str] = []
     for line in body.splitlines():
         stripped = line.strip()
-        if stripped.startswith("- ") or stripped.startswith("* "):
+        if stripped.startswith(("- ", "* ")):
             items.append(stripped[2:].strip())
     return items
 
@@ -17271,16 +27647,15 @@ def _export_diff_summary(
 ) -> dict[str, Any]:
     """Build the diff_summary block from git diff output.
 
-    Uses `git diff --numstat -M --diff-filter=AMRD <merge_base>..HEAD` for
-    per-file additions/deletions, `--name-status -M` for status (A/M/R/D),
-    and a unified-diff scan for added export lines.
+    Uses copy-aware Git diff materialization for per-file additions/deletions,
+    status (A/M/R/C/D), and a unified-diff scan for added export lines.
     """
     diff = materialized or _export_materialize_diff(merge_base_sha, repo_root)
     head_sha = diff.head_sha
 
     # numstat: per-file additions/deletions. Renames render as a tab-separated
-    # `old\tnew` path on the third column (or `{old => new}` brace form when
-    # `-M` matches a rename).
+    # `old\tnew` path on the third column, a `{old => new}` brace form, or a
+    # root-level `old => new` arrow form when `-M` matches a rename.
     files_numstat: dict[str, dict[str, Any]] = {}
     if diff.numstat_rc == 0:
         for line in diff.numstat.splitlines():
@@ -17308,13 +27683,17 @@ def _export_diff_summary(
                 # numstat may emit `old\tnew\t` for moved files; take new.
                 pieces = path_raw.split("\t")
                 path = pieces[-1] if pieces else path_raw
+            elif " => " in path_raw:
+                # Root-level rename: `old.txt => new.txt` → `new.txt`.
+                path = path_raw.rsplit(" => ", 1)[1]
             files_numstat[path] = {
                 "path": path,
                 "additions": adds,
                 "deletions": dels,
             }
 
-    # name-status: A/M/D/R. Renames appear as `R<score>\told\tnew`.
+    # name-status: A/M/D/R/C. Renames and copies appear as
+    # `<status><score>\told\tnew`.
     file_status: dict[str, str] = {}
     if diff.name_status_rc == 0:
         for line in diff.name_status.splitlines():
@@ -17918,10 +28297,7 @@ def _export_is_glossary_candidate(path: str) -> bool:
         return False
     if any(part in _EXPORT_GLOSSARY_SKIP_DIRS for part in parts[:-1]):
         return False
-    return not (
-        path.startswith("plugins/flow-next/codex/")
-        or path.startswith(".flow/memory/")
-    )
+    return not path.startswith(("plugins/flow-next/codex/", ".flow/memory/"))
 
 
 def _export_changed_glossary_paths(name_status: str) -> list[str]:
@@ -18095,7 +28471,7 @@ def _export_strategy_alignment(
     if body:
         for line in body.splitlines():
             stripped = line.strip()
-            if stripped.startswith("- ") or stripped.startswith("* "):
+            if stripped.startswith(("- ", "* ")):
                 track = stripped[2:].strip()
                 # Strip backticks / bold markers.
                 track = track.strip("`").strip("*").strip()
@@ -18114,7 +28490,7 @@ def _export_strategy_alignment(
             continue
         for line in body.splitlines():
             stripped = line.strip()
-            if stripped.startswith("- ") or stripped.startswith("* "):
+            if stripped.startswith(("- ", "* ")):
                 # Format: `- <track>: <reason>` if present.
                 content = stripped[2:].strip()
                 track, _, reason = content.partition(":")
@@ -18751,7 +29127,7 @@ def cmd_task_set_backend(args: argparse.Namespace) -> None:
 
     # Validate each non-empty spec up front — reject bad specs before we touch
     # disk. Empty string is a clear-signal and skips validation.
-    for field, value in (
+    for _field_name, value in (
         ("--impl", args.impl),
         ("--review", args.review),
         ("--sync", args.sync),
@@ -19526,7 +29902,7 @@ def cmd_ready(args: argparse.Namespace) -> None:
     in_progress = []
     blocked = []
 
-    for task_id, task in tasks.items():
+    for task in tasks.values():
         # MU-2: Track in_progress tasks separately
         if task["status"] == "in_progress":
             in_progress.append(task)
@@ -20383,6 +30759,20 @@ def cmd_rp_select_add(args: argparse.Namespace) -> None:
 def cmd_rp_chat_send(args: argparse.Namespace) -> None:
     message = read_text_or_exit(Path(args.message_file), "Message file", use_json=False)
     chat_id_arg = getattr(args, "chat_id", None)
+    tab_arg = getattr(args, "tab", None)
+    context_id_arg = getattr(args, "context_id", None)
+    if not tab_arg and not context_id_arg:
+        error_exit(
+            "chat-send requires Classic --tab or CE --context-id",
+            use_json=False,
+            code=2,
+        )
+    if context_id_arg and not chat_id_arg:
+        error_exit(
+            "chat-send --context-id requires --chat-id",
+            use_json=False,
+            code=2,
+        )
     mode = getattr(args, "mode", "chat") or "chat"
     oracle_payload = build_chat_payload(
         message=message,
@@ -20399,19 +30789,23 @@ def cmd_rp_chat_send(args: argparse.Namespace) -> None:
         chat_id=chat_id_arg,
         selected_paths=args.selected_paths,
     )
-    oracle_cmd = [
-        "-w",
-        str(args.window),
-        "-t",
-        args.tab,
-        "-e",
-        f"call oracle_send {oracle_payload}",
-    ]
+    oracle_cmd = (
+        ["--context-id", context_id_arg]
+        if context_id_arg
+        else ["-w", str(args.window)]
+    )
+    if tab_arg:
+        oracle_cmd.extend(("-t", tab_arg))
+    oracle_cmd.extend(("-e", f"call oracle_send {oracle_payload}"))
+    if context_id_arg:
+        res = run_rp_cli(oracle_cmd)
+        print(res.stdout, end="")
+        return
     legacy_cmd = [
         "-w",
         str(args.window),
         "-t",
-        args.tab,
+        tab_arg,
         "-e",
         f"call chat_send {legacy_payload}",
     ]
@@ -20445,26 +30839,47 @@ def cmd_rp_prompt_export(args: argparse.Namespace) -> None:
 
 
 def cmd_rp_setup_review(args: argparse.Namespace) -> None:
-    """Atomic RP setup: resolve matching window, then open a builder tab.
+    """Atomic RP setup: resolve a window, then run Context Builder.
 
-    Returns W=<window> T=<tab> on success, exits non-zero on failure.
-    With --response-type review, also returns CHAT_ID and review findings.
-
-    Requires RepoPrompt 1.6.0+ for --response-type review.
+    CE review mode consumes the authoritative direct tool result. Classic is
+    the isolated compatibility fallback and retains its published-tab flow.
     """
 
     repo_root = os.path.realpath(args.repo_root)
-    summary = args.summary
+    summary_file = getattr(args, "summary_file", None)
+    summary = (
+        read_text_or_exit(Path(summary_file), "Review summary", use_json=False)
+        if summary_file
+        else args.summary
+    )
     response_type = getattr(args, "response_type", None)
+    response_file = getattr(args, "response_file", None)
+    if not isinstance(summary, str) or not summary.strip():
+        error_exit(
+            "setup-review requires a non-blank --summary",
+            use_json=False,
+            code=2,
+        )
+    rp_cli = require_rp_cli()
+    is_ce = Path(rp_cli).name != "rp-cli"
+    if is_ce and response_type == "review" and not args.json and not response_file:
+        error_exit(
+            "CE setup-review with --response-type review requires "
+            "--response-file unless --json is used",
+            use_json=False,
+            code=2,
+        )
 
     # Step 1: pick-window
     roots = normalize_repo_root(repo_root)
     win_id = bind_context_window(
-        repo_root, create_if_missing=bool(getattr(args, "create", False))
+        repo_root,
+        create_if_missing=bool(getattr(args, "create", False)),
+        rp_cli=rp_cli,
     )
     windows: list[dict[str, Any]] = []
     if win_id is None:
-        result = run_rp_cli(["--raw-json", "-e", "windows"])
+        result = run_rp_cli(["--raw-json", "-e", "windows"], rp_cli=rp_cli)
         windows = parse_windows(result.stdout or "")
 
     # Single window with no root paths - use it
@@ -20491,7 +30906,8 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
                 "--raw-json",
                 "-e",
                 f"call manage_workspaces {json.dumps({'action': 'list'})}",
-            ]
+            ],
+            rp_cli=rp_cli,
         )
         workspace = find_workspace_for_repo(
             parse_manage_workspaces(workspaces_res.stdout or ""),
@@ -20515,7 +30931,8 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
                             "--raw-json",
                             "-e",
                             f"call manage_workspaces {json.dumps(switch_cmd)}",
-                        ]
+                        ],
+                        rp_cli=rp_cli,
                     )
                     try:
                         switch_data = json.loads(switch_res.stdout or "{}")
@@ -20533,7 +30950,9 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
             create_cmd = (
                 f"workspace create {shlex.quote(ws_name)} --new-window --folder-path {shlex.quote(repo_root)}"
             )
-            create_res = run_rp_cli(["--raw-json", "-e", create_cmd])
+            create_res = run_rp_cli(
+                ["--raw-json", "-e", create_cmd], rp_cli=rp_cli
+            )
             try:
                 data = json.loads(create_res.stdout or "{}")
                 win_id = extract_response_window_id(data)
@@ -20548,10 +30967,15 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
         else:
             error_exit("No RepoPrompt window matches repo root", use_json=False, code=2)
 
-    # Step 2: builder (with optional --type flag for RP 1.6.0+)
-    builder_expr = f"builder {json.dumps(summary)}"
-    if response_type:
-        builder_expr += f" --type {response_type}"
+    # Step 2: builder. CE requires the named-tool instructions field. Classic
+    # retains its established positional command and published-tab contract.
+    if is_ce:
+        builder_payload: dict[str, Any] = {"instructions": summary}
+        if response_type:
+            builder_payload["response_type"] = response_type
+        builder_expr = f"call context_builder {json.dumps(builder_payload)}"
+    else:
+        builder_expr = f"builder {shlex.quote(summary)}"
 
     builder_cmd = [
         "-w",
@@ -20560,44 +30984,62 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
         "-e",
         builder_expr,
     ]
-    builder_res = run_rp_cli(builder_cmd)
+    builder_res = run_rp_cli(builder_cmd, rp_cli=rp_cli)
     output = (builder_res.stdout or "") + (
         "\n" + builder_res.stderr if builder_res.stderr else ""
     )
 
-    # Parse response based on response-type
-    if response_type == "review":
+    # CE review is a single direct tool result. It may intentionally have no
+    # visible compose-tab projection, so never query workspace_context here.
+    if is_ce and response_type == "review":
         try:
             data = json.loads(builder_res.stdout or "{}")
-            tab = extract_builder_tab_from_payload(data) or ""
-            chat_id = data.get("review", {}).get("chat_id", "")
-            review_response = data.get("review", {}).get("response", "")
+        except json.JSONDecodeError as exc:
+            error_exit(
+                f"CE context_builder review JSON parse failed: {exc}",
+                use_json=False,
+                code=2,
+            )
+        data = validate_rp_ce_builder_review(data)
+        tab = str(data["context_id"])
+        review = data["review"]
+        chat_id = str(review["chat_id"])
+        review_response = str(review["response"])
+        if response_file:
+            atomic_write(Path(response_file), review_response)
 
-            if not tab:
-                error_exit("Builder did not return a tab/context id", use_json=False, code=2)
-
-            if args.json:
-                print(
-                    json.dumps(
-                        {
-                            "window": win_id,
-                            "tab": tab,
-                            "chat_id": chat_id,
-                            "review": review_response,
-                            "repo_root": repo_root,
-                            "file_count": data.get("file_count", 0),
-                            "total_tokens": data.get("total_tokens", 0),
-                        }
+        result = {
+            "mode": "ce",
+            "window": win_id,
+            "tab": tab,
+            "context_id": tab,
+            "chat_id": chat_id,
+            "review": review_response,
+            "repo_root": repo_root,
+            "status": data["status"],
+            "prompt": data["prompt"],
+            "selection": data["selection"],
+            "file_count": data["file_count"],
+            "total_tokens": data["total_tokens"],
+            "response_type": data["response_type"],
+            "follow_up_hint": data.get("follow_up_hint"),
+        }
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print(
+                " ".join(
+                    (
+                        "RP_MODE=ce",
+                        f"W={win_id}",
+                        f"T={shlex.quote(tab)}",
+                        f"CHAT_ID={shlex.quote(chat_id)}",
                     )
                 )
-            else:
-                print(f"W={win_id} T={tab} CHAT_ID={chat_id}")
-                if review_response:
-                    print(review_response)
-        except json.JSONDecodeError:
-            error_exit("Failed to parse builder review response", use_json=False, code=2)
+            )
     else:
-        # Try JSON first (RP 2.1.4+), fall back to regex for older versions
+        # Classic compatibility: Context Builder publishes a tab which the
+        # caller augments before a separate chat dispatch.
         tab = ""
         try:
             data = json.loads(builder_res.stdout or "{}")
@@ -20609,10 +31051,22 @@ def cmd_rp_setup_review(args: argparse.Namespace) -> None:
         if not tab:
             error_exit("Builder did not return a tab/context id", use_json=False, code=2)
 
+        verify_rp_classic_builder_context(win_id, tab, rp_cli=rp_cli)
+
         if args.json:
-            print(json.dumps({"window": win_id, "tab": tab, "repo_root": repo_root}))
+            print(
+                json.dumps(
+                    {
+                        "mode": "classic" if not is_ce else "context",
+                        "window": win_id,
+                        "tab": tab,
+                        "repo_root": repo_root,
+                    }
+                )
+            )
         else:
-            print(f"W={win_id} T={tab}")
+            mode = "classic" if not is_ce else "context"
+            print(f"RP_MODE={mode} W={win_id} T={shlex.quote(tab)}")
 
 
 # --- Codex Commands ---
@@ -21299,8 +31753,16 @@ implementations.
         review_json_tally_block=REVIEW_JSON_TALLY_BLOCK,
     )
 
-# Fallback template body if the on-disk file is missing (global installs, Codex
-# mirror, or stripped-down deployments). Keep in sync with validate-pass.md.
+VALIDATOR_TEMPLATE_REL = (
+    "plugins/flow-next/skills/flow-next-impl-review/validate-pass.md"
+)
+
+# Fallback body used only when validate-pass.md is absent (global installs,
+# Codex mirror, stripped-down deployments). This is a deliberately SHORTER
+# hand-written condensation of that template, authored alongside it in #118 -
+# NOT a copy, and NOT drift. Do not expand it to match the template: that is a
+# prompt change, and it is the exact mistake reverted in #245. Keep it
+# semantically faithful; test_prompt_text_pinned.py pins the bytes.
 VALIDATOR_TEMPLATE_FALLBACK = """# Validator prompt (fn-32.1 --validate)
 
 You are validating review findings for false positives. For each finding below,
@@ -21426,7 +31888,7 @@ def render_findings_block(findings: list[dict]) -> str:
             header_bits.append(f"confidence={conf}")
         if cls:
             header_bits.append(f"classification={cls}")
-        lines.append(f"### " + " | ".join(header_bits))
+        lines.append("### " + " | ".join(header_bits))
         if loc:
             lines.append(f"- location: `{loc}`")
         if title:
@@ -21888,8 +32350,11 @@ DEEP_PASSES_TEMPLATE_REL = (
     "plugins/flow-next/skills/flow-next-impl-review/deep-passes.md"
 )
 
-# Fallback templates if the on-disk file is missing (global installs, Codex
-# mirror, stripped-down deployments). Keep in sync with deep-passes.md.
+# Fallback bodies used only when deep-passes.md is absent (global installs,
+# Codex mirror, stripped-down deployments). Deliberately SHORTER hand-written
+# condensations of the template blocks, authored alongside them in #118 - NOT
+# copies, and NOT drift. Do not expand them to match the template; see the note
+# on VALIDATOR_TEMPLATE_FALLBACK above.
 DEEP_PASSES_FALLBACK: dict[str, str] = {
     "adversarial": """# Adversarial pass
 
@@ -23166,6 +33631,102 @@ def cmd_sync_get_state(args: argparse.Namespace) -> None:
             print(f"  {key}: {val if val is not None else '(unset)'}")
 
 
+def _live_spec_operation_claim(flow_dir: Path, spec_id: str) -> Optional[dict]:
+    """First LIVE spec-keyed tracker operation claim for ``spec_id``, or None.
+
+    PR #246: the tracker verbs serialize their whole read/provider-mutation/
+    persist transactions via per-spec claims under `.flow/create-first/`
+    (create/persist-external: `spec-<id>.json`, sync-body:
+    `syncbody-<id>.json`, status:
+    `status-<id>.json`, facade sequences: `facade-<id>.json` - the outer
+    claim the push/reconcile/comment facades hold ACROSS their steps, since the
+    per-step claims leave relinkable gaps between steps). The relink writer
+    must HONOR those claims - each
+    verb's locked identity recheck can only detect a repoint after the remote
+    mutation has already landed on the old issue; it cannot undo it. Refusing
+    the relink while a live claim exists makes the exclusion claim-based
+    rather than detect-after-the-fact.
+
+    Staleness follows flowctl_tracker's owner rules (`_claim_is_stale`): a
+    claim within the stale window is live; past the window a dead pid on THIS
+    host is a crashed run's leftover and is ignored (NOT reclaimed - releasing
+    is the owning verb's job); another host's pid space is unknowable, so its
+    claims stay live (fail closed). Inner comment-marker claims are keyed by
+    marker hash rather than spec id; the comment facade's outer claim supplies
+    the spec-wide exclusion. Older `.flow/bin` copies without the tracker
+    package have no claim writers either, so the guarded import degrades to no
+    check - exactly their current semantics.
+    """
+    try:
+        from flowctl_tracker.lifecycle.verbs import _claim_is_stale
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if not (here / "flowctl_tracker").is_dir():
+            return None
+        sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker.lifecycle.verbs import _claim_is_stale
+        except ImportError:
+            return None
+    candidates = [
+        (flow_dir / "create-first" / f"{prefix}-{spec_id}.json", op)
+        for prefix, op in (("spec", "create"), ("syncbody", "sync-body"),
+                           ("status", "status"), ("facade", "facade"))
+    ]
+    candidates.extend(
+        (path, "relate")
+        for path in sorted(
+            (flow_dir / "create-first").glob(f"relate-{spec_id}-*.json"))
+    )
+    for rec_path, op in candidates:
+        try:
+            claim = json.loads(rec_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if (isinstance(claim, dict)
+                and claim.get("status") == "pending"
+                and not _claim_is_stale(claim, rec_path)):
+            return {"op": claim.get("op") or op, "file": rec_path.name,
+                    "pid": claim.get("pid"), "host": claim.get("host")}
+    return None
+
+
+def _locked_sync_state_update(args: argparse.Namespace, *, action: str,
+                              mutate):
+    """Reload, claim-check, and mutate one legacy tracker sidecar atomically.
+
+    Deterministic tracker transactions hold a per-spec operation claim for
+    their full read/provider-write/persist window. Legacy sync-state setters
+    must honor that inventory under the same writer lock or a stale whole-file
+    write can erase the transaction's newly committed state.
+
+    ``mutate`` receives the tracker state and returns ``False`` for a true
+    no-op; any other return value is passed back after the atomic write.
+    """
+    flow_dir = get_flow_dir()
+    try:
+        with _shared_config_lock(flow_dir):
+            spec_json_path, spec_data = _resolve_sync_spec(args)
+            live = _live_spec_operation_claim(flow_dir, args.id)
+            if live is not None:
+                error_exit(
+                    f"spec {args.id} has a tracker {live['op']} operation in "
+                    f"flight (claim {live['file']}, pid {live['pid']} on "
+                    f"{live['host']}); refusing to {action} while it holds "
+                    "the claim; retry after the operation finishes",
+                    use_json=args.json,
+                )
+            result = mutate(spec_data["tracker"])
+            if result is not False:
+                _write_sync_state(spec_json_path, spec_data)
+            return spec_data, result
+    except TimeoutError as exc:
+        error_exit(
+            f"could not acquire the config writer lock for {action}: {exc}",
+            use_json=args.json,
+        )
+
+
 def cmd_sync_set_tracker_id(args: argparse.Namespace) -> None:
     """Link a spec to a tracker issue (UUID id + display identifier + url) (R4)."""
     if not ensure_flow_exists():
@@ -23200,31 +33761,71 @@ def cmd_sync_set_tracker_id(args: argparse.Namespace) -> None:
             use_json=args.json,
         )
 
-    spec_json_path, spec_data = _resolve_sync_spec(args)
-
-    # Collision guard (R5): refuse to link two specs to one tracker UUID unless
-    # forced (re-link of the same spec is always fine).
+    # PR #246: the relink is a spec-identity WRITE, so the whole
+    # reload-guard-mutate-write runs INSIDE the shared config writer lock -
+    # the same lock every tracker verb's identity recheck (syncbody commit,
+    # comment recheck, linkstate _complete) reloads the spec under. Without
+    # it a relink could land between a verb's locked recheck and its reload,
+    # letting the recheck validate a locator the spec no longer holds. Under
+    # the lock a relink commits wholly before a recheck (detected) or wholly
+    # after it (serialized). Older `.flow/bin` copies without the tracker
+    # package degrade to the previous unlocked write via the nullcontext
+    # fallback - those copies have no locked recheck to coordinate with.
     flow_dir = get_flow_dir()
-    for owner_id, owner_state in _iter_tracker_states(flow_dir):
-        if owner_id == args.id:
-            continue
-        if owner_state.get("id") and owner_state["id"] == args.tracker_id:
-            if not getattr(args, "force", False):
+    try:
+        with _shared_config_lock(flow_dir):
+            spec_json_path, spec_data = _resolve_sync_spec(args)
+
+            # PR #246: honor LIVE per-spec operation claims (create/sync-body/
+            # status). A verb's identity recheck can only detect a relink
+            # AFTER its provider mutation landed on the old issue; refusing
+            # here keeps the relink out of the whole claimed window. The
+            # operation is short-lived and releases its claim on completion -
+            # this refusal is retryable.
+            live = _live_spec_operation_claim(flow_dir, args.id)
+            if live is not None:
                 error_exit(
-                    f"Tracker id {args.tracker_id} already linked to spec "
-                    f"{owner_id}. Pass --force to override (rare; usually a "
-                    f"duplicate-issue mistake).",
+                    f"spec {args.id} has a tracker {live['op']} operation in "
+                    f"flight (claim {live['file']}, pid {live['pid']} on "
+                    f"{live['host']}); refusing to relink while it holds the "
+                    "claim; retry after the operation finishes",
                     use_json=args.json,
                 )
 
-    state = spec_data["tracker"]
-    state["id"] = args.tracker_id
-    if validated_identifier is not None:
-        # Persist the canonical stripped display form (e.g. "WOR-17").
-        state["identifier"] = validated_identifier[2]
-    if args.url is not None:
-        state["url"] = args.url
-    _write_sync_state(spec_json_path, spec_data)
+            # Collision guard (R5): refuse to link two specs to one tracker
+            # UUID unless forced (re-link of the same spec is always fine).
+            for owner_id, owner_state in _iter_tracker_states(flow_dir):
+                if owner_id == args.id:
+                    continue
+                if owner_state.get("id") and owner_state["id"] == args.tracker_id:
+                    if not getattr(args, "force", False):
+                        error_exit(
+                            f"Tracker id {args.tracker_id} already linked to spec "
+                            f"{owner_id}. Pass --force to override (rare; usually a "
+                            f"duplicate-issue mistake).",
+                            use_json=args.json,
+                        )
+
+            state = spec_data["tracker"]
+            state["id"] = args.tracker_id
+            # A durable provider id completes an identifier-only MCP link.
+            # derive_link_state gives this explicit field precedence, so
+            # leaving it unchanged would keep durable-only verbs blocked.
+            state["linkState"] = "linked"
+            if validated_identifier is not None:
+                # Persist the canonical stripped display form (e.g. "WOR-17").
+                state["identifier"] = validated_identifier[2]
+            if args.url is not None:
+                state["url"] = args.url
+            _write_sync_state(spec_json_path, spec_data)
+    except TimeoutError as exc:
+        # ConfigLockTimeout (a TimeoutError): another writer holds the lock
+        # past the acquisition deadline. Surface cleanly instead of a
+        # traceback; nothing was written.
+        error_exit(
+            f"could not acquire the config writer lock for set-tracker-id: {exc}",
+            use_json=args.json,
+        )
 
     if args.json:
         json_output({"id": args.id, "tracker": state, "message": "tracker id set"})
@@ -23242,10 +33843,14 @@ def cmd_sync_set_last_synced(args: argparse.Namespace) -> None:
     if not is_spec_id(args.id):
         error_exit(f"Invalid spec ID: {args.id}", use_json=args.json)
 
-    spec_json_path, spec_data = _resolve_sync_spec(args)
     ts = args.at if getattr(args, "at", None) else now_iso()
-    spec_data["tracker"]["lastSyncedAt"] = ts
-    _write_sync_state(spec_json_path, spec_data)
+
+    def mutate(state):
+        state["lastSyncedAt"] = ts
+        return True
+
+    _locked_sync_state_update(
+        args, action="set-last-synced", mutate=mutate)
 
     if args.json:
         json_output({"id": args.id, "lastSyncedAt": ts, "message": "lastSyncedAt set"})
@@ -23291,13 +33896,16 @@ def cmd_sync_set_merge_base(args: argparse.Namespace) -> None:
             use_json=args.json,
         )
 
-    spec_json_path, spec_data = _resolve_sync_spec(args)
+    def mutate(state):
+        state["mergeBaseFlow"] = flow_body
+        state["baseHashFlow"] = _content_hash(flow_body)
+        state["mergeBaseTracker"] = tracker_body
+        state["baseHashTracker"] = _content_hash(tracker_body)
+        return True
+
+    spec_data, _ = _locked_sync_state_update(
+        args, action="set-merge-base", mutate=mutate)
     state = spec_data["tracker"]
-    state["mergeBaseFlow"] = flow_body
-    state["baseHashFlow"] = _content_hash(flow_body)
-    state["mergeBaseTracker"] = tracker_body
-    state["baseHashTracker"] = _content_hash(tracker_body)
-    _write_sync_state(spec_json_path, spec_data)
 
     if args.json:
         json_output(
@@ -23327,9 +33935,26 @@ def cmd_sync_clear(args: argparse.Namespace) -> None:
     if not is_spec_id(args.id):
         error_exit(f"Invalid spec ID: {args.id}", use_json=args.json)
 
-    spec_json_path, spec_data = _resolve_sync_spec(args)
-    spec_data["tracker"] = default_spec_tracker_state()
-    _write_sync_state(spec_json_path, spec_data)
+    flow_dir = get_flow_dir()
+    try:
+        with _shared_config_lock(flow_dir):
+            spec_json_path, spec_data = _resolve_sync_spec(args)
+            live = _live_spec_operation_claim(flow_dir, args.id)
+            if live is not None:
+                error_exit(
+                    f"spec {args.id} has a tracker {live['op']} operation in "
+                    f"flight (claim {live['file']}, pid {live['pid']} on "
+                    f"{live['host']}); refusing to unlink while it holds the "
+                    "claim; retry after the operation finishes",
+                    use_json=args.json,
+                )
+            spec_data["tracker"] = default_spec_tracker_state()
+            _write_sync_state(spec_json_path, spec_data)
+    except TimeoutError as exc:
+        error_exit(
+            f"could not acquire the config writer lock for sync clear: {exc}",
+            use_json=args.json,
+        )
 
     if args.json:
         json_output({"id": args.id, "tracker": spec_data["tracker"], "message": "unlinked"})
@@ -23485,8 +34110,10 @@ def cmd_sync_list_dep_relations(args: argparse.Namespace) -> None:
     resolves the dep spec's tracker link + LOCAL status, plus whether the edge
     is already in our `depRelations` provenance ledger. Self-edges are skipped
     (a spec can never `depends_on_epics` itself, but we guard defensively so the
-    listing can never represent a self-relation). Transport-blind: this is pure
-    flowctl plumbing; the projection DECISION lives in the skill (fn-64.5).
+    listing can never represent a self-relation). fn-141 R8 supersedes fn-57
+    R3: this command remains a local-state enumerator, while deterministic
+    tracker transport and relation mutation now live in `flowctl tracker`.
+    Semantic conflict recovery remains in the tracker-sync skill.
 
     Output (`--json`): `[{dep_spec, dep_tracker_id, dep_identifier,
     dep_status, projected}]` where `dep_status` is the local dep-spec status.
@@ -23576,44 +34203,32 @@ def cmd_sync_set_dep_relation(args: argparse.Namespace) -> None:
     if dep_spec == args.id:
         error_exit("A spec cannot have a dependency relation to itself", use_json=args.json)
 
-    spec_json_path, spec_data = _resolve_sync_spec(args)
-    if dep_spec == args.id:  # re-check post-expand (args.id is now canonical)
-        error_exit("A spec cannot have a dependency relation to itself", use_json=args.json)
-
     rel_type = getattr(args, "type", None) or "blocks"
     source = getattr(args, "source", None) or "flow"
     key = _dep_relation_key(args.from_tracker_id, args.to_tracker_id)
 
-    state = spec_data["tracker"]
-    ledger = state.setdefault("depRelations", [])
-    for entry in ledger:
-        if entry.get("key") == key:
-            # Idempotent no-op — same directed edge already recorded.
-            if args.json:
-                json_output(
-                    {
-                        "success": True,
-                        "id": args.id,
-                        "key": key,
-                        "depRelations": ledger,
-                        "message": "dep relation already recorded",
-                    }
-                )
-            else:
-                print(f"dep relation {key} already recorded for {args.id}")
-            return
+    def mutate(state):
+        if dep_spec == args.id:  # args.id is canonical after locked resolve
+            error_exit(
+                "A spec cannot have a dependency relation to itself",
+                use_json=args.json)
+        ledger = state.setdefault("depRelations", [])
+        if any(entry.get("key") == key for entry in ledger):
+            return False
+        ledger.append({
+            "key": key,
+            "dep_spec": dep_spec,
+            "from_tracker_id": args.from_tracker_id,
+            "to_tracker_id": args.to_tracker_id,
+            "type": rel_type,
+            "source": source,
+            "updatedAt": now_iso(),
+        })
+        return True
 
-    entry = {
-        "key": key,
-        "dep_spec": dep_spec,
-        "from_tracker_id": args.from_tracker_id,
-        "to_tracker_id": args.to_tracker_id,
-        "type": rel_type,
-        "source": source,
-        "updatedAt": now_iso(),
-    }
-    ledger.append(entry)
-    _write_sync_state(spec_json_path, spec_data)
+    spec_data, changed = _locked_sync_state_update(
+        args, action="set-dep-relation", mutate=mutate)
+    ledger = spec_data["tracker"].setdefault("depRelations", [])
 
     if args.json:
         json_output(
@@ -23622,11 +34237,16 @@ def cmd_sync_set_dep_relation(args: argparse.Namespace) -> None:
                 "id": args.id,
                 "key": key,
                 "depRelations": ledger,
-                "message": f"recorded dep relation to {dep_spec}",
+                "message": (
+                    f"recorded dep relation to {dep_spec}"
+                    if changed else "dep relation already recorded"),
             }
         )
     else:
-        print(f"Recorded dep relation {key} ({args.id} → {dep_spec})")
+        if changed:
+            print(f"Recorded dep relation {key} ({args.id} → {dep_spec})")
+        else:
+            print(f"dep relation {key} already recorded for {args.id}")
 
 
 def cmd_sync_active(args: argparse.Namespace) -> None:
@@ -23754,6 +34374,309 @@ def compute_create_first_key(tracker_type: str, title: str, body: str) -> str:
     normalized_type = (tracker_type or "").strip().lower()
     payload = "\0".join([normalized_type, title or "", body or ""])
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def cmd_tracker_resolve(args: argparse.Namespace) -> None:
+    """`flowctl tracker resolve` (fn-139.6, R9) - explicit deterministic
+    backfill of `tracker.resolved` (destination + ids scope + capabilities).
+
+    Thin shell: the whole verb lives in `flowctl_tracker.resolve_verb`, which
+    emits the single result envelope on stdout and a fixed numeric exit code.
+    `--json` is accepted-and-ignored (the envelope is always JSON). The package
+    ships alongside flowctl.py; a named-files-only legacy copy reports the gap
+    explicitly rather than pretending the verb does not exist.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    try:
+        from flowctl_tracker import resolve_verb  # noqa: PLC0415
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import resolve_verb  # noqa: PLC0415
+        except ImportError:
+            error_exit(
+                "flowctl_tracker package is not installed alongside flowctl.py; "
+                "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+                use_json=getattr(args, "json", False))
+    payload, code = resolve_verb.run(
+        get_flow_dir(),
+        scope=getattr(args, "scope", None),
+        refresh=bool(getattr(args, "refresh", False)),
+        select=getattr(args, "select", None),
+    )
+    print(payload)
+    sys.exit(code)
+
+
+def cmd_tracker_wire(args: argparse.Namespace) -> None:
+    """`flowctl tracker wire <verb>` (fn-140.1) - locator-addressed wire verbs.
+
+    Thin shell over `flowctl_tracker.wire`: parse args, call the verb layer,
+    print the result envelope, exit with its code. Never raises across the
+    verb boundary - TrackerError maps to the envelope at this edge only.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    try:
+        from flowctl_tracker import wire as tracker_wire  # noqa: PLC0415
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import wire as tracker_wire  # noqa: PLC0415
+        except ImportError:
+            error_exit(
+                "flowctl_tracker package is not installed alongside flowctl.py; "
+                "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+                use_json=getattr(args, "json", False))
+    payload, code = tracker_wire.run(
+        get_flow_dir(),
+        args.wire_verb,
+        locator=getattr(args, "locator", None),
+        title=getattr(args, "title", None),
+        body_file=getattr(args, "body_file", None),
+        comment_id=getattr(args, "comment_id", None),
+        subject_id=getattr(args, "subject_id", None),
+        blocked_stage=getattr(args, "blocked_stage", None),
+        reason_code=getattr(args, "reason_code", None),
+        question_slug=getattr(args, "question_slug", None),
+        add=getattr(args, "add", None),
+        remove=getattr(args, "remove", None),
+        file_path=getattr(args, "file", None),
+        attachment_id=getattr(args, "attachment_id", None),
+        out_path=getattr(args, "out", None),
+    )
+    print(payload)
+    sys.exit(code)
+
+
+def _import_tracker_lifecycle():
+    """Guarded import matching cmd_tracker_wire / cmd_tracker_resolve."""
+    try:
+        from flowctl_tracker import lifecycle as tracker_lifecycle  # noqa: PLC0415
+        return tracker_lifecycle
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import lifecycle as tracker_lifecycle  # noqa: PLC0415
+            return tracker_lifecycle
+        except ImportError:
+            return None
+
+
+def cmd_tracker_lifecycle(args: argparse.Namespace) -> None:
+    """`flowctl tracker create|create-first|persist-external` (fn-140.2).
+
+    Thin envelope shells over `flowctl_tracker.lifecycle`. No `tracker reconcile`
+    command — UUID completion is `complete_identifier_only`, called by the .7
+    facade's `tracker sync --op reconcile`.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    tracker_lifecycle = _import_tracker_lifecycle()
+    if tracker_lifecycle is None:
+        error_exit(
+            "flowctl_tracker package is not installed alongside flowctl.py; "
+            "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+            use_json=getattr(args, "json", False))
+    payload, code = tracker_lifecycle.run(
+        get_flow_dir(),
+        args.lifecycle_verb,
+        spec_id=getattr(args, "spec_id", None),
+        title=getattr(args, "title", None),
+        body_file=getattr(args, "body_file", None),
+        event=getattr(args, "event", None),
+        retry_key=getattr(args, "retry_key", None),
+        identifier=getattr(args, "identifier", None),
+        durable_id=getattr(args, "durable_id", None),
+        url=getattr(args, "url", None),
+        source=getattr(args, "source", None),
+    )
+    print(payload)
+    sys.exit(code)
+
+
+def _import_tracker_status():
+    """Guarded import matching cmd_tracker_lifecycle / cmd_tracker_wire."""
+    try:
+        from flowctl_tracker import status as tracker_status  # noqa: PLC0415
+        return tracker_status
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import status as tracker_status  # noqa: PLC0415
+            return tracker_status
+        except ImportError:
+            return None
+
+
+def cmd_tracker_status(args: argparse.Namespace) -> None:
+    """`flowctl tracker status <spec-id> --to <slot>` (fn-140.3).
+
+    Thin envelope shell over `flowctl_tracker.status`. `--to` is a request;
+    fn-66's merge-evidence gate + who-wins ladder decide the outcome.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    tracker_status = _import_tracker_status()
+    if tracker_status is None:
+        error_exit(
+            "flowctl_tracker package is not installed alongside flowctl.py; "
+            "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+            use_json=getattr(args, "json", False))
+    payload, code = tracker_status.run(
+        get_flow_dir(),
+        spec_id=getattr(args, "spec_id", None),
+        to=getattr(args, "to", None),
+        reason=getattr(args, "reason", None),
+        event=getattr(args, "event", None),
+    )
+    print(payload)
+    sys.exit(code)
+
+
+def _import_tracker_relate():
+    """Guarded import matching cmd_tracker_status / cmd_tracker_wire."""
+    try:
+        from flowctl_tracker import relate as tracker_relate  # noqa: PLC0415
+        return tracker_relate
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import relate as tracker_relate  # noqa: PLC0415
+            return tracker_relate
+        except ImportError:
+            return None
+
+
+def cmd_tracker_relate(args: argparse.Namespace) -> None:
+    """`flowctl tracker relate <spec-id> --blocked-by <other>` (fn-140.4).
+
+    Thin envelope shell over `flowctl_tracker.relate`. Writes depRelations
+    ledger + event-tagged receipt; never clobbers a foreign edge.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    tracker_relate = _import_tracker_relate()
+    if tracker_relate is None:
+        error_exit(
+            "flowctl_tracker package is not installed alongside flowctl.py; "
+            "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+            use_json=getattr(args, "json", False))
+    payload, code = tracker_relate.run(
+        get_flow_dir(),
+        spec_id=getattr(args, "spec_id", None),
+        blocked_by=getattr(args, "blocked_by", None),
+        event=getattr(args, "event", None),
+    )
+    print(payload)
+    sys.exit(code)
+
+
+def _import_tracker_syncbody():
+    """Guarded import matching cmd_tracker_relate / cmd_tracker_wire."""
+    try:
+        from flowctl_tracker import syncbody as tracker_syncbody  # noqa: PLC0415
+        return tracker_syncbody
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import syncbody as tracker_syncbody  # noqa: PLC0415
+            return tracker_syncbody
+        except ImportError:
+            return None
+
+
+def cmd_tracker_syncbody(args: argparse.Namespace) -> None:
+    """`flowctl tracker sync-body <spec-id> --flow-file F` (fn-140.5).
+
+    Thin envelope shell over `flowctl_tracker.syncbody`. Writes (optional) +
+    readback + paired merge base atomically; never composes a merged body.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    tracker_syncbody = _import_tracker_syncbody()
+    if tracker_syncbody is None:
+        error_exit(
+            "flowctl_tracker package is not installed alongside flowctl.py; "
+            "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+            use_json=getattr(args, "json", False))
+    payload, code = tracker_syncbody.run(
+        get_flow_dir(),
+        spec_id=getattr(args, "spec_id", None),
+        flow_file=getattr(args, "flow_file", None),
+        tracker_body_file=getattr(args, "tracker_body_file", None),
+        direction=getattr(args, "direction", "push") or "push",
+        event=getattr(args, "event", None),
+    )
+    print(payload)
+    sys.exit(code)
+
+
+def _import_tracker_facade():
+    """Guarded import matching cmd_tracker_syncbody / cmd_tracker_wire."""
+    try:
+        from flowctl_tracker import facade as tracker_facade  # noqa: PLC0415
+        return tracker_facade
+    except ImportError:
+        here = Path(__file__).resolve().parent
+        if (here / "flowctl_tracker").is_dir():
+            sys.path.insert(0, str(here))
+        try:
+            from flowctl_tracker import facade as tracker_facade  # noqa: PLC0415
+            return tracker_facade
+        except ImportError:
+            return None
+
+
+def cmd_tracker_facade(args: argparse.Namespace) -> None:
+    """`flowctl tracker sync <spec-id> --op ...` (fn-140.7 lifecycle facade).
+
+    Distinct from legacy `flowctl sync ...` plumbing. One aggregate receipt;
+    judgment-bearing content always arrives as an input file.
+    """
+    if not ensure_flow_exists():
+        error_exit(".flow/ does not exist. Run 'flowctl init' first.",
+                   use_json=getattr(args, "json", False))
+    tracker_facade = _import_tracker_facade()
+    if tracker_facade is None:
+        error_exit(
+            "flowctl_tracker package is not installed alongside flowctl.py; "
+            "re-run /flow-next:setup (or reinstall) to get the tracker verbs",
+            use_json=getattr(args, "json", False))
+    payload, code = tracker_facade.run(
+        get_flow_dir(),
+        spec_id=getattr(args, "spec_id", None),
+        op=getattr(args, "op", None),
+        event=getattr(args, "event", None),
+        flow_file=getattr(args, "flow_file", None),
+        body_file=getattr(args, "body_file", None),
+        comments_file=getattr(args, "comments_file", None),
+        source_body_file=getattr(args, "source_body_file", None),
+        comment_file=getattr(args, "comment_file", None),
+        pr_url=getattr(args, "pr_url", None),
+        status_only=getattr(args, "status_only", False),
+    )
+    print(payload)
+    sys.exit(code)
 
 
 def cmd_sync_create_first_recovery(args: argparse.Namespace) -> None:
@@ -24194,9 +35117,9 @@ def cmd_sync_check(args: argparse.Namespace) -> None:
     success/failure detail. `event: null` (pre-flag) receipts never clear.
 
     Exit 0 always (best-effort contract — output drives agent action, not the
-    exit code). NO tracker-mutation code lives here or anywhere in flowctl
-    (R3): all tracker mutations stay agent-driven through the tracker-sync
-    skill; this command only reads local receipts.
+    exit code). fn-141 R8 supersedes fn-57 R3: `flowctl tracker` now owns
+    deterministic tracker mutations. This audit command itself remains
+    read-only and reads only local receipts.
     """
     # R8 zero-overhead gate: bridge inactive → silent constant-time exit 0,
     # BEFORE any receipt IO, id resolution, or output. `tracker_sync_active`
@@ -24282,7 +35205,8 @@ def spec_md_rel_path(spec_id: str) -> str:
 
 
 def _gather_review_diff(
-    base_branch: str,
+    base_sha: str,
+    head_sha: str = "HEAD",
     *,
     max_diff_bytes: int = 50000,
     truncate_marker: Optional[str] = "... [diff truncated at 50KB]",
@@ -24296,7 +35220,7 @@ def _gather_review_diff(
     diff_summary = ""
     try:
         diff_result = subprocess.run(
-            ["git", "diff", "--stat", f"{base_branch}...HEAD"],
+            ["git", "diff", "--stat", f"{base_sha}..{head_sha}"],
             capture_output=True,
             text=True, encoding="utf-8",
             cwd=get_repo_root(),
@@ -24309,7 +35233,7 @@ def _gather_review_diff(
     diff_content = ""
     try:
         proc = subprocess.Popen(
-            ["git", "diff", f"{base_branch}...HEAD"],
+            ["git", "diff", f"{base_sha}..{head_sha}"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=get_repo_root(),
@@ -24339,27 +35263,36 @@ def _gather_review_diff(
     return diff_summary, diff_content
 
 
-def _gather_review_diff_capped(base_branch: str) -> tuple[str, str]:
+def _gather_review_diff_capped(
+    base_sha: str, head_sha: str = "HEAD"
+) -> tuple[str, str]:
     """Codex/copilot gather: 50KB hard cap + truncation marker."""
-    return _gather_review_diff(base_branch)
+    return _gather_review_diff(base_sha, head_sha)
 
 
-def _gather_review_diff_cursor(base_branch: str) -> tuple[str, str]:
+def _gather_review_diff_cursor(
+    base_sha: str, head_sha: str = "HEAD"
+) -> tuple[str, str]:
     """Cursor gather: generous read cap; argv-budget fit owns truncation."""
     return _gather_review_diff(
-        base_branch,
+        base_sha,
+        head_sha,
         max_diff_bytes=CURSOR_ARGV_PROMPT_MAX * 2,
         truncate_marker=None,
     )
 
 
 def _clear_stale_review_receipt(receipt_path: Optional[str]) -> None:
-    """Best-effort unlink of a stale receipt (shared failure-path cleanup)."""
+    """Archive valid evidence before unlinking a stale latest pointer."""
     if not receipt_path:
         return
     try:
-        Path(receipt_path).unlink(missing_ok=True)
-    except OSError:
+        path = Path(receipt_path)
+        with cross_process_lock(_review_receipt_lock_path(path)):
+            if path.exists():
+                _preserve_review_receipt_generation(path)
+            path.unlink(missing_ok=True)
+    except (CrossProcessLockError, OSError, ReviewReceiptHistoryError):
         pass
 
 
@@ -24548,6 +35481,55 @@ def stamp_ralph_iteration(receipt: dict) -> None:
     except ValueError:
         pass
 
+
+def _completion_review_receipt_recovery_path(review_id: str) -> Path:
+    return (
+        get_flow_dir()
+        / "tmp"
+        / f"completion-review-receipt-recovery-{review_id}.json"
+    )
+
+
+def _resolve_review_sha(ref: str) -> Optional[str]:
+    """Resolve a review anchor locally; never dispatch or contact a remote."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+            cwd=get_repo_root(),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = proc.stdout.strip()
+    return value if proc.returncode == 0 and value else None
+
+
+def _capture_review_snapshot(base_ref: str) -> tuple[str, str]:
+    """Capture the exact merge-base/head pair before reviewer dispatch."""
+    head_sha = _resolve_review_sha("HEAD")
+    base_tip = _resolve_review_sha(base_ref)
+    if head_sha is None or base_tip is None:
+        raise ValueError(f"cannot resolve review snapshot: {base_ref}...HEAD")
+    try:
+        proc = subprocess.run(
+            ["git", "merge-base", base_tip, head_sha],
+            cwd=get_repo_root(),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ValueError(f"cannot resolve review merge base: {exc}") from exc
+    base_sha = proc.stdout.strip()
+    if proc.returncode != 0 or not base_sha:
+        raise ValueError(f"cannot resolve review merge base: {base_ref}...HEAD")
+    return base_sha, head_sha
+
+
 def _write_backend_review_receipt(
     receipt_path: str,
     *,
@@ -24566,6 +35548,8 @@ def _write_backend_review_receipt(
     suppressed_count=None,
     classification_counts=None,
     unaddressed_rids=None,
+    reviewed_base_sha: Optional[str] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> None:
     """Write a review receipt with stable key order (Ralph / pilot / land)."""
     receipt_data: dict = {
@@ -24586,6 +35570,28 @@ def _write_backend_review_receipt(
     receipt_data["spec"] = str(resolved_spec)
     receipt_data["timestamp"] = now_iso()
     receipt_data["review"] = review_text
+    if review_type == "completion_review":
+        flow_dir = get_flow_dir()
+        spec_path = find_spec_json_path(flow_dir, review_id)
+        if spec_path.exists():
+            spec_data = normalize_epic(
+                load_json_or_exit(
+                    spec_path, f"Spec {review_id}", use_json=False
+                )
+            )
+            attempts = _review_attempt_summary(
+                spec_data,
+                "plan",
+                None,
+                review_type="completion",
+            )["attempts"]
+            latest = attempts[-1] if attempts else {}
+            if (
+                latest.get("backend") == backend
+                and latest.get("verdict") == verdict
+                and isinstance(latest.get("timestamp"), str)
+            ):
+                receipt_data["attempt_timestamp"] = latest["timestamp"]
     stamp_ralph_iteration(receipt_data)
     if focus:
         receipt_data["focus"] = focus
@@ -24596,9 +35602,38 @@ def _write_backend_review_receipt(
         receipt_data["pre_existing_count"] = classification_counts["pre_existing"]
     if unaddressed_rids is not None:
         receipt_data["unaddressed"] = unaddressed_rids
-    Path(receipt_path).write_text(
-        json.dumps(receipt_data, indent=2) + "\n", encoding="utf-8"
-    )
+    receipt_file = Path(receipt_path)
+    with cross_process_lock(_review_receipt_lock_path(receipt_file)):
+        head_sha = reviewed_head_sha or _resolve_review_sha("HEAD")
+        if head_sha is not None:
+            base_sha = reviewed_base_sha
+            if base_sha is None and base_branch:
+                base_sha = _resolve_review_sha(base_branch)
+            findings = build_review_receipt_findings(
+                review_text,
+                review_type=review_type,
+                review_id=review_id,
+                backend=backend,
+                head_sha=head_sha,
+                base_sha=base_sha,
+                prior_receipt_path=receipt_file,
+                anchor_side="head",
+            )
+            if findings is not None:
+                receipt_data["findings"] = findings
+        if review_type == "completion_review":
+            criteria = bind_review_criteria(parse_review_criteria(review_text))
+            if criteria is not None:
+                receipt_data["criteria"] = criteria
+        content = json.dumps(receipt_data, indent=2) + "\n"
+        if review_type == "completion_review":
+            # Preserve the payload before the terminal pointer. The skill can
+            # recover without dispatching another review round.
+            recovery_path = _completion_review_receipt_recovery_path(review_id)
+            atomic_write(recovery_path, content)
+        if receipt_file.exists():
+            _preserve_review_receipt_generation(receipt_file)
+        atomic_write(receipt_file, content)
 
 
 
@@ -24836,6 +35871,7 @@ def _dispatch_backend_review(
     review_kind: Optional[str],
     review_type: str,
     task_id: Optional[str] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> tuple[str, Optional[str], int, str]:
     """Run a backend and refund if dispatch itself terminates before a result."""
     try:
@@ -24857,6 +35893,7 @@ def _dispatch_backend_review(
                 output="backend dispatch terminated before returning output",
                 failure_class="dispatch_error",
                 task_id=task_id,
+                reviewed_head_sha=reviewed_head_sha,
                 review_type=review_type,
                 use_json=args.json,
             )
@@ -24883,6 +35920,7 @@ def _dispatch_backend_review(
                 output=detail,
                 failure_class="dispatch_exception",
                 task_id=task_id,
+                reviewed_head_sha=reviewed_head_sha,
                 review_type=review_type,
                 use_json=args.json,
             )
@@ -24904,7 +35942,7 @@ def _dispatch_backend_review(
             use_json=args.json,
             code=2,
         )
-        raise AssertionError("error_exit must terminate")
+        raise AssertionError("error_exit must terminate") from None
 
 
 
@@ -24930,7 +35968,14 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
             error_exit(f"Task spec not found: {task_spec_path}", use_json=args.json)
         task_spec = task_spec_path.read_text(encoding="utf-8")
 
-    diff_summary, diff_content = reg["gather_diff"](base_branch)
+    resolved_spec = reg["resolve_spec"](args, task_id)
+    try:
+        reviewed_base_sha, reviewed_head_sha = _capture_review_snapshot(base_branch)
+    except ValueError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
+    diff_summary, diff_content = reg["gather_diff"](
+        reviewed_base_sha, reviewed_head_sha
+    )
 
     receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
 
@@ -24989,8 +36034,6 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
             receipt_path=receipt_path,
         )
 
-    resolved_spec = reg["resolve_spec"](args, task_id)
-
     # Cursor: persona override + final argv-cap backstop (after resolve so
     # task_id is canonicalized; order matches the pre-migration handler).
     if reg["prompt_fit"] == "cursor_argv":
@@ -25025,6 +36068,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_kind=None if standalone else "impl",
         review_type="impl",
         task_id=None if standalone else task_id,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -25039,10 +36083,9 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
         review_kind=None if standalone else "impl",
         review_type="impl",
         task_id=None if standalone else task_id,
+        reset_rounds_on_ship=not standalone,
+        reviewed_head_sha=reviewed_head_sha,
     )
-
-    if verdict == "SHIP" and not standalone:
-        reset_review_cap(spec_id_from_task(task_id), "impl", task_id=task_id)
 
     review_id = task_id if task_id else "branch"
     review_text = reg["extract_review"](output)
@@ -25072,6 +36115,8 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
             suppressed_count=suppressed_count,
             classification_counts=classification_counts,
             unaddressed_rids=unaddressed_rids,
+            reviewed_base_sha=reviewed_base_sha,
+            reviewed_head_sha=reviewed_head_sha,
         )
 
     if args.json:
@@ -25136,6 +36181,10 @@ def _finish_backend_exec(
     review_kind: Optional[str] = None,
     review_type: Optional[str] = None,
     task_id: Optional[str] = None,
+    finalize_status_kind: Optional[str] = None,
+    reset_rounds_on_ship: bool = False,
+    attempt_out: Optional[dict] = None,
+    reviewed_head_sha: Optional[str] = None,
 ) -> str:
     """Shared post-exec gates and verdict-aware round finalization.
 
@@ -25146,7 +36195,7 @@ def _finish_backend_exec(
     verdict = parse_codex_verdict(output)
     if verdict:
         if spec_id and review_kind:
-            record_review_attempt(
+            summary = record_review_attempt(
                 spec_id,
                 review_kind,
                 backend=backend,
@@ -25155,7 +36204,12 @@ def _finish_backend_exec(
                 task_id=task_id,
                 review_type=review_type,
                 use_json=args.json,
+                finalize_status_kind=finalize_status_kind,
+                reset_rounds_on_ship=reset_rounds_on_ship,
+                reviewed_head_sha=reviewed_head_sha,
             )
+            if attempt_out is not None:
+                attempt_out.update(summary)
         return verdict
 
     sandbox_failure = (
@@ -25182,6 +36236,7 @@ def _finish_backend_exec(
             output=output,
             failure_class=failure_class,
             task_id=task_id,
+            reviewed_head_sha=reviewed_head_sha,
             review_type=review_type,
             use_json=args.json,
         )
@@ -25202,9 +36257,16 @@ def _finish_backend_exec(
     if sandbox_failure:
         _clear_stale_review_receipt(receipt_path)
         msg = (
-            "Codex sandbox blocked operations. "
-            "Try --sandbox danger-full-access (or auto) or set "
-            "CODEX_SANDBOX=danger-full-access"
+            "Codex sandbox blocked operations during review. Reviewers are "
+            "READ-ONLY by contract: a reviewer that needed a write or a "
+            "blocked shell command is a prompt/scope bug, not a permissions "
+            "problem. Do NOT widen the reviewer sandbox to work around this; "
+            "fix whatever asked the reviewer to mutate the workspace. "
+            "Widening (--sandbox danger-full-access / CODEX_SANDBOX) is "
+            "legitimate ONLY on Windows, where the AppContainer sandbox "
+            "blocks reads too (auto already resolves there). No verdict was "
+            "delivered, so no review round was consumed; a delivered verdict "
+            "is never a transport failure."
         )
         error_exit(msg, use_json=args.json, code=3)
 
@@ -25267,6 +36329,11 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
     )
 
     base_branch = args.base if hasattr(args, "base") and args.base else "main"
+    resolved_spec = reg["resolve_spec"](args, None, spec_id=epic_id)
+    try:
+        reviewed_base_sha, reviewed_head_sha = _capture_review_snapshot(base_branch)
+    except ValueError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
     context_hints = gather_context_hints(base_branch)
     prompt = build_review_prompt(
         "plan", epic_spec, context_hints, task_specs=task_specs
@@ -25301,8 +36368,6 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         )
         prompt = rereview_preamble + prompt
 
-    resolved_spec = reg["resolve_spec"](args, None, spec_id=epic_id)
-
     if reg["prompt_fit"] == "cursor_argv":
         prompt = build_cursor_persona_override() + prompt
         prompt = fit_cursor_prompt_to_budget(
@@ -25328,6 +36393,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="plan",
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -25335,20 +36401,22 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
         prior_receipt_model=prior_receipt_model,
         prior_receipt_effort=prior_receipt_effort,
     )
+    attempt_summary: dict = {}
     verdict = _finish_backend_exec(
         backend=backend, reg=reg, args=args, receipt_path=receipt_path,
         output=output, stderr=stderr, exit_code=exit_code,
         spec_id=epic_id,
         review_kind="plan",
         review_type="plan",
+        finalize_status_kind="plan",
+        reset_rounds_on_ship=True,
+        attempt_out=attempt_summary,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
-    if verdict == "SHIP":
-        reset_review_cap(epic_id, "plan")
-
-    written_status = _self_write_review_status(
-        epic_id, "plan", verdict, use_json=args.json
-    )
+    # issue #279: attempt row, plan_review_status, and the SHIP cap reset all
+    # landed in ONE atomic sidecar write inside record_review_attempt.
+    written_status = attempt_summary.get("status_written")
 
     review_text = reg["extract_review"](output)
 
@@ -25365,6 +36433,9 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
             resolved_spec=resolved_spec,
             review_text=review_text,
             include_effort=reg["include_effort"],
+            base_branch=base_branch,
+            reviewed_base_sha=reviewed_base_sha,
+            reviewed_head_sha=reviewed_head_sha,
         )
 
     review_rounds = _current_review_rounds(epic_id, "plan", use_json=args.json)
@@ -25398,6 +36469,14 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
     if not ensure_flow_exists():
         error_exit(".flow/ does not exist", use_json=args.json)
 
+    # Fail closed pre-dispatch (fn-137): an existing-but-invalid
+    # .flow/criteria.md must abort the review instead of silently running
+    # every backend without the configured standing criteria.
+    try:
+        build_global_criteria_block()
+    except ValueError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
+
     epic_id = resolve_spec_id_arg(get_flow_dir(), args.epic, use_json=args.json)
     epic_spec_path, tasks_dir, epic_spec, task_specs, task_ids = (
         _load_epic_and_task_specs(
@@ -25410,11 +36489,18 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
     base_branch = args.base if hasattr(args, "base") and args.base else "main"
     receipt_path = args.receipt if hasattr(args, "receipt") and args.receipt else None
     repo_root = get_repo_root()
+    resolved_spec = reg["resolve_spec"](args, None, spec_id=epic_id)
 
     # Cursor: resume BEFORE prompt so the preamble is reserved in argv budget.
     # Codex/copilot: gather + build prompt first (pre-migration order).
+    try:
+        reviewed_base_sha, reviewed_head_sha = _capture_review_snapshot(base_branch)
+    except ValueError as exc:
+        error_exit(str(exc), use_json=args.json, code=2)
     if reg["prompt_fit"] == "cursor_argv":
-        diff_summary, diff_content = reg["gather_diff"](base_branch)
+        diff_summary, diff_content = reg["gather_diff"](
+            reviewed_base_sha, reviewed_head_sha
+        )
         session_id, is_rereview, prior_receipt_model, prior_receipt_effort = (
             _resume_session_from_receipt(
                 receipt_path,
@@ -25450,7 +36536,9 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
             task_ids=task_ids or None,
         )
     else:
-        diff_summary, diff_content = reg["gather_diff"](base_branch)
+        diff_summary, diff_content = reg["gather_diff"](
+            reviewed_base_sha, reviewed_head_sha
+        )
         prompt = build_completion_review_prompt(
             epic_spec, task_specs, diff_summary, diff_content,
         )
@@ -25473,8 +36561,6 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
             )
             prompt = rereview_preamble + prompt
 
-    resolved_spec = reg["resolve_spec"](args, None, spec_id=epic_id)
-
     # Completion reviews reuse the spec-scoped plan-review counter.
     enforce_and_increment_review_cap(epic_id, "plan", use_json=args.json)
 
@@ -25492,6 +36578,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="completion",
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     resolved_spec, effective_model, effective_effort = _bind_receipt_model_effort(
@@ -25505,13 +36592,8 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
         spec_id=epic_id,
         review_kind="plan",
         review_type="completion",
-    )
-
-    if verdict == "SHIP":
-        reset_review_cap(epic_id, "plan")
-
-    written_status = _self_write_review_status(
-        epic_id, "completion", verdict, use_json=args.json
+        reset_rounds_on_ship=True,
+        reviewed_head_sha=reviewed_head_sha,
     )
 
     # Preserve session_id for continuity (avoid clobbering on resumed sessions).
@@ -25540,7 +36622,18 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
             suppressed_count=suppressed_count,
             classification_counts=classification_counts,
             unaddressed_rids=unaddressed_rids,
+            reviewed_base_sha=reviewed_base_sha,
+            reviewed_head_sha=reviewed_head_sha,
         )
+
+    # Receipt evidence must land before terminal status. If receipt persistence
+    # fails, the recovery payload above remains and status stays non-terminal;
+    # the skill restores the receipt and status before any later dispatch.
+    written_status = _self_write_review_status(
+        epic_id, "completion", verdict, use_json=args.json
+    )
+    if written_status is not None and receipt_path:
+        _completion_review_receipt_recovery_path(epic_id).unlink(missing_ok=True)
 
     review_rounds = _current_review_rounds(epic_id, "plan", use_json=args.json)
 
@@ -25645,6 +36738,7 @@ def build_completion_review_prompt(
         confidence_rubric_block=CONFIDENCE_RUBRIC_BLOCK,
         classification_rubric_block=CLASSIFICATION_RUBRIC_BLOCK,
         protected_artifacts_block=PROTECTED_ARTIFACTS_BLOCK,
+        global_criteria_block=build_global_criteria_block(),
         review_json_tally_block=REVIEW_JSON_TALLY_BLOCK,
     )
 
@@ -26029,7 +37123,7 @@ def _triage_chore_is_version_only(
     for line in proc.stdout.splitlines():
         if line.startswith(("+++", "---", "diff ", "index ", "@@", "Binary ")):
             continue
-        if not (line.startswith("+") or line.startswith("-")):
+        if not line.startswith(("+", "-")):
             continue
         content = line[1:]
         if not content.strip():
@@ -27721,7 +38815,7 @@ def _prime_git_many(
         from concurrent.futures import ThreadPoolExecutor
 
         with ThreadPoolExecutor(max_workers=min(4, len(commands))) as pool:
-            results = list(pool.map(run, zip(commands, private_collectors)))
+            results = list(pool.map(run, zip(commands, private_collectors, strict=False)))
     except Exception:
         # Thread/resource exhaustion must not turn the fail-soft classifier
         # into a crash. Re-run in stable command order; read-only probes may
@@ -29069,7 +40163,6 @@ def _prime_collect_scope(
     if top is None:
         # Not a git repo — home-base detection FIRST.
         c.op()
-        parent_self = root_resolved
         siblings, _wt = _prime_sibling_git_dirs(root_resolved, Path("/__none__"))
         has_manifest = any(
             (root_resolved / m).exists()
@@ -29328,7 +40421,7 @@ def _prime_destructive_context(line: str, target: str) -> str:
     bounded | unbounded. The skill maps these to severities.
     """
     stripped = line.strip()
-    if stripped.startswith("#") or stripped.startswith("//") or stripped.startswith("*"):
+    if stripped.startswith(("#", "//", "*")):
         return "comment"
     if re.match(r'^\s*echo\s', line) or re.search(r'echo\s+["\'].*(?:rm|clean|force)', line):
         return "string-literal"
@@ -29551,7 +40644,7 @@ def _prime_collect_atomic_pairs(
         base = rel.rsplit("/", 1)[-1]
         if base.endswith((".py", ".ts", ".js", ".go")) and "/" in rel:
             by_base.setdefault(base, []).append(rel)
-    for base, locs in by_base.items():
+    for locs in by_base.values():
         if len(locs) >= 2:
             pairs.append({"kind": "dual-copy-candidate", "files": sorted(locs)[:4]})
     # Dedup identical pair entries.
@@ -29622,7 +40715,7 @@ def _prime_collect_docs_freshness(
         )
     results = _prime_git_many(root, commands, c)
 
-    for doc, (rc, out, _err) in zip(docs, results[: len(docs)]):
+    for doc, (rc, out, _err) in zip(docs, results[: len(docs)], strict=False):
         ts = int(out.strip()) if rc == 0 and out.strip().isdigit() else None
         if ts is not None:
             instruction_files.append({"path": doc, "last_commit_ts": ts})
@@ -30085,7 +41178,6 @@ def _prime_collect_config_presence(
 ) -> "tuple[dict[str, Any], _PrimeCollector]":
     """FH7 / FH11 / FH12 / FH13: config-presence rows (raw booleans + evidence)."""
     c = _PrimeCollector("substance-config-presence", budget=120)
-    tracked = set(deduped)
     basenames = {p.rsplit("/", 1)[-1] for p in deduped}
 
     def _grep_any(files: "list[str]", pat: "re.Pattern") -> "Optional[str]":
@@ -30278,7 +41370,6 @@ def _prime_collect_coverage_threshold(
 ) -> "tuple[dict[str, Any], _PrimeCollector]":
     """TS5: an ENFORCED coverage threshold quoted from config (raw presence)."""
     c = _PrimeCollector("substance-coverage-threshold", budget=60)
-    basenames = {p.rsplit("/", 1)[-1] for p in deduped}
     candidates = [
         p for p in deduped if p.rsplit("/", 1)[-1] in (
             "pyproject.toml", "setup.cfg", ".coveragerc", "tox.ini", "pytest.ini",
@@ -31014,6 +42105,307 @@ def main() -> None:
 
     # sync (tracker bridge plumbing — fn-52.1). Distinct from /flow-next:sync
     # (plan-sync); this command group is the deterministic tracker-sync substrate.
+    # fn-139.6: deterministic tracker verbs (flowctl_tracker package).
+    p_tracker = subparsers.add_parser(
+        "tracker", help="Deterministic tracker transport verbs (fn-139)"
+    )
+    tracker_sub = p_tracker.add_subparsers(dest="tracker_cmd", required=True)
+    p_tracker_resolve = tracker_sub.add_parser(
+        "resolve",
+        help="Backfill/refresh tracker.resolved (destination, ids scope, capabilities)",
+    )
+    p_tracker_resolve.add_argument(
+        "--scope", default=None,
+        help="Re-resolve only this nested path (destination | "
+             "destination.statusIds | destination.stateIds | capabilities)",
+    )
+    p_tracker_resolve.add_argument(
+        "--refresh", action="store_true",
+        help="Force re-resolution of scopes that are already fresh",
+    )
+    p_tracker_resolve.add_argument(
+        "--select", default=None, metavar="NORMALIZED=ID",
+        help="Persist ONE human slot tiebreak (validated against live "
+             "candidates; repeatable across calls; re-select overwrites)",
+    )
+    p_tracker_resolve.add_argument("--json", action="store_true",
+                                   help="Accepted and ignored (output is always JSON)")
+    p_tracker_resolve.set_defaults(func=cmd_tracker_resolve)
+
+    # wire verbs (fn-140.1) — locator-addressed, no local state / no receipt.
+    p_tracker_wire = tracker_sub.add_parser(
+        "wire",
+        help="Locator-addressed wire verbs (issue/comment/relation/question/attachment)",
+    )
+    wire_sub = p_tracker_wire.add_subparsers(dest="wire_verb", required=True)
+
+    def _wire_locator(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--locator", required=True,
+            help='JSON locator {"durable":"<id>","display":"<#N|project#iid|KEY-N>"}',
+        )
+
+    def _wire_json(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--json", action="store_true",
+                       help="Accepted and ignored (output is always JSON)")
+
+    p_wire_read = wire_sub.add_parser("read", help="Fetch one issue by locator")
+    _wire_locator(p_wire_read)
+    _wire_json(p_wire_read)
+    p_wire_read.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_update = wire_sub.add_parser("update", help="Update title/body by locator")
+    _wire_locator(p_wire_update)
+    p_wire_update.add_argument("--title", default=None)
+    p_wire_update.add_argument("--body-file", default=None)
+    _wire_json(p_wire_update)
+    p_wire_update.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_cadd = wire_sub.add_parser("comment-add", help="Add a comment")
+    _wire_locator(p_wire_cadd)
+    p_wire_cadd.add_argument("--body-file", required=True)
+    _wire_json(p_wire_cadd)
+    p_wire_cadd.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_clist = wire_sub.add_parser("comment-list", help="List comments")
+    _wire_locator(p_wire_clist)
+    _wire_json(p_wire_clist)
+    p_wire_clist.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_cupd = wire_sub.add_parser("comment-update",
+                                     help="Update a comment (requires parent locator)")
+    _wire_locator(p_wire_cupd)
+    p_wire_cupd.add_argument("comment_id", help="Provider comment id")
+    p_wire_cupd.add_argument("--body-file", required=True)
+    _wire_json(p_wire_cupd)
+    p_wire_cupd.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_cdel = wire_sub.add_parser("comment-delete",
+                                     help="Delete a comment (requires parent locator)")
+    _wire_locator(p_wire_cdel)
+    p_wire_cdel.add_argument("comment_id", help="Provider comment id")
+    _wire_json(p_wire_cdel)
+    p_wire_cdel.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_label = wire_sub.add_parser("label", help="Add/remove labels")
+    _wire_locator(p_wire_label)
+    p_wire_label.add_argument("--add", action="append", default=[])
+    p_wire_label.add_argument("--remove", action="append", default=[])
+    _wire_json(p_wire_label)
+    p_wire_label.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_assign = wire_sub.add_parser("assign", help="Add/remove assignees")
+    _wire_locator(p_wire_assign)
+    p_wire_assign.add_argument("--add", action="append", default=[])
+    p_wire_assign.add_argument("--remove", action="append", default=[])
+    _wire_json(p_wire_assign)
+    p_wire_assign.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_list = wire_sub.add_parser("list-open",
+                                     help="List open issues (no locator)")
+    _wire_json(p_wire_list)
+    p_wire_list.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_relations = wire_sub.add_parser(
+        "relation-list", help="List normalized dependency relations")
+    _wire_locator(p_wire_relations)
+    _wire_json(p_wire_relations)
+    p_wire_relations.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_question = wire_sub.add_parser(
+        "question", help="Idempotently post a question-valve comment")
+    _wire_locator(p_wire_question)
+    p_wire_question.add_argument("--subject-id", required=True)
+    p_wire_question.add_argument("--blocked-stage", required=True)
+    p_wire_question.add_argument("--reason-code", required=True)
+    p_wire_question.add_argument("--question-slug", required=True)
+    p_wire_question.add_argument("--body-file", required=True)
+    _wire_json(p_wire_question)
+    p_wire_question.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_attach = wire_sub.add_parser(
+        "attach", help="Upload an attachment (capability-gated; fn-140.4)")
+    _wire_locator(p_wire_attach)
+    p_wire_attach.add_argument("--file", required=True,
+                               help="Local file to upload")
+    _wire_json(p_wire_attach)
+    p_wire_attach.set_defaults(func=cmd_tracker_wire)
+
+    p_wire_aget = wire_sub.add_parser(
+        "attach-get",
+        help="Download an attachment by id (no locator; fn-140.4)")
+    p_wire_aget.add_argument("attachment_id", help="Provider attachment id")
+    p_wire_aget.add_argument("--out", required=True,
+                             help="Local path to write retrieved bytes")
+    _wire_json(p_wire_aget)
+    p_wire_aget.set_defaults(func=cmd_tracker_wire)
+
+    # lifecycle verbs (fn-140.2) — create / create-first / persist-external.
+    # No `tracker reconcile` CLI: UUID completion is complete_identifier_only,
+    # invoked by the .7 facade's `tracker sync --op reconcile`.
+    p_tracker_create = tracker_sub.add_parser(
+        "create",
+        help="Create a tracker issue and link an existing spec (writes receipt)",
+    )
+    p_tracker_create.add_argument("spec_id", help="Spec ID")
+    p_tracker_create.add_argument("--title", required=True)
+    p_tracker_create.add_argument("--body-file", required=True)
+    p_tracker_create.add_argument("--event", default=None,
+                                  help="perEvent key stamped on the sync receipt")
+    p_tracker_create.add_argument("--json", action="store_true",
+                                  help="Accepted and ignored (output is always JSON)")
+    p_tracker_create.set_defaults(func=cmd_tracker_lifecycle, lifecycle_verb="create")
+
+    p_tracker_cf = tracker_sub.add_parser(
+        "create-first",
+        help="Create a tracker issue before any local spec (fn-134; no receipt)",
+    )
+    p_tracker_cf.add_argument("--title", required=True)
+    p_tracker_cf.add_argument("--body-file", required=True)
+    p_tracker_cf.add_argument("--retry-key", required=True,
+                              help="16-hex key from sync create-first-key")
+    p_tracker_cf.add_argument("--json", action="store_true",
+                              help="Accepted and ignored (output is always JSON)")
+    p_tracker_cf.set_defaults(func=cmd_tracker_lifecycle, lifecycle_verb="create-first")
+
+    p_tracker_pe = tracker_sub.add_parser(
+        "persist-external",
+        help="Record an MCP-performed Linear create (resolves UUID via GraphQL)",
+    )
+    p_tracker_pe.add_argument("spec_id", help="Spec ID")
+    p_tracker_pe.add_argument("--identifier", required=True,
+                              help="Display identifier returned by MCP (e.g. WOR-17)")
+    p_tracker_pe.add_argument("--id", dest="durable_id", default=None,
+                              help="Durable UUID when already known")
+    p_tracker_pe.add_argument("--url", default=None)
+    p_tracker_pe.add_argument("--source", required=True, choices=["mcp"],
+                              help="Must be mcp (MCP is create/discovery only)")
+    p_tracker_pe.add_argument("--event", default=None)
+    p_tracker_pe.add_argument("--json", action="store_true",
+                              help="Accepted and ignored (output is always JSON)")
+    p_tracker_pe.set_defaults(func=cmd_tracker_lifecycle,
+                              lifecycle_verb="persist-external")
+
+    # status verb (fn-140.3) — merge-evidence gate + who-wins ladder.
+    p_tracker_status = tracker_sub.add_parser(
+        "status",
+        help="Reconcile tracker status for a linked spec (--to is a request; "
+             "fn-66 merge-evidence gate decides)",
+    )
+    p_tracker_status.add_argument("spec_id", help="Spec ID")
+    p_tracker_status.add_argument(
+        "--to", required=True,
+        choices=["backlog", "todo", "in_progress", "in_review", "done", "cancelled"],
+        help="Requested normalized slot (not an authority — the gate decides)",
+    )
+    p_tracker_status.add_argument(
+        "--reason", default=None,
+        help="GitHub state_reason: completed|not_planned|duplicate|reopened",
+    )
+    p_tracker_status.add_argument("--event", default=None,
+                                  help="perEvent key stamped on the sync receipt")
+    p_tracker_status.add_argument("--json", action="store_true",
+                                  help="Accepted and ignored (output is always JSON)")
+    p_tracker_status.set_defaults(func=cmd_tracker_status)
+
+    # relate verb (fn-140.4) - depRelations ledger + blocked-by projection.
+    p_tracker_relate = tracker_sub.add_parser(
+        "relate",
+        help="Project a blocked-by relation between two linked specs "
+             "(depRelations ledger; fn-64 contract)",
+    )
+    p_tracker_relate.add_argument("spec_id", help="Spec ID (the blocked issue)")
+    p_tracker_relate.add_argument(
+        "--blocked-by", required=True, dest="blocked_by",
+        help="Spec ID of the blocker",
+    )
+    p_tracker_relate.add_argument("--event", default=None,
+                                  help="perEvent key stamped on the sync receipt")
+    p_tracker_relate.add_argument("--json", action="store_true",
+                                  help="Accepted and ignored (output is always JSON)")
+    p_tracker_relate.set_defaults(func=cmd_tracker_relate)
+
+    # sync-body verb (fn-140.5) - write/readback + paired merge base transaction.
+    p_tracker_syncbody = tracker_sub.add_parser(
+        "sync-body",
+        help="Write issue body (optional), read back, commit paired merge base "
+             "(server readback is canonical for the tracker half)",
+    )
+    p_tracker_syncbody.add_argument("spec_id", help="Spec ID")
+    p_tracker_syncbody.add_argument(
+        "--flow-file", required=True, dest="flow_file",
+        help="Final local body (agent-rendered or conflict-resolved); becomes "
+             "mergeBaseFlow exactly",
+    )
+    p_tracker_syncbody.add_argument(
+        "--tracker-body-file", default=None, dest="tracker_body_file",
+        help="Optional agent-approved tracker-side body for a two-way reconcile push",
+    )
+    p_tracker_syncbody.add_argument(
+        "--direction", default="push", choices=["push", "pull"],
+        help="push writes then readbacks; pull snapshots without writing",
+    )
+    p_tracker_syncbody.add_argument("--event", default=None,
+                                    help="perEvent key stamped on the sync receipt")
+    p_tracker_syncbody.add_argument("--json", action="store_true",
+                                    help="Accepted and ignored (output is always JSON)")
+    p_tracker_syncbody.set_defaults(func=cmd_tracker_syncbody)
+
+    # lifecycle facade (fn-140.7) — distinct from legacy `flowctl sync ...`.
+    p_tracker_sync = tracker_sub.add_parser(
+        "sync",
+        help="Lifecycle facade: push|pull|reconcile|comment as one unit "
+             "(create-if-unlinked, sequence, marker dedup, one aggregate receipt)",
+    )
+    p_tracker_sync.add_argument("spec_id", help="Spec ID")
+    p_tracker_sync.add_argument(
+        "--op", required=True, choices=["push", "pull", "reconcile", "comment"],
+        help="Facade op (matches perEvent vocabulary)",
+    )
+    p_tracker_sync.add_argument(
+        "--event", required=True,
+        help="perEvent key stamped on the single aggregate sync receipt",
+    )
+    p_tracker_sync.add_argument(
+        "--flow-file", default=None, dest="flow_file",
+        help="Exact final local flow-form body (required for push/pull/reconcile; "
+             "forbidden for comment); becomes mergeBaseFlow",
+    )
+    p_tracker_sync.add_argument(
+        "--body-file", default=None, dest="body_file",
+        help="Tracker-rendered body for push/reconcile, exact tracker snapshot "
+             "used to produce a pull fold, or comment text (required)",
+    )
+    p_tracker_sync.add_argument(
+        "--comments-file", default=None, dest="comments_file",
+        help="JSON array from the normalized comment-list snapshot used to "
+             "produce a pull/reconcile fold (required for pull/reconcile; "
+             "forbidden for push/comment)",
+    )
+    p_tracker_sync.add_argument(
+        "--source-body-file", default=None, dest="source_body_file",
+        help="Exact tracker body snapshot used to prepare a reconcile merge "
+             "(required for reconcile; forbidden for other ops)",
+    )
+    p_tracker_sync.add_argument(
+        "--comment-file", default=None, dest="comment_file",
+        help="Optional judgment-bearing comment to post inside --op push; "
+             "forbidden for pull/reconcile/comment",
+    )
+    p_tracker_sync.add_argument(
+        "--pr-url", default=None, dest="pr_url",
+        help="Optional PR URL to link inside --op reconcile --event makePr; "
+             "forbidden for every other op/event",
+    )
+    p_tracker_sync.add_argument(
+        "--status-only", action="store_true", dest="status_only",
+        help="For --op push, create/link if needed and project status only; "
+             "skip body and relation writes",
+    )
+    p_tracker_sync.add_argument("--json", action="store_true",
+                                help="Accepted and ignored (output is always JSON)")
+    p_tracker_sync.set_defaults(func=cmd_tracker_facade)
+
     p_sync = subparsers.add_parser(
         "sync", help="Tracker sync plumbing (config / state / enumerate / receipt)"
     )
@@ -31274,6 +42666,59 @@ def main() -> None:
     )
     p_review_backend.add_argument("--json", action="store_true", help="JSON output")
     p_review_backend.set_defaults(func=cmd_review_backend)
+
+    # review-findings — deterministic receipt-write plumbing. Direct skill
+    # writers use the same parser/currentness contract as subprocess backends.
+    p_review_findings = subparsers.add_parser(
+        "review-findings",
+        help="Attach versioned structured findings to a direct-writer receipt",
+    )
+    review_findings_sub = p_review_findings.add_subparsers(
+        dest="review_findings_cmd", required=True
+    )
+    p_findings_attach = review_findings_sub.add_parser(
+        "attach",
+        help="Parse an existing reviewer response and atomically write the receipt",
+    )
+    p_findings_attach.add_argument(
+        "--receipt", required=True, help="Final receipt path"
+    )
+    p_findings_attach.add_argument(
+        "--input", required=True, help="Base receipt JSON payload"
+    )
+    p_findings_attach.add_argument(
+        "--review-file", required=True, dest="review_file",
+        help="Reviewer output already captured by the caller",
+    )
+    p_findings_attach.add_argument(
+        "--prior",
+        default=None,
+        help="Prior receipt path for lineage (defaults to --receipt)",
+    )
+    p_findings_attach.add_argument(
+        "--recovery",
+        default=None,
+        help=(
+            "Optional recovery copy written inside the receipt transaction "
+            "before the terminal pointer advances"
+        ),
+    )
+    p_findings_attach.add_argument(
+        "--require-prior-current",
+        action="store_true",
+        help=(
+            "Reject when an explicit --prior snapshot no longer equals the "
+            "terminal receipt after acquiring its lock"
+        ),
+    )
+    p_findings_attach.add_argument(
+        "--head", default="HEAD", help="Reviewed head ref (default: HEAD)"
+    )
+    p_findings_attach.add_argument(
+        "--base", default=None, help="Optional reviewed base ref"
+    )
+    p_findings_attach.add_argument("--json", action="store_true", help="JSON output")
+    p_findings_attach.set_defaults(func=cmd_review_findings_attach)
 
     # models resolve (fn-115.3) — pure map + precedence lookup for skills
     p_models = subparsers.add_parser(
@@ -31739,6 +43184,346 @@ def main() -> None:
     )
     p_prospect_promote.set_defaults(func=cmd_prospect_promote)
 
+    # chart (fn-135) — decision-map discovery store.
+    # Task 1: create/show/list + allocator + journal. Task 9: graph/claims.
+    p_chart = subparsers.add_parser(
+        "chart",
+        help="Chart commands (decision-map discovery; fn-135)",
+    )
+    chart_sub = p_chart.add_subparsers(dest="chart_cmd", required=True)
+
+    p_chart_create = chart_sub.add_parser(
+        "create",
+        help="Allocate a chart id; optional initial-map validates size first",
+    )
+    p_chart_create.add_argument("--title", required=True, help="Chart title")
+    p_chart_create.add_argument(
+        "--outcome",
+        required=True,
+        help="What reaching the end of this chart looks like",
+    )
+    p_chart_create.add_argument(
+        "--initial-map-file",
+        dest="initial_map_file",
+        default=None,
+        help="JSON file of titled decisions + parked questions (validated pre-alloc)",
+    )
+    p_chart_create.add_argument(
+        "--force-size",
+        action="store_true",
+        help="Override chart.maxDecisions (requires --reason; audited)",
+    )
+    p_chart_create.add_argument(
+        "--reason",
+        default=None,
+        help="Reason for --force-size override (recorded in create transaction)",
+    )
+    p_chart_create.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_create.set_defaults(func=cmd_chart_create)
+
+    p_chart_show = chart_sub.add_parser(
+        "show",
+        help="Show compact chart metadata and map body",
+    )
+    p_chart_show.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_show.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_show.set_defaults(func=cmd_chart_show)
+
+    p_chart_list = chart_sub.add_parser(
+        "list",
+        help="List charts with compact progress metadata",
+    )
+    p_chart_list.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_list.set_defaults(func=cmd_chart_list)
+
+    p_chart_add = chart_sub.add_parser(
+        "add-decision",
+        help="Allocate next D-ID under a chart",
+    )
+    p_chart_add.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_add.add_argument("--title", required=True, help="Decision title")
+    p_chart_add.add_argument(
+        "--type",
+        required=True,
+        help="research|probe|eval|prototype|interview|task",
+    )
+    p_chart_add.add_argument(
+        "--attendance",
+        default=None,
+        help="attended|unattended (required for type=task; derived otherwise)",
+    )
+    p_chart_add.add_argument(
+        "--body-file",
+        dest="body_file",
+        default=None,
+        help="File containing the ## Question body",
+    )
+    p_chart_add.add_argument(
+        "--blocked-by",
+        dest="blocked_by",
+        default=None,
+        help="Comma-separated D-IDs that must close before this is actionable",
+    )
+    p_chart_add.add_argument(
+        "--depends-on",
+        dest="depends_on",
+        default=None,
+        help="Comma-separated premise D-IDs (provenance; not readiness)",
+    )
+    p_chart_add.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_add.set_defaults(func=cmd_chart_add_decision)
+
+    p_chart_park = chart_sub.add_parser(
+        "park-question",
+        help="Add a normalized parked Open Question; returns stable key",
+    )
+    p_chart_park.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_park.add_argument(
+        "--body-file",
+        dest="body_file",
+        required=True,
+        help="File containing the parked question text",
+    )
+    p_chart_park.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_park.set_defaults(func=cmd_chart_park_question)
+
+    p_chart_rmq = chart_sub.add_parser(
+        "remove-question",
+        help="Remove a parked question by stable key",
+    )
+    p_chart_rmq.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_rmq.add_argument(
+        "--question",
+        required=True,
+        help="Stable parked-question key from park-question",
+    )
+    p_chart_rmq.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_rmq.set_defaults(func=cmd_chart_remove_question)
+
+    p_chart_wire = chart_sub.add_parser(
+        "wire-decision",
+        help="Atomically replace blocked_by/depends_on for a decision",
+    )
+    p_chart_wire.add_argument(
+        "decision_id",
+        help="Decision id (<chart-id>.D<n> or D<n> with chart context)",
+    )
+    p_chart_wire.add_argument(
+        "--blocked-by",
+        dest="blocked_by",
+        default=None,
+        help="Replacement blocked_by list (comma-separated; empty clears)",
+    )
+    p_chart_wire.add_argument(
+        "--depends-on",
+        dest="depends_on",
+        default=None,
+        help="Replacement depends_on list (comma-separated; empty clears)",
+    )
+    p_chart_wire.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_wire.set_defaults(func=cmd_chart_wire_decision)
+
+    p_chart_frontier = chart_sub.add_parser(
+        "frontier",
+        help="Open, unblocked, unclaimed decisions (dependency-ordered)",
+    )
+    p_chart_frontier.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_frontier.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_frontier.set_defaults(func=cmd_chart_frontier)
+
+    p_chart_claim = chart_sub.add_parser(
+        "claim",
+        help="Atomic claim; does not change decision status",
+    )
+    p_chart_claim.add_argument("decision_id", help="Decision id (<chart-id>.D<n>)")
+    p_chart_claim.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_claim.set_defaults(func=cmd_chart_claim)
+
+    p_chart_release = chart_sub.add_parser(
+        "release-claim",
+        help="Owner release or age-gated --break-stale --reason",
+    )
+    p_chart_release.add_argument("decision_id", help="Decision id (<chart-id>.D<n>)")
+    p_chart_release.add_argument(
+        "--break-stale",
+        action="store_true",
+        help="Break another actor's claim after chart.claimStaleAfter",
+    )
+    p_chart_release.add_argument(
+        "--reason",
+        default=None,
+        help="Required with --break-stale; audited with actor/prior/age",
+    )
+    p_chart_release.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_release.set_defaults(func=cmd_chart_release_claim)
+
+    p_chart_attach = chart_sub.add_parser(
+        "attach-asset",
+        help="Idempotently attach a safe evidence/prototype asset; decision stays open",
+    )
+    p_chart_attach.add_argument(
+        "decision_id",
+        help="Decision id (<chart-id>.D<n>)",
+    )
+    p_chart_attach.add_argument(
+        "--asset-file",
+        dest="asset_file",
+        required=True,
+        help="JSON file: {kind, reference, display, revision?}",
+    )
+    p_chart_attach.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_attach.set_defaults(func=cmd_chart_attach_asset)
+
+    p_chart_resolve = chart_sub.add_parser(
+        "resolve",
+        help="Write answer once, close decision, ledger gist; optional supersession/sharpen",
+    )
+    p_chart_resolve.add_argument(
+        "decision_id",
+        help="Decision id (<chart-id>.D<n>)",
+    )
+    p_chart_resolve.add_argument(
+        "--answer-file",
+        dest="answer_file",
+        required=True,
+        help="File containing the answer body (safe content only)",
+    )
+    p_chart_resolve.add_argument(
+        "--assets",
+        default=None,
+        help="JSON list of asset objects to merge at resolve time",
+    )
+    p_chart_resolve.add_argument(
+        "--sharpen-file",
+        dest="sharpen_file",
+        default=None,
+        help="JSON: new titled decisions + remove_questions keys (one transaction)",
+    )
+    p_chart_resolve.add_argument(
+        "--supersedes",
+        default=None,
+        help="Comma-separated D-IDs this answer supersedes",
+    )
+    p_chart_resolve.add_argument(
+        "--keep-dependents",
+        action="store_true",
+        help="Suppress depends_on cascade; record the judgment on affected records",
+    )
+    p_chart_resolve.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_resolve.set_defaults(func=cmd_chart_resolve)
+
+    p_chart_oos = chart_sub.add_parser(
+        "out-of-scope",
+        help="Close decision without ledger answer; write ## Boundaries reason",
+    )
+    p_chart_oos.add_argument(
+        "decision_id",
+        help="Decision id (<chart-id>.D<n>)",
+    )
+    p_chart_oos.add_argument(
+        "--reason",
+        required=True,
+        help="One-line reason recorded under ## Boundaries",
+    )
+    p_chart_oos.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_oos.set_defaults(func=cmd_chart_out_of_scope)
+
+    p_chart_abandon = chart_sub.add_parser(
+        "abandon",
+        help="Close chart as abandoned with reason; nothing deleted",
+    )
+    p_chart_abandon.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_abandon.add_argument(
+        "--reason",
+        required=True,
+        help="Why discovery stops (recorded; decisions preserved)",
+    )
+    p_chart_abandon.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_abandon.set_defaults(func=cmd_chart_abandon)
+
+    p_chart_briefing = chart_sub.add_parser(
+        "briefing",
+        help=(
+            "Validate a confirmed split proposal and emit an immutable "
+            "versioned briefing (B1, B2, ...); first final sets done"
+        ),
+    )
+    p_chart_briefing.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_briefing.add_argument(
+        "--proposal-file",
+        required=True,
+        dest="proposal_file",
+        help=(
+            "Agent-confirmed proposal JSON: clusters[{key,rationale,decisions}], "
+            "shared_context[]"
+        ),
+    )
+    p_chart_briefing.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Emit an explicitly draft briefing while open/blocked/claimed/"
+            "parked items remain; leaves chart open; never capture-ready"
+        ),
+    )
+    p_chart_briefing.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_briefing.set_defaults(func=cmd_chart_briefing)
+
+    p_chart_reopen = chart_sub.add_parser(
+        "reopen",
+        help="Reopen done/abandoned chart; stale prior briefings and spec links",
+    )
+    p_chart_reopen.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_reopen.add_argument(
+        "--reason",
+        required=True,
+        help="Why discovery reopens (recorded; prior briefings/links staled)",
+    )
+    p_chart_reopen.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_reopen.set_defaults(func=cmd_chart_reopen)
+
+    p_chart_locate = chart_sub.add_parser(
+        "locate",
+        help=(
+            "Resolve a chart/D-ID, stored tracker identifier, or stored "
+            "tracker URL through the local provenance ledger (no network)"
+        ),
+    )
+    p_chart_locate.add_argument(
+        "selector",
+        help="Canonical chart/D-ID, stored tracker identifier, or stored URL",
+    )
+    p_chart_locate.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_locate.set_defaults(func=cmd_chart_locate)
+
+    p_chart_link = chart_sub.add_parser(
+        "link-spec",
+        help="Idempotently record a successful capture handoff in produced_specs[]",
+    )
+    p_chart_link.add_argument("chart_id", help="Chart id (fn-N)")
+    p_chart_link.add_argument(
+        "--briefing",
+        required=True,
+        help="Briefing id (B1, B2, ...)",
+    )
+    p_chart_link.add_argument(
+        "--spec",
+        required=True,
+        help="Spec id produced by capture",
+    )
+    p_chart_link.add_argument(
+        "--decisions",
+        required=True,
+        help="Comma-separated D-IDs mapped into this spec",
+    )
+    p_chart_link.add_argument(
+        "--cluster",
+        default=None,
+        help="Optional cluster key from the briefing proposal",
+    )
+    p_chart_link.add_argument("--json", action="store_true", help="JSON output")
+    p_chart_link.set_defaults(func=cmd_chart_link_spec)
+
     # anchor (fn-83.3) — single-call worker anchor bundle: the verbatim
     # outputs of every worker Phase-1 re-anchor read in one deterministic
     # payload (plus dependency ids/titles/statuses/done-summaries).
@@ -31895,6 +43680,23 @@ def main() -> None:
     p_glossary_remove.add_argument("term", help="Term name (case-insensitive match)")
     p_glossary_remove.add_argument("--json", action="store_true", help="JSON output")
     p_glossary_remove.set_defaults(func=cmd_glossary_remove)
+
+    p_criteria = subparsers.add_parser(
+        "criteria",
+        help="Global acceptance criteria (.flow/criteria.md)",
+    )
+    criteria_sub = p_criteria.add_subparsers(dest="criteria_cmd", required=True)
+    p_criteria_list = criteria_sub.add_parser(
+        "list",
+        help="List global criteria (absent file -> empty list, ok exit)",
+    )
+    p_criteria_list.add_argument("--json", action="store_true", help="JSON output")
+    p_criteria_list.set_defaults(func=cmd_criteria_list)
+    p_criteria_pb = criteria_sub.add_parser(
+        "prompt-block",
+        help="Print the completion-review criteria injection block (empty when absent)",
+    )
+    p_criteria_pb.set_defaults(func=cmd_criteria_prompt_block)
 
     # strategy status / read / list (fn-39.1)
     # Read-only plumbing. The skill (`/flow-next:strategy`) writes the file
@@ -32246,6 +44048,68 @@ def main() -> None:
         ),
     )
     p_scope_wp.set_defaults(func=cmd_scope_write_policy)
+
+    # pr-cognitive-aid — host composes intent; flowctl owns only the portable
+    # contract, immutable generations, current projection, and Markdown.
+    p_pr_aid = subparsers.add_parser(
+        "pr-cognitive-aid",
+        help="Validate, persist, select, and render a v1 PR cognitive-aid artifact",
+    )
+    pr_aid_sub = p_pr_aid.add_subparsers(dest="pr_aid_cmd", required=True)
+    p_pr_aid_validate = pr_aid_sub.add_parser(
+        "validate", help="Validate one artifact without writing it"
+    )
+    p_pr_aid_validate.add_argument("--file", required=True, help="JSON file or -")
+    p_pr_aid_validate.add_argument("--json", action="store_true", help="JSON output")
+    p_pr_aid_validate.set_defaults(func=cmd_pr_cognitive_aid_validate)
+    p_pr_aid_html_input = pr_aid_sub.add_parser(
+        "html-input",
+        help="Emit a lossless HTML-safe semantic carrier for one validated artifact",
+    )
+    p_pr_aid_html_input.add_argument("--file", required=True, help="JSON file or -")
+    p_pr_aid_html_input.set_defaults(func=cmd_pr_cognitive_aid_html_input)
+    for command, handler, help_text in (
+        (
+            "write",
+            cmd_pr_cognitive_aid_write,
+            "Validate and atomically persist one generation",
+        ),
+        (
+            "current",
+            cmd_pr_cognitive_aid_current,
+            "Select the current base/head-bound generation",
+        ),
+        (
+            "render",
+            cmd_pr_cognitive_aid_render,
+            "Render the supported current generation as Markdown",
+        ),
+    ):
+        pr_aid_parser = pr_aid_sub.add_parser(command, help=help_text)
+        pr_aid_parser.add_argument(
+            "id", nargs="?" if command == "render" else None, help="Canonical spec ID"
+        )
+        pr_aid_parser.add_argument(
+            "--base-sha",
+            required=command != "render",
+            help="Current merge-base SHA",
+        )
+        pr_aid_parser.add_argument(
+            "--head-sha",
+            required=command != "render",
+            help="Current PR-head SHA",
+        )
+        if command == "write":
+            pr_aid_parser.add_argument("--file", required=True, help="JSON file or -")
+        elif command == "render":
+            pr_aid_parser.add_argument(
+                "--file", help="Validate and render this JSON file without persistence"
+            )
+        if command != "render":
+            pr_aid_parser.add_argument(
+                "--json", action="store_true", help="JSON output"
+            )
+        pr_aid_parser.set_defaults(func=handler)
 
     # task create
     p_task = subparsers.add_parser("task", help="Task commands")
@@ -32617,7 +44481,15 @@ def main() -> None:
 
     p_rp_chat = rp_sub.add_parser("chat-send", help="Send chat via rp-cli")
     p_rp_chat.add_argument("--window", type=int, required=True, help="Window id")
-    p_rp_chat.add_argument("--tab", required=True, help="Tab id or name")
+    p_rp_chat.add_argument(
+        "--tab",
+        help="Tab id or name (Classic)",
+    )
+    p_rp_chat.add_argument(
+        "--context-id",
+        dest="context_id",
+        help="Canonical CE context returned by setup-review",
+    )
     p_rp_chat.add_argument("--message-file", required=True, help="Message file")
     p_rp_chat.add_argument("--new-chat", action="store_true", help="Start new chat")
     p_rp_chat.add_argument("--chat-name", help="Chat name (with --new-chat)")
@@ -32650,12 +44522,22 @@ def main() -> None:
         "setup-review", help="Atomic: resolve window + open builder tab"
     )
     p_rp_setup.add_argument("--repo-root", required=True, help="Repo root path")
-    p_rp_setup.add_argument("--summary", required=True, help="Builder summary/instructions")
+    setup_summary = p_rp_setup.add_mutually_exclusive_group(required=True)
+    setup_summary.add_argument("--summary", help="Builder summary/instructions")
+    setup_summary.add_argument(
+        "--summary-file",
+        help="Read complete builder instructions from this file",
+    )
     p_rp_setup.add_argument(
         "--response-type",
         dest="response_type",
         choices=["review"],
-        help="Use builder review mode (requires RP 1.6.0+)",
+        help="Use CE Context Builder review mode; Classic keeps its compatibility flow",
+    )
+    p_rp_setup.add_argument(
+        "--response-file",
+        dest="response_file",
+        help="Write the CE direct review response to this file",
     )
     p_rp_setup.add_argument(
         "--create",
@@ -32669,7 +44551,7 @@ def main() -> None:
     p_codex = subparsers.add_parser("codex", help="Codex CLI helpers")
     codex_sub = p_codex.add_subparsers(dest="codex_cmd", required=True)
 
-    p_codex_impl = _add_impl_review_parser(codex_sub, "codex")
+    _add_impl_review_parser(codex_sub, "codex")
 
     _add_plan_review_parser(codex_sub, "codex")
     _add_completion_review_parser(codex_sub, "codex")
@@ -32735,7 +44617,7 @@ def main() -> None:
     p_copilot = subparsers.add_parser("copilot", help="GitHub Copilot CLI helpers")
     copilot_sub = p_copilot.add_subparsers(dest="copilot_cmd", required=True)
 
-    p_copilot_impl = _add_impl_review_parser(copilot_sub, "copilot")
+    _add_impl_review_parser(copilot_sub, "copilot")
 
     _add_plan_review_parser(copilot_sub, "copilot")
     _add_completion_review_parser(copilot_sub, "copilot")
@@ -32748,7 +44630,7 @@ def main() -> None:
     p_cursor = subparsers.add_parser("cursor", help="Cursor (cursor-agent CLI) helpers")
     cursor_sub = p_cursor.add_subparsers(dest="cursor_cmd", required=True)
 
-    p_cursor_impl = _add_impl_review_parser(cursor_sub, "cursor")
+    _add_impl_review_parser(cursor_sub, "cursor")
 
     _add_plan_review_parser(cursor_sub, "cursor")
     _add_completion_review_parser(cursor_sub, "cursor")

--- a/.flow/bin/flowctl_bootstrap.py
+++ b/.flow/bin/flowctl_bootstrap.py
@@ -8,6 +8,7 @@ never read or written.
 
 import hashlib
 import importlib.util
+import json
 import os
 import sys
 import types
@@ -17,8 +18,11 @@ from pathlib import Path
 MIN_PYTHON = (3, 11)
 SOURCE_NAME = "flowctl.py"
 HELP_NAME = "flowctl-help.txt"
-SOURCE_SHA256 = "61030e2505f7139b5cdb727075e854b743346f35e976be72db79fdce5515b499"
-HELP_SHA256 = "ad7c987b1f90e8dd12f1e22c6ec4163c72222c3bbf49111ce278337258f01d85"
+# fn-139.5: the single-file SOURCE_SHA256 pin became the distribution manifest
+# (flowctl_tracker/MANIFEST.json) - one integrity mechanism, verified by
+# installers post-copy, consulted here only to authenticate the static-help
+# fast path. A missing/stale manifest declines the fast path safely.
+HELP_SHA256 = "9b17f24e169c3a4ccf74e5d34955b59999f90519efe44476b11ea99aeea2d178"
 HELP_PYTHON = (3, 14)
 USAGE_ERROR = (
     "No usage guide found (searched the plugin's templates/usage.md, then "
@@ -103,8 +107,28 @@ def _load_flowctl(source: Path):
     module.__package__ = ""
     module.__spec__ = spec
     sys.modules["flowctl"] = module
-    exec(code, module.__dict__)
+    exec(  # noqa: S102 - compiling flowctl.py in memory is this module's job
+        code, module.__dict__)
     return module
+
+
+def _manifest_source_sha(source: Path):
+    """flowctl.py's recorded hash from the sibling distribution manifest.
+
+    Returns None (never matches) when the manifest is absent or unreadable -
+    the fast path declines and live argparse serves help, exactly the old
+    mismatch behavior.
+    """
+    try:
+        manifest = json.loads(
+            (source.parent / "flowctl_tracker" / "MANIFEST.json")
+            .read_text(encoding="utf-8"))
+        for entry in manifest.get("files", []):
+            if entry.get("path") == SOURCE_NAME:
+                return entry.get("sha256")
+    except (OSError, ValueError):
+        pass
+    return None
 
 
 def _root_help_fast_path(source: Path) -> bool:
@@ -123,7 +147,7 @@ def _root_help_fast_path(source: Path) -> bool:
     try:
         source_bytes = source.read_bytes()
         help_bytes = help_path.read_bytes()
-        if hashlib.sha256(source_bytes).hexdigest() != SOURCE_SHA256:
+        if hashlib.sha256(source_bytes).hexdigest() != _manifest_source_sha(source):
             return False
         if hashlib.sha256(help_bytes).hexdigest() != HELP_SHA256:
             return False

--- a/.flow/bin/flowctl_tracker/MANIFEST.json
+++ b/.flow/bin/flowctl_tracker/MANIFEST.json
@@ -1,0 +1,186 @@
+{
+  "files": [
+    {
+      "path": "flowctl.py",
+      "sha256": "c8d965d498d34cbc59534e7577335a8f8faa5259e1b1e678b9fe27f31d057ca9"
+    },
+    {
+      "path": "flowctl_tracker/__init__.py",
+      "sha256": "21ac29eb50e4222bc741261a5a24e412eaf61de2a268eb29e9231119f3ded691"
+    },
+    {
+      "path": "flowctl_tracker/attach/__init__.py",
+      "sha256": "3d056a08841e695a7412dc158f6bbcba87cf65eb500e0bbaf26d54bc13f881d4"
+    },
+    {
+      "path": "flowctl_tracker/attach/providers.py",
+      "sha256": "d8c6c7447b34e381e5b11c170e12e95df3029119c0956e3b9ec9a50057efd24e"
+    },
+    {
+      "path": "flowctl_tracker/classify.py",
+      "sha256": "dfdf6225ebaf694debf742b3a306ca3743ccbdaf51b31b97311464e0b69797e9"
+    },
+    {
+      "path": "flowctl_tracker/config_lock.py",
+      "sha256": "1f517b18bcfc8bee94c6d91739a79c47549cfb2a678e82ca8d25f0e0e24083d4"
+    },
+    {
+      "path": "flowctl_tracker/credentials.py",
+      "sha256": "7911099e37d053422aba9327a0169118f0fe5cbd14d54ad846ab865aa0a5a983"
+    },
+    {
+      "path": "flowctl_tracker/envelope.py",
+      "sha256": "fa0e8cd9b17dbd42c461c940d0c6f498c6430dd68184a48c4045d8ed842c4aa0"
+    },
+    {
+      "path": "flowctl_tracker/executor.py",
+      "sha256": "72ac9efe1c8c69f61ef9806b34eaa221196674476a6b8f8df9d0e55e667c4688"
+    },
+    {
+      "path": "flowctl_tracker/facade/__init__.py",
+      "sha256": "028051f400cadf38ac3204316d14a1229c686923c344fe5811a2aa29bb06114a"
+    },
+    {
+      "path": "flowctl_tracker/facade/chart_projection.py",
+      "sha256": "8744a30f9d51ed30abf0e2c493030d147baf0435debd8e1134345cd74c20dae2"
+    },
+    {
+      "path": "flowctl_tracker/facade/helpers.py",
+      "sha256": "de4e6735462b5b28eea2d176d18c183cab3db2d1ff8d11d10716928ccb512cb1"
+    },
+    {
+      "path": "flowctl_tracker/facade/ops.py",
+      "sha256": "89dc96113c513452c4f2235d256243d5024de817d092c0e3d0f12a0e25a99c4d"
+    },
+    {
+      "path": "flowctl_tracker/facade/projections.py",
+      "sha256": "550014529018ac80bd244bc88e48834a6038598c072804f1c1d2faf9cfcf16f1"
+    },
+    {
+      "path": "flowctl_tracker/facade/steps.py",
+      "sha256": "8647da8c63e1b790328beecf4026d1be848a04631a325b39d2259677a0add41b"
+    },
+    {
+      "path": "flowctl_tracker/lifecycle/__init__.py",
+      "sha256": "f27ce20cb15782440af103bf389e035af1418854106d3615e7a6b87b94f0dc0d"
+    },
+    {
+      "path": "flowctl_tracker/lifecycle/helpers.py",
+      "sha256": "873019a26841498f37422904108775af346e4e9542a81b54c498ce383eea32a0"
+    },
+    {
+      "path": "flowctl_tracker/lifecycle/linkstate.py",
+      "sha256": "f0a1b970dfb6dc0960172b78b909f481aefe3f10b73a6d2c82d9c44ea198e318"
+    },
+    {
+      "path": "flowctl_tracker/lifecycle/providers.py",
+      "sha256": "02d77098354b88740169f58c967527fafdc64a54d6e892ac47ddb49fddf593ba"
+    },
+    {
+      "path": "flowctl_tracker/lifecycle/verbs.py",
+      "sha256": "4b0300543616bab87a45c0505a050e1058964eed7dacea26e39911e5c5ec6152"
+    },
+    {
+      "path": "flowctl_tracker/providers/__init__.py",
+      "sha256": "21e547a2f0bee33048c7e89f9f5fb0e43a01d18c303ccd01d551fe86298ebadb"
+    },
+    {
+      "path": "flowctl_tracker/providers/github.py",
+      "sha256": "e4882c0625c59d89b216e25468c52897ec9ab38827dc29e6d84c293c406507f7"
+    },
+    {
+      "path": "flowctl_tracker/providers/gitlab.py",
+      "sha256": "aca0f0bc4273a0161c71f08d4ee187ac78213d1a94195a2ebc26ecbccdc01bf7"
+    },
+    {
+      "path": "flowctl_tracker/providers/jira.py",
+      "sha256": "7c90a22039746df7a94b37c5939cf3ab5611f45dba6462e0e939788516ca82ec"
+    },
+    {
+      "path": "flowctl_tracker/providers/linear.py",
+      "sha256": "f049938c14c41617690c7fb8285cdea281684a83c83ecaae0ccfe89f31cb5331"
+    },
+    {
+      "path": "flowctl_tracker/question_claim.py",
+      "sha256": "a49115a4fff46b68f18f4da41ef642d28dd87c2dfefe7e414248acbcb4580d79"
+    },
+    {
+      "path": "flowctl_tracker/relate/__init__.py",
+      "sha256": "50f9e9ad36d0e4796a4f45eef9e1149a35a73df72c385b009469bad757f4ae36"
+    },
+    {
+      "path": "flowctl_tracker/relate/ledger.py",
+      "sha256": "0c29aa39e7655a6dd186c965eff2300c1fd79624a983a2e10d2b6667f3859072"
+    },
+    {
+      "path": "flowctl_tracker/relate/listing.py",
+      "sha256": "0e30261bcb2dd4b094b7dcfd5ad9a2b73df1e10a9527862a9b17f9f1b7cc9928"
+    },
+    {
+      "path": "flowctl_tracker/relate/providers.py",
+      "sha256": "d69ecf8e1c7fab41f7956c42c641cda0f1c2d42e6dc7c69c55ea0e0548a9cfa1"
+    },
+    {
+      "path": "flowctl_tracker/resolve_verb.py",
+      "sha256": "95ac59474cbc2c125e43a6bcf14137a8b162cb1993a7487d65ece9ffc5f5409c"
+    },
+    {
+      "path": "flowctl_tracker/resolved_cache.py",
+      "sha256": "da33f9014e4331c7828c3539c5a46fcb570ff5193af65a559a1b55a040def835"
+    },
+    {
+      "path": "flowctl_tracker/states.py",
+      "sha256": "133ccf527af6918cadb392592c252c1db544354701668030e54ad4737cbe5515"
+    },
+    {
+      "path": "flowctl_tracker/status/__init__.py",
+      "sha256": "a074ed529e1e8d6c1990f0b85477189ff60afe423c1255982dd208f53c61801c"
+    },
+    {
+      "path": "flowctl_tracker/status/policy.py",
+      "sha256": "c4eb4f862160e3ba26a68b3b5617f04cacb0a0cfb57582b418cd86e07ee6e5a0"
+    },
+    {
+      "path": "flowctl_tracker/status/providers.py",
+      "sha256": "b78f5bc7e0f6a3e9ec9a81e0ecc653eca78f93057de9e08f098eb5b5a2ce0a11"
+    },
+    {
+      "path": "flowctl_tracker/status/verb.py",
+      "sha256": "09ae76a3dc2233549a37e1785b48c190030a8dcd65cfb29fbb78e549bac18f7c"
+    },
+    {
+      "path": "flowctl_tracker/subjects.py",
+      "sha256": "8005754930019097167137ab01fc12ffcdee4bebf150270d12f33c268500fcc9"
+    },
+    {
+      "path": "flowctl_tracker/syncbody/__init__.py",
+      "sha256": "102a535f259f680340bcc9c2550529f074ea3466916d61b064d3b07b27dd2223"
+    },
+    {
+      "path": "flowctl_tracker/types.py",
+      "sha256": "ea8c0ee9f456702e434fe1ea45929273ee941e77070d24ee89f37d958aeaa34e"
+    },
+    {
+      "path": "flowctl_tracker/wire/__init__.py",
+      "sha256": "9a23ef109e678692cf9fb239d6a6be4d51de28db57ce56a4563f94f53f2a25bf"
+    },
+    {
+      "path": "flowctl_tracker/wire/github.py",
+      "sha256": "0fdcbe0fe41b478fb42838f9d24b0fa09a7a672d515ddf4a1f9e75d0b0a34503"
+    },
+    {
+      "path": "flowctl_tracker/wire/gitlab.py",
+      "sha256": "112e910521931262a7bb994bf7d0ba47b4f9a5bcbf2e4d4629f23de89f6ce49c"
+    },
+    {
+      "path": "flowctl_tracker/wire/jira.py",
+      "sha256": "76fd96ec7ea777fbd95eef410a7f1d9eecdae1d7f068b66f079941496747ed70"
+    },
+    {
+      "path": "flowctl_tracker/wire/linear.py",
+      "sha256": "50909d66020933b7b9b32d66ba1e6646b190db90a72d09d1565c4e3883239a45"
+    }
+  ],
+  "generated_by": "scripts/gen_tracker_manifest.py",
+  "package": "flowctl_tracker"
+}

--- a/.flow/bin/flowctl_tracker/__init__.py
+++ b/.flow/bin/flowctl_tracker/__init__.py
@@ -1,0 +1,25 @@
+"""Deterministic tracker transport for flowctl (fn-139 spec A).
+
+WHY THIS IS A PACKAGE, AND WHY THE NAME IS NAMESPACED.
+
+flowctl ships as *named files*, not a package: `install-codex.sh` copies
+`flowctl` and `flowctl.py` by name, copy-mode setup writes a fixed list into
+`.flow/bin/`, and Ralph scaffolding does the same. So a package only reaches a
+user if the distribution paths are taught about it - that is task .5, and until
+it lands this package is importable from a checkout but NOT from an install.
+
+The name is `flowctl_tracker`, never a bare `tracker`: the launcher runs
+`flowctl_bootstrap.py` as a script, so `sys.path[0]` is that file's directory
+and this package sits directly on `sys.path`. A generic top-level name there
+would collide with anything else a user happens to have installed.
+
+Adapters land in `providers/` in later tasks; this module holds no transport
+logic and imports nothing from flowctl, so the dependency runs one way only.
+"""
+
+# Deliberately no __version__ here. An earlier draft carried one claiming to
+# track the flow-next release while hardcoding a value the manifests contradict.
+# Nothing consumes it yet, and distribution/version wiring is task .5 - a field
+# that lies is worse than an absent one.
+
+__all__: list[str] = []

--- a/.flow/bin/flowctl_tracker/attach/__init__.py
+++ b/.flow/bin/flowctl_tracker/attach/__init__.py
@@ -1,0 +1,127 @@
+"""Wire attach / attach-get (fn-140.4).
+
+Capability-gated uploads with byte-identical retrieval. attach takes a locator;
+attach-get is context-free (attachment id only). Never raises across the boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import ACTIVE, Execute, dict_, read_config, tracker_type
+from ..types import ErrorClass, TrackerError
+from . import providers
+
+Result = Union[dict, TrackerError]
+
+
+def _caps(config: dict) -> dict:
+    caps = dict_(dict_(dict_(config.get("tracker")).get("resolved")).get("capabilities"))
+    if caps:
+        return caps
+    from ..resolved_cache import STATIC_CAPABILITIES  # noqa: PLC0415
+    t = tracker_type(config)
+    return dict(STATIC_CAPABILITIES.get(t) or {})
+
+
+def attach(config: dict, locator: Any, *, file_path: str,
+           execute: Execute) -> Result:
+    """Upload a file to the locator's issue. Returns {id, url, size, sha256}."""
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    caps = _caps(config)
+    if caps.get("attachments") is False:
+        return TrackerError(
+            ErrorClass.CAPABILITY,
+            "attachments are not available on this tracker; GitHub has no "
+            "attachment API (POST /issues/:n/uploads returns 404). Workaround: "
+            "commit the file and link it (private-repo URLs carry expiring tokens)",
+            subtype="attachments",
+            details={"capability": "attachments",
+                     "workaround": "commit-and-link"},
+        )
+    from ..wire import parse_locator  # noqa: PLC0415
+    parsed = parse_locator(locator)
+    if isinstance(parsed, TrackerError):
+        return parsed
+    path = Path(file_path)
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"cannot read --file: {exc}", subtype="file")
+    mod = providers.PROVIDERS.get(provider)
+    if mod is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    return mod.upload(config, parsed, execute, path=path, data=raw)
+
+
+def attach_get(config: dict, *, attachment_id: str, out_path: str,
+               execute: Execute) -> Result:
+    """Retrieve bytes by attachment id (no locator). Writes --out; returns sha256."""
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    caps = _caps(config)
+    if caps.get("attachments") is False:
+        return TrackerError(
+            ErrorClass.CAPABILITY,
+            "attachments are not available on this tracker",
+            subtype="attachments",
+            details={"capability": "attachments"},
+        )
+    if not attachment_id or not str(attachment_id).strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "attach-get requires <attachment-id>",
+                            subtype="attachment_id")
+    if not out_path:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "attach-get requires --out", subtype="out")
+    mod = providers.PROVIDERS.get(provider)
+    if mod is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    return mod.download(config, execute, attachment_id=str(attachment_id).strip(),
+                        out_path=out_path)
+
+
+def run(flow_dir, verb: str, *, locator: Any = None, file_path: Optional[str] = None,
+        attachment_id: Optional[str] = None, out_path: Optional[str] = None,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """CLI entry for wire attach / attach-get."""
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        t = dict_(config.get("tracker")).get("type")
+        if t is not None and t not in ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}",
+                subtype="provider"))
+        return envelope.inactive()
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+    try:
+        if verb == "attach":
+            if not file_path:
+                return envelope.failure(TrackerError(
+                    ErrorClass.INVALID_INPUT, "attach requires --file",
+                    subtype="file"))
+            out = attach(config, locator, file_path=file_path, execute=ex)
+        elif verb == "attach-get":
+            out = attach_get(config, attachment_id=attachment_id or "",
+                             out_path=out_path or "", execute=ex)
+        else:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown attach verb {verb!r}",
+                subtype="verb"))
+    except Exception as exc:  # noqa: BLE001 - boundary must never raise
+        return envelope.failure(TrackerError(
+            ErrorClass.TRANSPORT, f"attach verb raised: {exc}",
+            subtype="unexpected"))
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/attach/providers.py
+++ b/.flow/bin/flowctl_tracker/attach/providers.py
@@ -1,0 +1,425 @@
+"""Per-provider attachment upload / retrieval routes (fn-140.4).
+
+Measured routes (2026-07-26):
+  jira   POST /rest/api/2/issue/{key}/attachments + X-Atlassian-Token: no-check
+         (missing header → 404 that classify surfaces as xsrf, not not_found);
+         GET  /rest/api/2/attachment/content/{id}
+  linear fileUpload → presigned PUT (PRESIGNED_ANONYMOUS, size EXACT) →
+         attachmentCreate referencing assetUrl;
+         retrieval GET assetUrl WITH provider auth
+  gitlab POST /projects/:id/uploads via HTTP multipart (op=upload; NEVER glab
+         api -F - executor forbids the CLI upload route);
+         GET /projects/:id/uploads/:upload_id (never the markdown /uploads/<secret>/ path)
+  github attachments: false - gated before any request (see attach.dispatch)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mimetypes
+from pathlib import Path
+from typing import Optional, Union
+from urllib.parse import quote
+
+from ..classify import classify
+from ..types import CredentialPolicy, ErrorClass, Request, Response, TrackerError
+from ..wire import (
+    Execute,
+    Result,
+    _destination,
+    _gql,
+    _jira_base,
+    parent_read,
+)
+
+#: Trusted origins for Linear asset retrieval - attach-get sends the LINEAR
+#: API KEY with the request, so an arbitrary URL is a credential-exfiltration
+#: primitive (`wire attach-get https://attacker/...`). Measured assetUrl host:
+#: uploads.linear.app.
+_LINEAR_ASSET_HOSTS = ("uploads.linear.app", "files.linear.app")
+
+
+def _random_boundary(payload: bytes) -> str:
+    """A fixed boundary can collide with binary payload bytes at a MIME line
+    boundary (truncation/rejection). Generate one absent from the payload."""
+    import secrets  # noqa: PLC0415
+    while True:
+        candidate = f"----flowctl-{secrets.token_hex(16)}"
+        if candidate.encode() not in payload:
+            return candidate
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _as_error(provider: str, result: Union[Response, TrackerError]
+              ) -> Optional[TrackerError]:
+    if isinstance(result, TrackerError):
+        return result
+    if isinstance(result, Response) and result.status >= 400:
+        return classify(provider, result) or TrackerError(
+            ErrorClass.TRANSPORT, f"{provider} attach HTTP {result.status}",
+            subtype="http")
+    return None
+
+
+def _multipart(filename: str, data: bytes, *, field: str = "file",
+               content_type: Optional[str] = None) -> tuple[bytes, str]:
+    ctype = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    boundary = _random_boundary(data)
+    # Keep filename ASCII-safe for the disposition header.
+    safe = filename.replace('"', "_").replace("\r", "").replace("\n", "")
+    parts = [
+        f"--{boundary}\r\n".encode(),
+        (f'Content-Disposition: form-data; name="{field}"; '
+         f'filename="{safe}"\r\n').encode(),
+        f"Content-Type: {ctype}\r\n\r\n".encode(),
+        data,
+        b"\r\n",
+        f"--{boundary}--\r\n".encode(),
+    ]
+    body = b"".join(parts)
+    return body, f"multipart/form-data; boundary={boundary}"
+
+
+def _write_out(out_path: str, data: bytes) -> Optional[TrackerError]:
+    try:
+        Path(out_path).write_bytes(data)
+    except OSError as exc:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"cannot write --out: {exc}", subtype="out")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Jira
+# ---------------------------------------------------------------------------
+
+def _jira_upload(config: dict, locator: dict, execute: Execute, *,
+                 path: Path, data: bytes) -> Result:
+    parent = parent_read("jira", config, locator, execute, op="wire-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    body, ctype = _multipart(path.name, data)
+    # Address by display key (same parent-gate convention as other jira writes).
+    key = locator["display"]
+    url = f"{base}/rest/api/2/issue/{quote(str(key), safe='')}/attachments"
+    result = execute(Request(
+        provider="jira", op="wire-attach", method="POST", url_or_argv=url,
+        headers={
+            "Content-Type": ctype,
+            "Accept": "application/json",
+            "X-Atlassian-Token": "no-check",
+        },
+        body=body,
+    ))
+    err = _as_error("jira", result)
+    if err:
+        return err
+    if not isinstance(result, Response):
+        return TrackerError(ErrorClass.TRANSPORT, "no response from transport",
+                            subtype="transport")
+    try:
+        payload = json.loads(result.body or b"null")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"malformed jira attach: {exc}",
+                            subtype="malformed_body")
+    # Response is a list of attachment objects.
+    item = payload[0] if isinstance(payload, list) and payload else payload
+    if not isinstance(item, dict) or item.get("id") is None:
+        return TrackerError(ErrorClass.TRANSPORT, "jira attach returned no id",
+                            subtype="malformed_body")
+    return {
+        "id": str(item["id"]),
+        "url": item.get("content") or item.get("self"),
+        "size": len(data),
+        "sha256": _sha(data),
+    }
+
+
+def _jira_download(config: dict, execute: Execute, *, attachment_id: str,
+                   out_path: str) -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    url = (f"{base}/rest/api/2/attachment/content/"
+           f"{quote(str(attachment_id), safe='')}")
+    result = execute(Request(
+        provider="jira", op="wire-attach-get", method="GET", url_or_argv=url,
+        headers={"Accept": "*/*"},
+        idempotent=True,
+        credential_policy=CredentialPolicy.PROVIDER_AUTH,
+    ))
+    err = _as_error("jira", result)
+    if err:
+        return err
+    if not isinstance(result, Response):
+        return TrackerError(ErrorClass.TRANSPORT, "no response from transport",
+                            subtype="transport")
+    raw = result.body or b""
+    werr = _write_out(out_path, raw)
+    if werr:
+        return werr
+    return {"id": attachment_id, "size": len(raw), "sha256": _sha(raw),
+            "out": out_path}
+
+
+# ---------------------------------------------------------------------------
+# Linear
+# ---------------------------------------------------------------------------
+
+def _linear_upload(config: dict, locator: dict, execute: Execute, *,
+                   path: Path, data: bytes) -> Result:
+    parent = parent_read("linear", config, locator, execute, op="wire-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    ctype = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    size = len(data)
+    gql = _gql(
+        execute, "wire-attach-fileUpload",
+        "mutation($contentType: String!, $filename: String!, $size: Int!) { "
+        "fileUpload(contentType: $contentType, filename: $filename, size: $size) { "
+        "success uploadFile { uploadUrl assetUrl headers { key value } } } }",
+        {"contentType": ctype, "filename": path.name, "size": size},
+    )
+    if isinstance(gql, TrackerError):
+        return gql
+    payload = gql.get("fileUpload")
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return TrackerError(ErrorClass.TRANSPORT, "linear fileUpload failed",
+                            subtype="mutation_failed")
+    upload = payload.get("uploadFile")
+    if not isinstance(upload, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear fileUpload missing uploadFile",
+                            subtype="malformed_body")
+    upload_url = upload.get("uploadUrl")
+    asset_url = upload.get("assetUrl")
+    if not isinstance(upload_url, str) or not isinstance(asset_url, str):
+        return TrackerError(ErrorClass.TRANSPORT, "linear fileUpload missing urls",
+                            subtype="malformed_body")
+    headers = {"Content-Type": ctype, "Cache-Control": "public, max-age=31536000"}
+    for h in upload.get("headers") or []:
+        if isinstance(h, dict) and h.get("key") and h.get("value") is not None:
+            headers[str(h["key"])] = str(h["value"])
+    # PRESIGNED_ANONYMOUS: no Linear key on the third-party asset host.
+    put = execute(Request(
+        provider="linear", op="wire-attach-presigned-put", method="PUT",
+        url_or_argv=upload_url, headers=headers, body=data,
+        credential_policy=CredentialPolicy.PRESIGNED_ANONYMOUS,
+    ))
+    err = _as_error("linear", put)
+    if err:
+        return err
+    # Reference the asset on the issue.
+    ref = _gql(
+        execute, "wire-attach-create",
+        "mutation($input: AttachmentCreateInput!) { "
+        "attachmentCreate(input: $input) { success attachment { id url } } }",
+        {"input": {"issueId": locator["durable"], "url": asset_url,
+                   "title": path.name}},
+    )
+    if isinstance(ref, TrackerError):
+        return _linear_uploaded_error(
+            ref, asset_url=asset_url, size=size, data=data)
+    ref_payload = ref.get("attachmentCreate")
+    if not isinstance(ref_payload, dict) or ref_payload.get("success") is not True:
+        return _linear_uploaded_error(
+            TrackerError(
+                ErrorClass.TRANSPORT,
+                "linear attachmentCreate reported failure",
+                subtype="mutation_failed"),
+            asset_url=asset_url, size=size, data=data)
+    return {"id": asset_url, "url": asset_url, "size": size, "sha256": _sha(data)}
+
+
+def _linear_uploaded_error(err: TrackerError, *, asset_url: str, size: int,
+                           data: bytes) -> TrackerError:
+    """Preserve the successful asset PUT when attachmentCreate fails."""
+    details = dict(err.details or {})
+    completed = list(details.get("completed_steps") or [])
+    if "asset-upload" not in completed:
+        completed.append("asset-upload")
+    details.update({
+        "completed_steps": completed,
+        "asset_url": asset_url,
+        "size": size,
+        "sha256": _sha(data),
+        "recoverable": True,
+    })
+    return TrackerError(
+        err.cls, err.message, subtype=err.subtype,
+        retry_after_s=err.retry_after_s, details=details,
+        auto_retryable=err.auto_retryable)
+
+
+def _linear_download(config: dict, execute: Execute, *, attachment_id: str,
+                     out_path: str) -> Result:
+    # attachment_id IS the assetUrl returned by upload. The request carries the
+    # LINEAR API KEY, so the origin MUST be a trusted Linear asset host - an
+    # arbitrary URL here is a credential-exfiltration primitive.
+    from urllib.parse import urlparse  # noqa: PLC0415
+    try:
+        # urlparse / .hostname raise ValueError on malformed input (e.g.
+        # "https://["). Fail CLOSED: reject as untrusted, never bypass.
+        parsed = urlparse(str(attachment_id))
+        scheme = parsed.scheme
+        hostname = parsed.hostname
+    except ValueError:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"linear attach-get only retrieves from trusted Linear asset hosts "
+            f"{_LINEAR_ASSET_HOSTS} over https; attachment id is not a "
+            f"parseable URL",
+            subtype="untrusted_origin")
+    if scheme != "https" or (hostname or "").lower() not in _LINEAR_ASSET_HOSTS:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"linear attach-get only retrieves from trusted Linear asset hosts "
+            f"{_LINEAR_ASSET_HOSTS} over https; got {hostname!r}",
+            subtype="untrusted_origin")
+    result = execute(Request(
+        provider="linear", op="wire-attach-get", method="GET",
+        url_or_argv=attachment_id, headers={"Accept": "*/*"},
+        idempotent=True,
+        credential_policy=CredentialPolicy.PROVIDER_AUTH,
+    ))
+    err = _as_error("linear", result)
+    if err:
+        return err
+    if not isinstance(result, Response):
+        return TrackerError(ErrorClass.TRANSPORT, "no response from transport",
+                            subtype="transport")
+    raw = result.body or b""
+    werr = _write_out(out_path, raw)
+    if werr:
+        return werr
+    return {"id": attachment_id, "size": len(raw), "sha256": _sha(raw),
+            "out": out_path}
+
+
+# ---------------------------------------------------------------------------
+# GitLab
+# ---------------------------------------------------------------------------
+
+def _gl_api_base(dest: dict) -> Union[str, TrackerError]:
+    host = dest.get("host") or "gitlab.com"
+    host = str(host).rstrip("/")
+    if host.startswith(("http://", "https://")):
+        return f"{host}/api/v4"
+    return f"https://{host}/api/v4"
+
+
+def _gitlab_upload(config: dict, locator: dict, execute: Execute, *,
+                   path: Path, data: bytes) -> Result:
+    parent = parent_read("gitlab", config, locator, execute, op="wire-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = dest.get("projectId")
+    if not isinstance(pid, int):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "gitlab destination missing numeric projectId",
+                            subtype="destination")
+    base = _gl_api_base(dest)
+    if isinstance(base, TrackerError):
+        return base
+    body, ctype = _multipart(path.name, data)
+    # op MUST be "upload" so the executor forbids the broken glab CLI route.
+    url = f"{base}/projects/{pid}/uploads"
+    result = execute(Request(
+        provider="gitlab", op="upload", method="POST", url_or_argv=url,
+        headers={"Content-Type": ctype, "Accept": "application/json"},
+        body=body,
+        credential_policy=CredentialPolicy.PROVIDER_AUTH,
+    ))
+    err = _as_error("gitlab", result)
+    if err:
+        return err
+    if not isinstance(result, Response):
+        return TrackerError(ErrorClass.TRANSPORT, "no response from transport",
+                            subtype="transport")
+    # Assert HTTP route: url_or_argv must be a str, not argv list.
+    try:
+        payload = json.loads(result.body or b"null")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"malformed gitlab upload: {exc}",
+                            subtype="malformed_body")
+    if not isinstance(payload, dict) or payload.get("id") is None:
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab upload returned no id",
+                            subtype="malformed_body")
+    return {
+        "id": str(payload["id"]),
+        "url": payload.get("url") or payload.get("full_path"),
+        "size": len(data),
+        "sha256": _sha(data),
+    }
+
+
+def _gitlab_download(config: dict, execute: Execute, *, attachment_id: str,
+                     out_path: str) -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = dest.get("projectId")
+    if not isinstance(pid, int):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "gitlab destination missing numeric projectId",
+                            subtype="destination")
+    base = _gl_api_base(dest)
+    if isinstance(base, TrackerError):
+        return base
+    # Retrieval by upload_id ONLY - never the markdown /uploads/<secret>/ path.
+    url = f"{base}/projects/{pid}/uploads/{quote(str(attachment_id), safe='')}"
+    result = execute(Request(
+        provider="gitlab", op="wire-attach-get", method="GET", url_or_argv=url,
+        headers={"Accept": "*/*"},
+        idempotent=True,
+        credential_policy=CredentialPolicy.PROVIDER_AUTH,
+    ))
+    err = _as_error("gitlab", result)
+    if err:
+        return err
+    if not isinstance(result, Response):
+        return TrackerError(ErrorClass.TRANSPORT, "no response from transport",
+                            subtype="transport")
+    raw = result.body or b""
+    werr = _write_out(out_path, raw)
+    if werr:
+        return werr
+    return {"id": attachment_id, "size": len(raw), "sha256": _sha(raw),
+            "out": out_path}
+
+
+class _Jira:
+    upload = staticmethod(_jira_upload)
+    download = staticmethod(_jira_download)
+
+
+class _Linear:
+    upload = staticmethod(_linear_upload)
+    download = staticmethod(_linear_download)
+
+
+class _Gitlab:
+    upload = staticmethod(_gitlab_upload)
+    download = staticmethod(_gitlab_download)
+
+
+PROVIDERS = {
+    "jira": _Jira,
+    "linear": _Linear,
+    "gitlab": _Gitlab,
+}

--- a/.flow/bin/flowctl_tracker/classify.py
+++ b/.flow/bin/flowctl_tracker/classify.py
@@ -1,0 +1,249 @@
+"""Per-provider response classification (fn-139.2).
+
+`401/403 = auth` is NOT sufficient, which is the whole reason this is a table
+and not a global rule:
+
+  * GitLab returns **403 for two unrelated things** - a bad token, and a
+    licence-gated feature (`is_blocked_by` on Free returns
+    "Blocked issues not available for current license"). One is `auth`, the
+    other is `capability`, and degrading the wrong one silently is how a Free
+    repo ends up looking unauthenticated.
+  * Linear reports **rate limiting as a GraphQL error over HTTP 200/400**, not
+    429, so a status-code-only classifier never sees it.
+
+Every provider table is total: anything unmatched falls through
+`_fallback`, so no response is ever left unclassified.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import Optional
+
+from .credentials import redact
+from .types import ErrorClass, Response, TrackerError
+
+_LICENCE_RE = re.compile(rb"not available for current license", re.I)
+
+
+def _fallback(resp: Response) -> TrackerError:
+    """Total rule. Retryability follows the SUBTYPE, not the class."""
+    if resp.status >= 500:
+        return TrackerError(ErrorClass.TRANSPORT, f"server error {resp.status}",
+                            subtype="5xx", auto_retryable=True)
+    if resp.status in (401, 403):
+        return TrackerError(ErrorClass.AUTH, f"unauthorized ({resp.status})", subtype="http")
+    if resp.status == 404:
+        return TrackerError(ErrorClass.NOT_FOUND, "not found", subtype="http")
+    if resp.status == 429:
+        return TrackerError(ErrorClass.RATE_LIMITED, "rate limited", subtype="http",
+                            retry_after_s=_retry_after(resp), auto_retryable=True)
+    if 400 <= resp.status < 500:
+        return TrackerError(ErrorClass.INVALID_INPUT, f"rejected ({resp.status})", subtype="http")
+    return TrackerError(ErrorClass.TRANSPORT, f"unexpected status {resp.status}",
+                        subtype="unknown")
+
+
+def _retry_after(resp: Response) -> Optional[float]:
+    v = resp.headers.get("retry-after") or resp.headers.get("Retry-After")
+    try:
+        return float(v) if v else None
+    except (TypeError, ValueError):
+        return None
+
+
+_LINEAR_BUCKETS = ("requests", "endpoint-requests", "complexity")
+
+
+def _linear_retry_after(resp: Response) -> Optional[float]:
+    """Linear never sends `Retry-After`; it sends per-bucket reset timestamps.
+
+    Three independent buckets can exhaust (`requests`, `endpoint-requests`, and
+    the complexity budget), each with its own `x-ratelimit-<bucket>-remaining` /
+    `-reset` pair, where reset is **epoch milliseconds**. Falling back to the
+    fixed 1s/2s ladder meant every retry landed inside the same limit window and
+    burned the whole budget without ever waiting long enough to clear it.
+
+    Only an EXHAUSTED bucket constrains us, and the buckets are INDEPENDENT: the
+    request is blocked until the LAST of them clears, so the delay is `max`, not
+    `min`. Taking the soonest reset retried while a slower bucket was still
+    limiting - burning the retry budget inside one window, which is the exact
+    failure the header parsing was added to prevent. `_sleep_backoff` still clamps.
+    """
+    lowered = {str(k).lower(): v for k, v in (resp.headers or {}).items()}
+    waits: list[float] = []
+    now = time.time()
+    for bucket in _LINEAR_BUCKETS:
+        try:
+            remaining = float(lowered[f"x-ratelimit-{bucket}-remaining"])
+            reset_ms = float(lowered[f"x-ratelimit-{bucket}-reset"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if remaining > 0:
+            continue
+        # `reset_ms != reset_ms` is the NaN test, not a typo.
+        if reset_ms != reset_ms or reset_ms in (float("inf"), float("-inf")):  # noqa: PLR0124
+            continue
+        waits.append(max(0.0, reset_ms / 1000.0 - now))
+    if waits:
+        return max(waits)
+    return _retry_after(resp)
+
+
+class _Malformed(Exception):
+    """The body is not a GraphQL document we can reason about."""
+
+
+def _graphql_errors(resp: Response) -> Optional[list[dict]]:
+    """GraphQL puts failures in a 200/400 body; the executor normalizes here.
+
+    Raises `_Malformed` rather than returning None for unparseable input:
+    returning None made invalid JSON over HTTP 200 look like SUCCESS, and a
+    non-dict entry in `errors` (e.g. `{"errors":["bad"]}`) raised AttributeError
+    out of the classifier.
+    """
+    try:
+        payload = json.loads(resp.body or b"{}")
+    except (ValueError, TypeError) as exc:
+        raise _Malformed(str(exc)) from exc
+    if not isinstance(payload, dict):
+        raise _Malformed("GraphQL payload is not an object")
+    errs = payload.get("errors")
+    if errs is None:
+        return None
+    if not isinstance(errs, list) or not all(isinstance(e, dict) for e in errs):
+        raise _Malformed("GraphQL 'errors' is not a list of objects")
+    for e in errs:
+        ext = e.get("extensions")
+        # `extensions` is server-controlled and may be any JSON value. Assuming
+        # dict raised AttributeError on `{"extensions": ["bad"]}`.
+        if ext is not None and not isinstance(ext, dict):
+            raise _Malformed("GraphQL 'extensions' is not an object")
+    return errs or None
+
+
+#: Ops whose 2xx body is raw bytes, not an API document. The Linear rule
+#: parses every 2xx body as GraphQL, which misclassified a binary asset
+#: download from uploads.linear.app as transport/malformed_body (measured
+#: live 2026-07-28). These ops classify on status alone.
+_RAW_BODY_OPS = frozenset({"wire-attach-get"})
+
+
+def classify(provider: str, resp: Response,
+             op: Optional[str] = None) -> Optional[TrackerError]:
+    """None means success. Otherwise a normalized, classified failure."""
+    if op in _RAW_BODY_OPS:
+        return _generic(resp)
+    fn = _TABLE.get(provider, _generic)
+    return fn(resp)
+
+
+def _generic(resp: Response) -> Optional[TrackerError]:
+    if 200 <= resp.status < 300:
+        return None
+    return _fallback(resp)
+
+
+def _gitlab(resp: Response) -> Optional[TrackerError]:
+    # MEASURED: a licence gate and a bad token both surface as 403. The body is
+    # the only discriminator, so it is read before the status rule applies.
+    if resp.status == 403 and _LICENCE_RE.search(resp.body or b""):
+        return TrackerError(
+            ErrorClass.CAPABILITY, "feature not available on this GitLab tier",
+            subtype="licence", details={"capability": "blockedBy", "required_plan": "premium"},
+        )
+    return _generic(resp)
+
+
+def _linear(resp: Response) -> Optional[TrackerError]:
+    # STATUS FIRST for the codes GraphQL never owns. Parsing the body first meant
+    # an HTTP 500 carrying {"errors":[...]} classified as invalid_input instead of
+    # transport, and a 401 with a GraphQL-shaped body lost its auth class - the
+    # total fallback was being bypassed by the body parse.
+    if resp.status in (401, 403, 429) or resp.status >= 500:
+        return _fallback(resp)
+    try:
+        errs = _graphql_errors(resp)
+    except _Malformed as exc:
+        return malformed_body(str(exc))
+    if errs:
+        # STRUCTURED CODES FIRST. `linear-graphql.md` documents
+        # `errors[].extensions.code` of RATELIMITED (over HTTP 400, not 429) and
+        # AUTHENTICATION_ERROR. Message-text heuristics miss both whenever the
+        # message is generic, which silently demotes them to invalid_input.
+        codes = {str((e.get("extensions") or {}).get("code", "")).upper() for e in errs}
+        if "RATELIMITED" in codes:
+            return TrackerError(ErrorClass.RATE_LIMITED, "linear rate limit (RATELIMITED)",
+                                subtype="graphql_code", retry_after_s=_linear_retry_after(resp),
+                                auto_retryable=True)
+        if "AUTHENTICATION_ERROR" in codes:
+            return TrackerError(ErrorClass.AUTH, "linear authentication failed",
+                                subtype="graphql_code")
+        joined = " ".join(str(e.get("message", "")) for e in errs).lower()
+        # MEASURED: Linear rate-limits via a GraphQL error, often over HTTP 200,
+        # and is complexity-based rather than request-count based.
+        if "rate limit" in joined or "complexity" in joined:
+            return TrackerError(ErrorClass.RATE_LIMITED, "linear rate limit",
+                                subtype="graphql", retry_after_s=_linear_retry_after(resp),
+                                auto_retryable=True)
+        if "authentication" in joined or "unauthorized" in joined:
+            return TrackerError(ErrorClass.AUTH, "linear authentication failed",
+                                subtype="graphql")
+        if "not found" in joined:
+            return TrackerError(ErrorClass.NOT_FOUND, "linear entity not found",
+                                subtype="graphql")
+        # Provider text is untrusted and may echo the credential back. Redact
+        # BEFORE it becomes a message; the envelope redacts again as depth.
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            redact(joined[:200]) or "graphql error", subtype="graphql")
+    return _generic(resp)
+
+
+def _jira(resp: Response) -> Optional[TrackerError]:
+    # Jira returns 404 for a missing XSRF header on attachment upload, which
+    # reads as a wrong endpoint. Surfaced with a subtype so the caller can tell.
+    if resp.status == 404 and b"XSRF" in (resp.body or b""):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "Jira rejected the request: missing X-Atlassian-Token header",
+                            subtype="xsrf")
+    return _generic(resp)
+
+
+def _github(resp: Response) -> Optional[TrackerError]:
+    # GitHub serves rate limiting as **403**, not 429, with X-RateLimit-Remaining: 0.
+    # Falling through to the generic rule reported it as `auth`, so the caller
+    # got false credential advice and no backoff ever happened.
+    if resp.status in (403, 429):
+        hdrs = {k.lower(): v for k, v in (resp.headers or {}).items()}
+        remaining = hdrs.get("x-ratelimit-remaining")
+        body = (resp.body or b"").lower()
+        if remaining == "0" or b"rate limit" in body or b"secondary rate limit" in body:
+            return TrackerError(
+                ErrorClass.RATE_LIMITED, "github rate limit", subtype="http_403",
+                retry_after_s=_retry_after(resp) or _reset_delay(hdrs), auto_retryable=True,
+            )
+    return _generic(resp)
+
+
+def _reset_delay(hdrs: dict[str, str]) -> Optional[float]:
+    """X-RateLimit-Reset is an absolute epoch; convert to a bounded delay."""
+    import time as _t
+
+    try:
+        reset = float(hdrs.get("x-ratelimit-reset", ""))
+    except (TypeError, ValueError):
+        return None
+    delay = reset - _t.time()
+    return delay if 0 < delay < 3600 else None
+
+
+_TABLE = {"gitlab": _gitlab, "linear": _linear, "jira": _jira, "github": _github}
+
+
+def malformed_body(detail: str) -> TrackerError:
+    """A body we could not parse is transport-class but NOT auto-retryable -
+    replaying it produces the same garbage."""
+    return TrackerError(ErrorClass.TRANSPORT, f"malformed response body: {detail}",
+                        subtype="malformed_body", auto_retryable=False)

--- a/.flow/bin/flowctl_tracker/config_lock.py
+++ b/.flow/bin/flowctl_tracker/config_lock.py
@@ -1,0 +1,310 @@
+"""The shared `.flow/config.json` writer lock (fn-139.3, R8b).
+
+One named design, used by EVERY config writer - `set_config`, `cmd_init`, and
+the resolve transaction. An atomic write alone prevents torn files but not
+stale-read clobbering: two writers can read, compute different changes, then
+serially replace the whole file, and the second silently discards the first.
+
+Mechanism: an **atomic lock directory** at `.flow/.locks/config.d` - `mkdir` is
+atomic on both POSIX and Windows - containing `owner.json` with
+`{pid, host, acquired_at}`.
+
+Recovery is rule-based, never manual: an owner older than `STALE_OWNER_S`
+whose pid is not alive **on the same host** is stale and reclaimable. A holder
+that crashed between `mkdir` and writing `owner.json` leaves an ownerless
+directory; that too is reclaimed by age (directory mtime), because refusing
+would deadlock every future writer on an artifact nobody owns.
+
+Reclamation is serialized by an atomic `os.rename` of the stale directory to a
+unique trash name: exactly one contender wins the rename, and the removal only
+ever targets the renamed path - never the live lock path. Removing the stale
+directory in place had an ABA race: two contenders both classify it stale, A
+removes and acquires a FRESH lock, then B's delayed removal deletes A's new
+lock and B acquires while A is inside its critical section.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import json
+import os
+import shutil
+import socket
+import stat as stat_mod
+import time
+from pathlib import Path
+from typing import Iterator
+
+#: R8b constants - fixed by the spec, not tunables.
+LOCK_TIMEOUT_S = 10.0
+STALE_OWNER_S = 120.0
+
+_POLL_S = 0.05
+
+
+class ConfigLockTimeout(TimeoutError):
+    """Could not acquire the config lock within LOCK_TIMEOUT_S."""
+
+
+class ConfigLockUnsafe(RuntimeError):
+    """The lock path is a symlink (or otherwise not a plain directory).
+
+    A malicious checkout can commit `.flow/.locks` as a symlink pointing
+    outside the repository; acquisition and release would then create and
+    recursively DELETE an external directory. Refuse instead - same policy as
+    flowctl's other managed-path symlink guards.
+    """
+
+
+def _lock_dir(flow_dir: Path) -> Path:
+    return Path(flow_dir) / ".locks" / "config.d"
+
+
+def _assert_component_safe(path: Path) -> None:
+    """No-follow check on one lock-path component. Absent is fine (we create
+    it); anything present must be a plain directory, never a symlink."""
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return
+    except OSError:
+        return  # unreadable: mkdir/rename below will surface the real error
+    if stat_mod.S_ISLNK(st.st_mode) or not stat_mod.S_ISDIR(st.st_mode):
+        raise ConfigLockUnsafe(
+            f"{path} is not a plain directory; refusing to operate on a "
+            "symlinked or spoofed lock path")
+
+
+def _assert_lock_path_safe(flow_dir: Path, lock: Path) -> None:
+    _assert_component_safe(lock.parent)   # .flow/.locks
+    _assert_component_safe(lock)          # .flow/.locks/config.d
+
+
+if os.name == "nt":  # pragma: no cover - exercised on the Windows CI row
+    def _pid_alive(pid: int) -> bool:
+        """Windows liveness WITHOUT os.kill: `os.kill(pid, sig)` with any sig
+        other than the two CTRL events calls TerminateProcess - a liveness
+        *probe* built on it KILLS the lock holder (or an unrelated pid-recycled
+        process). Query, never signal."""
+        if pid <= 0:
+            return False
+        import ctypes
+        from ctypes import wintypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        ERROR_ACCESS_DENIED = 5
+        STILL_ACTIVE = 259
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            # Access denied means the process exists but is not ours - alive.
+            return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+        try:
+            code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return True  # unknowable counts as alive - never reclaim on doubt
+            return code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+else:
+    def _pid_alive(pid: int) -> bool:
+        """Best-effort liveness. Unknowable states count as ALIVE (never
+        reclaim a lock we cannot prove abandoned)."""
+        if pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True  # exists, owned by someone else
+        except OSError as exc:  # pragma: no cover - platform-specific errno spread
+            return exc.errno != errno.ESRCH
+        return True
+
+
+def _owner_is_stale(lock: Path, now: float) -> bool:
+    owner_path = lock / "owner.json"
+    try:
+        owner = json.loads(owner_path.read_text(encoding="utf-8"))
+        acquired_at = float(owner["acquired_at"])
+        pid = int(owner["pid"])
+        host = str(owner["host"])
+    except (OSError, ValueError, KeyError, TypeError):
+        # No readable owner: either the holder crashed between mkdir and the
+        # owner write, or the file is corrupt. Fall back to directory age -
+        # refusing forever would deadlock every writer on an orphan.
+        try:
+            return (now - lock.stat().st_mtime) > STALE_OWNER_S
+        except OSError:
+            return False  # raced with a release; treat as held
+    if (now - acquired_at) <= STALE_OWNER_S:
+        return False
+    if host != socket.gethostname():
+        # A different host's pid space is unknowable (shared/network checkout).
+        # Age alone must not reclaim there - fail closed.
+        return False
+    return not _pid_alive(pid)
+
+
+def _acquire_reclaimer_claim(lock: Path):
+    """Take the reclaimer claim as an OS FILE LOCK, or return None.
+
+    The claim's ONE job is to make the staleness re-check race-free, and it
+    must not itself need stale recovery - an aged-out mkdir claim reintroduced
+    the exact ABA it existed to close (a contender deleting a live claim off
+    an old observation). An OS lock has neither problem: the kernel releases
+    it when the holder dies (crash recovery for free, no age heuristic) and
+    nothing ever deletes the claim path - the file persists, only the lock
+    state changes. flock on POSIX, msvcrt byte-range locking on Windows.
+    """
+    path = lock.with_name("config.d.reclaimer.lock")
+    # No-follow semantics on the claim leaf, same policy as the directory
+    # components: a malicious checkout can commit this path as a symlink (or a
+    # FIFO/device) pointing outside the repository, and a following open would
+    # create or open the external target. lstat rejects what exists;
+    # O_NOFOLLOW closes the check-to-open window where the platform has it.
+    try:
+        st = os.lstat(path)
+        if not stat_mod.S_ISREG(st.st_mode):
+            raise ConfigLockUnsafe(
+                f"{path} is not a regular file; refusing to open a symlinked "
+                "or special claim leaf")
+    except FileNotFoundError:
+        pass
+    except OSError:
+        return None
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        f = os.fdopen(os.open(path, flags, 0o644), "r+b")
+    except OSError:
+        return None
+    try:
+        if os.name == "nt":  # pragma: no cover - exercised on the Windows CI row
+            import msvcrt
+            f.seek(0)
+            msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return f
+    except OSError:
+        f.close()
+        return None
+
+
+def _release_reclaimer_claim(f) -> None:
+    try:
+        if os.name == "nt":  # pragma: no cover - exercised on the Windows CI row
+            import msvcrt
+            f.seek(0)
+            msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    except OSError:  # pragma: no cover - close() below still drops the lock
+        pass
+    finally:
+        f.close()
+
+
+def _try_reclaim(lock: Path) -> bool:
+    """Reclaim a stale lock without the ABA race, in two layers:
+
+    1. The **reclaimer claim** (an OS file lock, see above) serializes
+       reclaimers and makes the staleness RE-CHECK inside it race-free: while
+       the claim is held the live path cannot change hands - acquirers cannot
+       `mkdir` an occupied path and no other reclaimer can rename it. The
+       hole in check-then-remove was a contender acting on a classification
+       made before another contender reclaimed and re-acquired.
+    2. Removal goes through an atomic rename to a unique trash name, so the
+       live lock path is never the target of a recursive delete.
+    """
+    claim = _acquire_reclaimer_claim(lock)
+    if claim is None:
+        return False  # another reclaimer is active; wait through the deadline loop
+    try:
+        if not _owner_is_stale(lock, time.time()):
+            return False  # the world changed before we got the claim
+        trash = lock.with_name(f"config.d.reclaim-{os.getpid()}-{time.monotonic_ns()}")
+        try:
+            os.rename(lock, trash)
+        except OSError:
+            return False  # removal not possible right now (permissions, AV, ro-fs)
+        shutil.rmtree(trash, ignore_errors=True)
+        return True
+    finally:
+        _release_reclaimer_claim(claim)
+
+
+@contextlib.contextmanager
+def config_lock(flow_dir: Path, *, timeout_s: float = LOCK_TIMEOUT_S) -> Iterator[None]:
+    """Acquire the shared config-writer lock, or raise ConfigLockTimeout.
+
+    Reentrancy is deliberately NOT supported: a writer that needs the lock
+    twice in one call stack is two writers racing themselves.
+    """
+    lock = _lock_dir(flow_dir)
+    _assert_lock_path_safe(flow_dir, lock)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            lock.mkdir()
+            break
+        except FileExistsError:
+            if _owner_is_stale(lock, time.time()) and _try_reclaim(lock):
+                # Reclaimed: retry the mkdir immediately. If someone else
+                # acquires first, their FRESH owner is not stale, so this
+                # branch cannot repeat - the loop is bounded by the deadline.
+                continue
+        except PermissionError:
+            # Windows: a directory whose deletion is still PENDING (the last
+            # holder released while a reader kept a handle open) fails mkdir
+            # with ERROR_ACCESS_DENIED, not FileExistsError. Transient - poll.
+            pass
+        # Held, un-reclaimable, delete-pending, or the reclaim rename failed
+        # (permissions, antivirus, read-only fs): all of these go through the
+        # deadline so acquisition can never spin forever.
+        if time.monotonic() >= deadline:
+            raise ConfigLockTimeout(
+                f"could not acquire {lock} within {timeout_s:.0f}s; "
+                "holder appears alive (see owner.json)"
+            ) from None
+        time.sleep(_POLL_S)
+    try:
+        (lock / "owner.json").write_text(json.dumps({
+            "pid": os.getpid(),
+            "host": socket.gethostname(),
+            "acquired_at": time.time(),
+        }), encoding="utf-8")
+        yield
+    finally:
+        _release(lock)
+
+
+def _release(lock: Path) -> None:
+    """Windows-robust release. A concurrent staleness check holds owner.json
+    open for milliseconds; deleting it in that window raises a sharing
+    violation, and `rmtree(ignore_errors=True)` swallowed it - the lock then
+    NEVER released, deadlocking every writer until the 120s stale rule fired
+    (measured on the windows-latest CI row as 10s acquisition timeouts).
+    Retry briefly; sharing violations clear as soon as the reader closes.
+    """
+    deadline = time.monotonic() + 5.0
+    while True:
+        try:
+            try:
+                (lock / "owner.json").unlink()
+            except FileNotFoundError:
+                pass
+            os.rmdir(lock)
+            return
+        except FileNotFoundError:
+            return
+        except OSError:
+            if time.monotonic() >= deadline:
+                shutil.rmtree(lock, ignore_errors=True)  # last resort
+                return
+            time.sleep(0.01)

--- a/.flow/bin/flowctl_tracker/credentials.py
+++ b/.flow/bin/flowctl_tracker/credentials.py
@@ -1,0 +1,155 @@
+"""Provider credential resolution (fn-139.2).
+
+flow-next implements **no keyring**. "Secure store" means whatever the host OS
+provides and the user has already exported into their environment - an earlier
+draft of this spec had a generic `env -> Keychain -> CLI config` ladder, which
+promised a cross-platform secret store that does not exist here.
+
+Resolution is per provider and by exact name, never a generic ladder.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional
+
+
+class Credential:
+    """A resolved secret plus how to attach it. Never logged, never persisted."""
+
+    __slots__ = ("_apply",)
+
+    def __init__(self, apply: Callable[[dict[str, str]], None]) -> None:
+        self._apply = apply
+
+    def attach(self, headers: dict[str, str]) -> None:
+        self._apply(headers)
+
+    def __repr__(self) -> str:  # pragma: no cover - defensive
+        return "<Credential redacted>"
+
+
+def _glab_config_token(host: Optional[str] = None) -> Optional[str]:
+    """Read glab's stored token FOR A SPECIFIC HOST. Not a keyring - glab's config.
+
+    Host scoping is the point: taking the first token in the file would send a
+    self-managed instance's token to gitlab.com (or the reverse) whenever a user
+    has more than one authenticated host. Fails closed when no stanza matches.
+    """
+    import re
+
+    want = (host or "gitlab.com").lower()
+    for candidate in (
+        os.path.expanduser("~/.config/glab-cli/config.yml"),
+        os.path.expanduser("~/Library/Application Support/glab-cli/config.yml"),
+    ):
+        try:
+            with open(candidate, encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        # hosts:\n    <host>:\n        token: <value>
+        m = re.search(
+            rf"^\s+{re.escape(want)}:\s*$(.*?)(?=^\s{{0,8}}\S+:\s*$|\Z)",
+            text, re.M | re.S,
+        )
+        if m:
+            tok = re.search(r"^\s+token:\s*(\S+)", m.group(1), re.M)
+            if tok:
+                return tok.group(1)
+    return None
+
+
+def _basic(user: str, token: str) -> str:
+    import base64
+
+    return "Basic " + base64.b64encode(f"{user}:{token}".encode()).decode()
+
+
+def resolve(provider: str, *, auth_scheme: Optional[str] = None,
+            host: Optional[str] = None) -> Optional[Credential]:
+    """Return a Credential, or None when the transport authenticates itself.
+
+    GitHub and GitLab ordinarily go through their CLI, which carries its own
+    auth - so None there is correct, not a failure.
+    """
+    if provider == "github":
+        tok = _remember(os.environ.get("GH_TOKEN"))
+        return Credential(lambda h: h.__setitem__("Authorization", f"Bearer {tok}")) if tok else None
+
+    if provider == "gitlab":
+        # Ordinary calls go through `glab`, which authenticates itself - but the
+        # upload route MUST use HTTP, and returning None there would send it
+        # unauthenticated. So fall back to glab's own stored token.
+        tok = _remember(os.environ.get("GITLAB_TOKEN") or _glab_config_token(host))
+        return Credential(lambda h: h.__setitem__("PRIVATE-TOKEN", tok)) if tok else None
+
+    if provider == "linear":
+        key = _remember(os.environ.get("LINEAR_API_KEY"))
+        return Credential(lambda h: h.__setitem__("Authorization", key)) if key else None
+
+    if provider == "jira":
+        # Selected by the PERSISTED authScheme rather than re-racing both sets
+        # every run: a site is Cloud or Data Center, and that does not change
+        # between invocations. Racing them would also make "which credential
+        # failed" unanswerable when both are present.
+        if auth_scheme == "bearer-pat":
+            pat = _remember(os.environ.get("JIRA_PAT"))
+            return Credential(lambda h: h.__setitem__("Authorization", f"Bearer {pat}")) if pat else None
+        email, tok = os.environ.get("JIRA_EMAIL"), _remember(os.environ.get("JIRA_API_TOKEN"))
+        if email and tok:
+            return Credential(lambda h: h.__setitem__("Authorization", _basic(email, tok)))
+        return None
+
+    return None
+
+
+#: Every secret this process has actually resolved, including ones that never
+#: appear in the environment. Scanning env vars alone missed the glab-config
+#: token used by the mandatory GitLab HTTP upload route, so a provider echoing
+#: it back would have leaked it.
+_SEEN: set[str] = set()
+
+
+#: Refuse, rather than exempt-from-redaction, a credential too short to redact
+#: safely. A round-7 length floor inside `redact()` was the wrong end of the
+#: problem: it let a 3-character token attach to a live request while being
+#: deliberately excluded from scrubbing, which breaks R6 outright. Rejecting at
+#: resolution keeps `redact()` floorless AND keeps a 1-2 char value from
+#: shredding every message it happens to appear inside. No provider here issues
+#: a credential this short, so nothing legitimate is refused.
+MIN_CREDENTIAL_LEN = 4
+
+
+class ShortCredential(ValueError):
+    """Resolved a credential too short to be real. Never carries the value."""
+
+
+def _remember(value: Optional[str]) -> Optional[str]:
+    if value and len(value) < MIN_CREDENTIAL_LEN:
+        raise ShortCredential(
+            f"resolved credential is shorter than {MIN_CREDENTIAL_LEN} characters; "
+            "refusing to use it (a value this short cannot be redacted from logs)"
+        )
+    if value:
+        _SEEN.add(value)
+    return value
+
+
+def redact(text: str) -> str:
+    """Strip every known secret from a string bound for a log, error or receipt."""
+    out = text
+    for name in ("GH_TOKEN", "GITLAB_TOKEN", "LINEAR_API_KEY", "JIRA_API_TOKEN", "JIRA_PAT"):
+        val = os.environ.get(name)
+        # Same rule as `_remember`: a value this short is never a usable
+        # credential (resolution refuses it), and adding it here would let a
+        # stray `JIRA_PAT=p` rewrite every message containing the letter p.
+        if val and len(val) >= MIN_CREDENTIAL_LEN:
+            _SEEN.add(val)
+    # NO length floor. Everything in `_SEEN` was accepted by `_remember`, which
+    # refuses anything under MIN_CREDENTIAL_LEN - so "too short to redact" is
+    # handled by rejecting the credential, never by exempting it here.
+    for secret in sorted(_SEEN, key=len, reverse=True):
+        if secret:
+            out = out.replace(secret, "<redacted>")
+    return out

--- a/.flow/bin/flowctl_tracker/envelope.py
+++ b/.flow/bin/flowctl_tracker/envelope.py
@@ -1,0 +1,101 @@
+"""The single result envelope every `flowctl tracker` command emits (fn-139.2).
+
+One JSON object on **stdout**; human-readable notes go to **stderr**. Callers
+therefore parse without branching, and `--json` is accepted-and-ignored rather
+than switching the shape.
+
+`degraded` means a real capability transition. A failed TTL re-probe is NOT a
+degradation - it reports through `probe`, because conflating "we could not
+check" with "the capability changed" is how a transient 403 becomes a permanent
+silent downgrade.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Optional
+
+from .credentials import redact
+from .types import EXIT_CODES, ErrorClass, TrackerError
+
+
+def success(data: Any, *, degraded: Optional[dict] = None,
+            probe: Optional[dict] = None) -> tuple[str, int]:
+    return json.dumps({
+        "success": True, "data": data,
+        "degraded": degraded, "probe": probe,
+    }, sort_keys=True), 0
+
+
+def _scrub(obj: Any) -> Any:
+    """Redact every string reachable in an outbound payload, at any depth.
+
+    Redacting only `err.message` was a hole with a concrete exploit: a provider
+    echoes the credential back, the classifier files it under
+    `conflict.candidates` or a capability payload, and `details` serialized it
+    verbatim. The keys that carry provider text are exactly the ones a caller is
+    meant to act on, so they cannot be excluded.
+    """
+    if isinstance(obj, str):
+        return redact(obj)
+    if isinstance(obj, dict):
+        # Keys too: a provider that echoes the token back as a mapping KEY
+        # (e.g. a per-credential error index) would otherwise leak it.
+        return {_scrub(k): _scrub(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_scrub(v) for v in obj]
+    return obj
+
+
+def _details_for(err: TrackerError) -> Optional[dict]:
+    """Typed variant keyed by class - NOT free-form.
+
+    A caller that must act on a failure needs the actionable field in a known
+    place: how long to wait, which capability is missing, which candidates an
+    ambiguity is between. Emitting `err.details` verbatim left `rate_limited`
+    with a null payload because `retry_after_s` lives on its own attribute.
+    """
+    base = dict(err.details or {})
+    if err.cls is ErrorClass.RATE_LIMITED:
+        return {"retry_after_s": err.retry_after_s, **base}
+    if err.cls is ErrorClass.CAPABILITY:
+        return {"capability": base.get("capability"),
+                "required_plan": base.get("required_plan"), **base}
+    if err.cls is ErrorClass.CONFLICT:
+        return {"normalized": base.get("normalized"),
+                "candidates": base.get("candidates", []), **base}
+    if err.cls is ErrorClass.EXTERNAL_ACTION_REQUIRED:
+        return {"action": base.get("action"), "payload": base.get("payload"), **base}
+    return base or None
+
+
+def failure(err: TrackerError, *, retryable: Optional[bool] = None) -> tuple[str, int]:
+    payload = {
+        "success": False,
+        "class": err.cls.value,
+        # Last line of defence: provider error text is untrusted and has been
+        # observed to echo credentials back. Redacting only at the classifier
+        # would leave any other TrackerError source unprotected.
+        "error": redact(err.message),
+        # Distinct from `auto_retryable`, which governs the executor's internal
+        # retry. This answers a different question: would re-invoking help?
+        "retryable": bool(err.auto_retryable if retryable is None else retryable),
+        "details": _scrub(_details_for(err)),
+    }
+    return json.dumps(payload, sort_keys=True), EXIT_CODES[err.cls]
+
+
+def emit(payload_and_code: tuple[str, int], *, note: Optional[str] = None) -> int:
+    if note:
+        # stderr is not a safe channel for an unredacted note: it is captured in
+        # CI logs and Ralph receipts exactly like stdout.
+        print(redact(note), file=sys.stderr)
+    payload, code = payload_and_code
+    print(payload)
+    return code
+
+
+def inactive() -> tuple[str, int]:
+    """Bridge off: a no-op, not an error the caller must handle."""
+    return failure(TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive"))

--- a/.flow/bin/flowctl_tracker/executor.py
+++ b/.flow/bin/flowctl_tracker/executor.py
@@ -1,0 +1,372 @@
+"""The injected request executor (fn-139.2).
+
+This is the seam. Adapters call `execute(request)` and nothing else - no
+`subprocess.run`, no sockets - which is what makes the whole suite testable
+with an in-process fake instead of a live tracker.
+
+It owns four things adapters must not: credential attachment (after the adapter
+boundary), bounded retry, redirect safety, and turning any transport-native
+explosion into a `TrackerError`.
+"""
+
+from __future__ import annotations
+
+import http.client
+import re
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Callable, Optional, Protocol, Union
+from urllib.parse import urlparse
+
+from .classify import classify
+from .credentials import Credential, redact, resolve
+from .types import (BACKOFF_CAP_S, CONCURRENCY_CAP, MAX_RETRIES, CredentialPolicy,
+                    ErrorClass, Request, Response, TrackerError)
+
+Result = Union[Response, TrackerError]
+
+#: The cap is enforced HERE, at the shared boundary, because a module constant
+#: that nothing acquires is documentation, not a bound. Adapters get bounded
+#: concurrency by construction rather than by remembering to ask for it.
+#: Config-overridable (fn-139 R7: "defaults, config-overridable"): one
+#: semaphore per distinct cap, created on first use and shared process-wide.
+_SLOTS = threading.BoundedSemaphore(CONCURRENCY_CAP)
+_SLOTS_BY_CAP = {CONCURRENCY_CAP: _SLOTS}
+_SLOTS_LOCK = threading.Lock()
+
+
+def _slots_for(cap: Optional[int]) -> threading.BoundedSemaphore:
+    if not isinstance(cap, int) or cap < 1 or cap == CONCURRENCY_CAP:
+        return _SLOTS
+    with _SLOTS_LOCK:
+        if cap not in _SLOTS_BY_CAP:
+            _SLOTS_BY_CAP[cap] = threading.BoundedSemaphore(cap)
+        return _SLOTS_BY_CAP[cap]
+
+
+def concurrency_slots_available() -> int:
+    """Test seam: how many transports may still start."""
+    return _SLOTS._value  # noqa: SLF001 - deliberate introspection for tests
+
+
+class Executor(Protocol):
+    def __call__(self, request: Request) -> Result: ...
+
+
+def _backoff_delay(attempt: int, retry_after: Optional[float],
+                   cap_s: float = BACKOFF_CAP_S) -> float:
+    """Server-supplied hints are untrusted input.
+
+    `Retry-After: -1` reached `time.sleep(-1)` and raised ValueError - another
+    breach of "never raises", caused by a hostile-or-broken header rather than
+    by our own code. Pure so the ACTUAL delay can be emitted before sleeping.
+    """
+    delay: Optional[float] = None
+    if retry_after is not None:
+        try:
+            candidate = float(retry_after)
+        except (TypeError, ValueError):
+            candidate = float("nan")
+        # `candidate == candidate` is the NaN test, not a typo.
+        if candidate == candidate and candidate >= 0 and candidate != float("inf"):  # noqa: PLR0124
+            delay = candidate
+    if delay is None:
+        delay = min(2.0 ** attempt, cap_s)
+    return max(0.0, min(delay, cap_s))
+
+
+def _origin(url: str) -> tuple[str, str, int]:
+    u = urlparse(url)
+    default_port = 443 if u.scheme == "https" else 80
+    return (u.scheme, (u.hostname or "").lower(), u.port or default_port)
+
+
+class _GuardedRedirect(urllib.request.HTTPRedirectHandler):
+    """Follow redirects, but never carry a credential to a NEW host.
+
+    Refusing every redirect was too blunt: presigned uploads and CDN-backed
+    asset fetches legitimately redirect, and an anonymous request has no secret
+    to protect. The rule is about credentials, not about redirects:
+
+      * no credential attached -> follow normally
+      * same host              -> follow, credential may stay
+      * cross host WITH a credential -> strip it before following
+    """
+
+    def __init__(self, authenticated: bool) -> None:
+        super().__init__()
+        self._authenticated = authenticated
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: D102
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is None:
+            return None
+        # Compare ORIGIN (scheme + host + port), not just host: an HTTPS->HTTP
+        # downgrade on the same host would otherwise carry the token in clear.
+        if self._authenticated and _origin(newurl) != _origin(req.full_url):
+            for h in list(new.headers):
+                if h.lower() in {"authorization", "private-token", "x-api-key"}:
+                    del new.headers[h]
+        return new
+
+
+def _read_body(resp) -> bytes:
+    """Single guarded reader. `.read()` can raise after the status line."""
+    data = resp.read()
+    return data if data is not None else b""
+
+
+def _attach(req: Request, headers: dict[str, str], cred: Optional[Credential]) -> None:
+    if req.credential_policy is CredentialPolicy.PROVIDER_AUTH and cred is not None:
+        cred.attach(headers)
+    # PRESIGNED_ANONYMOUS and NONE attach nothing. This is the branch that keeps
+    # the Linear API key off a third-party presigned asset host.
+
+
+def _http(req: Request, cred: Optional[Credential], verify_tls: bool) -> Result:
+    headers = dict(req.headers)
+    _attach(req, headers, cred)
+    started = time.monotonic()
+    authenticated = (req.credential_policy is CredentialPolicy.PROVIDER_AUTH
+                     and cred is not None)
+    handlers: list = [_GuardedRedirect(authenticated)]
+    if not verify_tls:
+        import ssl
+
+        # `OpenerDirector.open()` takes no `context` kwarg - it must be installed
+        # on an HTTPSHandler. Passing it to open() raises TypeError, which is
+        # exactly how the opt-out was broken.
+        handlers.append(urllib.request.HTTPSHandler(context=ssl._create_unverified_context()))  # noqa: S323
+    try:
+        # Request construction is INSIDE the try: a malformed persisted URL or a
+        # non-str target raises here, and the contract says this function returns
+        # a TrackerError rather than letting an exception escape.
+        opener = urllib.request.build_opener(*handlers)
+        r = urllib.request.Request(req.url_or_argv, data=req.body, headers=headers,
+                                   method=req.method)
+        with opener.open(r, timeout=req.timeout_s) as resp:
+            return Response(resp.status, dict(resp.headers), _read_body(resp),
+                            time.monotonic() - started)
+    except urllib.error.HTTPError as exc:
+        # Reading the ERROR body can itself raise IncompleteRead, and doing it
+        # inside this handler put it beyond the reach of the sibling handlers.
+        # One guarded reader serves both the success and error paths.
+        try:
+            body = _read_body(exc)
+        except (http.client.HTTPException, TimeoutError, OSError) as read_exc:
+            # A sibling `except` cannot catch what is raised INSIDE this handler,
+            # so a socket timeout while reading the error body escaped entirely.
+            return TrackerError(ErrorClass.TRANSPORT,
+                                redact(f"incomplete error body: {read_exc}"),
+                                subtype="read", auto_retryable=True)
+        return Response(exc.code, dict(exc.headers or {}), body, time.monotonic() - started)
+    except http.client.HTTPException as exc:
+        # `resp.read()` can raise IncompleteRead / HTTPException AFTER the status
+        # line is parsed. Uncaught, these broke the "never raises" contract.
+        return TrackerError(ErrorClass.TRANSPORT, redact(f"incomplete response: {exc}"),
+                            subtype="read", auto_retryable=True)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, redact(str(exc)), subtype="timeout",
+                            auto_retryable=True)
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.INVALID_INPUT, redact(f"bad request target: {exc}"),
+                            subtype="construction")
+
+
+#: `gh`/`glab` surface the upstream status in their diagnostics ("HTTP 401",
+#: "status code 429"). Without this the CLI route cannot be classified at all.
+_CLI_STATUS_RE = re.compile(rb"(?:HTTP|status(?:\s+code)?)[^0-9]{0,8}([1-5][0-9]{2})", re.I)
+
+
+def _cli(req: Request, verify_tls: bool) -> Result:
+    """CLI route. `timeout_s` is a TOTAL process deadline here - `gh`/`glab`
+    expose no timeout flag of their own."""
+    if not verify_tls:
+        # gh/glab expose no TLS-verification flag. Silently ignoring the opt-out
+        # would claim a guarantee the route cannot honour.
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"sslVerify=false is not supported on the {req.provider} CLI route; "
+            "use the HTTP route or restore TLS verification",
+            subtype="tls_unsupported",
+        )
+    started = time.monotonic()
+    try:
+        # No shell. Body goes on stdin, never argv, so a body containing shell
+        # metacharacters or a very long payload cannot become an argument.
+        proc = subprocess.run(  # noqa: S603 - argv list, shell=False
+            list(req.url_or_argv), input=req.body, capture_output=True,
+            timeout=req.timeout_s, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return TrackerError(ErrorClass.TRANSPORT, "CLI process deadline exceeded",
+                            subtype="timeout", auto_retryable=True)
+    except (OSError, ValueError, TypeError) as exc:
+        # subprocess.run raises TypeError for a non-str argv element or a
+        # non-bytes body (e.g. ["gh", None]) - not OSError.
+        return TrackerError(ErrorClass.TRANSPORT, redact(str(exc)), subtype="spawn",
+                            auto_retryable=False)
+    elapsed = time.monotonic() - started
+    # `glab` prints its "Multiple config files found" warning to STDOUT, which
+    # corrupts JSON parsing (measured). Strip leading non-JSON noise.
+    out = proc.stdout or b""
+    if req.provider == "gitlab":
+        idx = min((i for i in (out.find(b"{"), out.find(b"[")) if i != -1), default=-1)
+        if idx > 0:
+            out = out[idx:]
+    if proc.returncode == 0:
+        return Response(200, {}, out, elapsed)
+    # A non-zero exit collapsed to a synthetic 400 made every CLI failure
+    # `invalid_input` and left the classifier's auth / rate-limit / licence /
+    # 5xx branches unreachable on the ordinary CLI route. `gh` and `glab` both
+    # print the upstream status, so extract it and classify on the real thing.
+    diag = (proc.stderr or b"") + b"\n" + (proc.stdout or b"")
+    m = _CLI_STATUS_RE.search(diag)
+    status = int(m.group(1)) if m else 400
+    return Response(status, {}, diag.strip() or b"", elapsed)
+
+
+#: Operations that MUST NOT use the CLI route, per provider. `glab api -F file=@`
+#: produces invalid multipart (measured), so GitLab uploads have no permitted CLI
+#: path - documenting that was not enough, because nothing stopped an adapter
+#: from passing argv anyway.
+_CLI_FORBIDDEN = {("gitlab", "upload")}
+
+
+def _validate_route(req: Request) -> Optional[TrackerError]:
+    is_cli = isinstance(req.url_or_argv, (list, tuple))
+    if is_cli and (req.provider, req.op) in _CLI_FORBIDDEN:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"{req.provider} '{req.op}' must use the HTTP route; the CLI form is "
+            "known-broken (glab api -F produces invalid multipart)",
+            subtype="forbidden_route",
+        )
+    return None
+
+
+def execute(
+    request: Request,
+    *,
+    auth_scheme: Optional[str] = None,
+    verify_tls: bool = True,
+    on_event: Optional[Callable[[str], None]] = None,
+    max_retries: Optional[int] = None,
+    backoff_cap_s: Optional[float] = None,
+    concurrency: Optional[int] = None,
+) -> Result:
+    """Run one request. Returns `Response | TrackerError` - never raises.
+
+    `max_retries` / `backoff_cap_s` / `concurrency` are the R7 bounds -
+    config-overridable by the caller, defaulting to the module constants.
+    Overrides are validated and CLAMPED (never raised past the defaults'
+    spirit): a hostile/typo'd config must not unbound the executor.
+    """
+    route_err = _validate_route(request)
+    if route_err is not None:
+        return route_err
+    try:
+        # urlparse raises on malformed input (e.g. "http://[::1" - unterminated
+        # IPv6), and this ran outside the guarded path, so it escaped execute().
+        dest_host = (urlparse(request.url_or_argv).hostname
+                     if isinstance(request.url_or_argv, str) else None)
+    except ValueError as exc:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            redact(f"malformed request target: {exc}"),
+                            subtype="construction")
+    is_cli = isinstance(request.url_or_argv, (list, tuple))
+    cred: Optional[Credential] = None
+    if not is_cli:
+        # HTTP route only. `_cli` never consumes the credential - gh/glab carry
+        # their own auth - so resolving here anyway meant a garbage GITLAB_TOKEN
+        # in the environment failed a glab CLI call with auth/resolve even
+        # though the call would have succeeded. Unused state must not gate.
+        try:
+            # A corrupt glab config or an unreadable credential source must not
+            # escape either - this sits outside every other guard.
+            cred = resolve(request.provider, auth_scheme=auth_scheme, host=dest_host)
+        except Exception as exc:  # noqa: BLE001 - boundary: nothing may escape execute()
+            return TrackerError(ErrorClass.AUTH, redact(f"credential resolution failed: {exc}"),
+                                subtype="resolve")
+    if not verify_tls:
+        # "Honoured but never silent" cannot depend on the caller happening to
+        # pass a sink - with the default API (no on_event) the downgrade was
+        # completely silent. Fail closed instead: an unrecordable downgrade is
+        # refused rather than performed quietly.
+        if on_event is None:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                "sslVerify=false requires an event sink so the downgrade is recorded; "
+                "refusing to disable TLS verification silently",
+                subtype="tls_unrecorded",
+            )
+        # Reject the unsupportable route BEFORE announcing a downgrade. Emitting
+        # first made the audit stream claim TLS verification was disabled on a
+        # request that was then refused and never sent - a false entry in the one
+        # record that exists to prove when verification was actually off.
+        if is_cli:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"sslVerify=false is not supported on the {request.provider} CLI route; "
+                "use the HTTP route or restore TLS verification",
+                subtype="tls_unsupported",
+            )
+        # The sink is caller-supplied and can itself raise. A sink that fails AT
+        # RECORD TIME is exactly as unrecordable as a missing one, so the same
+        # rule applies: refuse rather than downgrade with no record. Letting the
+        # exception escape would also break the "never raises" contract.
+        try:
+            on_event(f"tls-verification-disabled provider={request.provider} op={request.op}")
+        except Exception as exc:  # noqa: BLE001 - boundary: nothing may escape execute()
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                redact(f"event sink failed while recording the TLS downgrade: {exc}; "
+                       "refusing to disable TLS verification unrecorded"),
+                subtype="tls_unrecorded",
+            )
+
+    retries_cap = MAX_RETRIES
+    if isinstance(max_retries, int) and 0 <= max_retries <= 5:
+        retries_cap = max_retries
+    backoff_cap = BACKOFF_CAP_S
+    if isinstance(backoff_cap_s, (int, float)) and 0 < backoff_cap_s <= 300:
+        backoff_cap = float(backoff_cap_s)
+    slots = _slots_for(concurrency)
+
+    attempt = 0
+    while True:
+        if on_event:
+            try:
+                on_event(f"attempt {attempt + 1} provider={request.provider} "
+                         f"op={request.op} route={'cli' if is_cli else 'http'}")
+            except Exception:  # noqa: BLE001, S110 - diagnostics only
+                pass
+        with slots:
+            raw = _cli(request, verify_tls) if is_cli else _http(request, cred, verify_tls)
+        if isinstance(raw, TrackerError):
+            err = raw
+        else:
+            err = classify(request.provider, raw, op=request.op)
+            if err is None:
+                return raw
+        # Retry ONLY when the class says rate-limited AND the caller declared the
+        # request idempotent. Replaying a non-idempotent write is how duplicates
+        # get created - and no tracker dedups on create (measured).
+        retryable = err.auto_retryable and err.cls is ErrorClass.RATE_LIMITED and request.idempotent
+        if not retryable or attempt >= retries_cap:
+            return err
+        delay = _backoff_delay(attempt, err.retry_after_s, backoff_cap)
+        if on_event:
+            # Best-effort, unlike the downgrade record above: the retry event is
+            # diagnostics, not the audit line a security property depends on.
+            # The ACTUAL delay is emitted, not the server's untrusted hint.
+            try:
+                on_event(f"retry attempt={attempt + 1}/{retries_cap} "
+                         f"class={err.cls.value} op={request.op} backoff_s={delay:.2f}")
+            except Exception:  # noqa: BLE001, S110 - never raises; diagnostics only
+                pass
+        time.sleep(delay)
+        attempt += 1

--- a/.flow/bin/flowctl_tracker/facade/__init__.py
+++ b/.flow/bin/flowctl_tracker/facade/__init__.py
@@ -1,0 +1,140 @@
+"""Lifecycle facade: `tracker sync --op push|pull|reconcile|comment` (fn-140.7).
+
+Callers invoke one op; the facade owns create-if-unlinked, granular sequence,
+comment marker + dedup, one aggregate event-tagged receipt, and structured
+conflict/degradation. Judgment-bearing content is always an input file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import ACTIVE, Execute, dict_, read_config, tracker_type
+from ..types import ErrorClass, TrackerError
+from .helpers import validate_inputs
+from .ops import op_comment, op_pull, op_push, op_reconcile
+
+__all__ = ["run", "sync"]
+
+
+def sync(flow_dir, spec_id: str, *, op: str, event: str,
+         flow_file: Optional[str] = None, body_file: Optional[str] = None,
+         comments_file: Optional[str] = None,
+         source_body_file: Optional[str] = None,
+         comment_file: Optional[str] = None,
+         pr_url: Optional[str] = None,
+         status_only: bool = False,
+         execute: Execute = default_execute):
+    """Compose one facade op. Returns data dict or TrackerError — never raises."""
+    flow_dir = Path(flow_dir)
+    bad = validate_inputs(
+        op, flow_file=flow_file, body_file=body_file,
+        comments_file=comments_file, source_body_file=source_body_file,
+        comment_file=comment_file, pr_url=pr_url,
+        event=event, status_only=status_only)
+    if bad:
+        return bad
+
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    try:
+        if op == "push":
+            return op_push(
+                flow_dir, spec_id, flow_file=flow_file or "",
+                body_file=body_file or "", event=event,
+                comment_file=comment_file, status_only=status_only,
+                execute=execute)
+        if op == "pull":
+            return op_pull(
+                flow_dir, spec_id, flow_file=flow_file or "",
+                body_file=body_file or "", comments_file=comments_file or "",
+                event=event, execute=execute)
+        if op == "reconcile":
+            return op_reconcile(
+                flow_dir, spec_id, flow_file=flow_file or "",
+                body_file=body_file or "", comments_file=comments_file or "",
+                source_body_file=source_body_file or "",
+                event=event, pr_url=pr_url, execute=execute)
+        if op == "comment":
+            return op_comment(
+                flow_dir, spec_id, body_file=body_file or "",
+                event=event, execute=execute)
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"unknown op {op!r}", subtype="op")
+    except Exception as exc:  # noqa: BLE001 - boundary must never raise
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"facade raised: {exc}", subtype="unexpected")
+
+
+def _partial_failure(err: TrackerError) -> tuple[str, int]:
+    """success:false + data.completed_steps (partial-success resume surface)."""
+    details = dict(err.details or {})
+    completed = details.pop("completed_steps", None) or []
+    receipt_status = details.pop("receipt_status", None)
+    base_payload, code = envelope.failure(err)
+    try:
+        payload = json.loads(base_payload)
+    except (ValueError, TypeError):
+        return base_payload, code
+    data = {"completed_steps": completed}
+    if receipt_status is not None:
+        data["receipt_status"] = receipt_status
+    # Keep remaining details under details; surface completed_steps on data.
+    payload["data"] = data
+    if isinstance(payload.get("details"), dict):
+        # Avoid duplicating the same list under details once moved to data.
+        payload["details"].pop("completed_steps", None)
+        payload["details"].pop("receipt_status", None)
+        if not payload["details"]:
+            payload["details"] = None
+    return json.dumps(payload, sort_keys=True), code
+
+
+def run(flow_dir, *, spec_id: Optional[str] = None, op: Optional[str] = None,
+        event: Optional[str] = None, flow_file: Optional[str] = None,
+        body_file: Optional[str] = None,
+        comments_file: Optional[str] = None,
+        source_body_file: Optional[str] = None,
+        comment_file: Optional[str] = None,
+        pr_url: Optional[str] = None,
+        status_only: bool = False,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """Thin envelope shell — never raises across the boundary."""
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        t = dict_(config.get("tracker")).get("type")
+        if t is not None and t not in ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}",
+                subtype="provider"))
+        return envelope.inactive()
+
+    if not spec_id or not op:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "tracker sync requires <spec-id> --op",
+            subtype="args"))
+
+    out = sync(flow_dir, spec_id, op=op, event=event or "",
+               flow_file=flow_file, body_file=body_file,
+               comments_file=comments_file,
+               source_body_file=source_body_file,
+               comment_file=comment_file, pr_url=pr_url,
+               status_only=status_only,
+               execute=execute)
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        # Partial success: completed_steps present → include data.
+        if out.details and out.details.get("completed_steps"):
+            # Also write the aggregate receipt for partial success when the
+            # ops layer already recorded receipt_status on the error.
+            return _partial_failure(out)
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/facade/chart_projection.py
+++ b/.flow/bin/flowctl_tracker/facade/chart_projection.py
@@ -1,0 +1,2053 @@
+"""Chart lifecycle projection through the deterministic tracker facade (fn-135.5).
+
+Local chart state is always canonical. When tracker.charts is on and the bridge
+is active, each committed local revision projects parent/child issues, type/
+attendance/status/safe evidence, native blocking (where supported), and a
+compact parent rollup. Partial/failed/reordered remote work persists completed
+steps + one aggregate receipt + revision so retry/reconcile converges without
+duplicates and never rolls back local chart state.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import unquote, urlparse
+
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import (Execute, Result, atomic_write_json, dict_,
+                                 now_iso, read_config, tracker_type)
+from ..lifecycle.providers import provider_create
+from ..relate.ledger import (dep_relation_key, ledger_append, ledger_drop,
+                             ledger_finalize, ledger_has)
+from ..subjects import (caps_of, chart_projection_lock, load_subject,
+                        locked_subject_write, parse_decision_id,
+                        projection_gate, subject_collision,
+                        subject_marker_token)
+from ..types import ErrorClass, TrackerError
+from .helpers import (collect_degraded, locator_of,
+                      write_aggregate_receipt)
+from .steps import fail_result, ok_result
+
+# Lifecycle events projected from chart transitions (receipt event tokens).
+CHART_EVENTS = frozenset({
+    "chart.create",
+    "chart.wire",
+    "chart.claim",
+    "chart.release",
+    "chart.resolve",
+    "chart.supersede",
+    "chart.outOfScope",
+    "chart.attachAsset",
+    "chart.briefing",
+    "chart.abandon",
+    "chart.reopen",
+    "chart.staleLink",
+})
+
+CHART_ROLLUP_OPEN = "<!-- flow-next:chart-rollup -->"
+CHART_ROLLUP_CLOSE = "<!-- /flow-next:chart-rollup -->"
+DECISION_BLOCK_OPEN = "<!-- flow-next:decision -->"
+DECISION_BLOCK_CLOSE = "<!-- /flow-next:decision -->"
+
+# URL host allowlists keyed by provider (normalized lowercase host).
+_DEFAULT_HOSTS = {
+    "github": ("github.com",),
+    "gitlab": ("gitlab.com",),
+    "linear": ("linear.app",),
+    "jira": (),  # host comes from perTracker.baseUrl
+}
+
+
+#: Bounded holder-drain passes per project_chart call: how many times the lock
+#: holder re-projects state that other chart commands committed while it was
+#: mid-remote-span (see project_chart's drain loop).
+_PROJECTION_DRAIN_LIMIT = 3
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _event_marker_key(event: str, revision: str, evidence: str) -> str:
+    return _sha(f"{event}\x00{revision}\x00{evidence}")[:16]
+
+
+def _parked_keys(chart: dict) -> list[str]:
+    """Stable identity of the chart's parked-question set."""
+    return sorted(
+        str(q.get("key") or q.get("body") or "")
+        for q in (chart.get("parked_questions") or [])
+        if isinstance(q, dict)
+    )
+
+
+def _chart_lifecycle_entry(chart: dict) -> dict:
+    """Chart-only transition identity (status, briefings, abandon/reopen).
+
+    abandon/reopen/final-briefing mutate ONLY the chart sidecar - no
+    decision sidecar and no parked key changes - so neither a supplied
+    chart_decision_revision nor the decision digest distinguishes the
+    state before and after such a commit. Without these fields the drain
+    pass recomputes the first pass's marker key and dedupes, leaving the
+    parent status stale. The success-marker write never touches any of
+    these fields, so identical-retry dedupe holds.
+    """
+    return {
+        "status": chart.get("status"),
+        "abandoned_at": chart.get("abandoned_at"),
+        "reopened_at": chart.get("reopened_at"),
+        "briefings": sorted(
+            (str(b.get("id") or ""), str(b.get("status") or ""))
+            for b in (chart.get("briefings") or [])
+            if isinstance(b, dict)
+        ),
+    }
+
+
+def _mutation_state_digest(chart: dict, decisions: list) -> str:
+    """Projection-side marker digest: claim/asset state + mutation identity.
+
+    The supplied chart revision (chart_decision_revision, the briefing-
+    fingerprint base - never change that hash) is content-based: a chart
+    wired back to a prior graph state (D1 blocked_by D2 -> D3 -> D2) reuses
+    the first event's revision, and claims/assets/timestamps are omitted
+    entirely. Fold in each decision sidecar's updated_at (every committed
+    chart mutation stamps it) so a returned-to-prior state still mints a
+    distinct marker, while a pure retry of the same committed mutation
+    (same sidecar bytes) still dedupes. The chart's own updated_at is
+    deliberately excluded: the success-marker write bumps it, which would
+    break retry dedupe.
+
+    Parked-question keys fold in for the same reason: park-question /
+    remove-question mutate ONLY the chart sidecar (no decision status or
+    digest changes), yet the parent rollup's parked count depends on them.
+    The marker write never touches parked state, so retry dedupe holds.
+
+    Chart-only lifecycle transitions (abandon/reopen/final-briefing) fold
+    in via _chart_lifecycle_entry for the same reason again.
+    """
+    return _sha(json.dumps({
+        "decisions": _digest_entries(decisions),
+        "parked": _parked_keys(chart),
+        "chart": _chart_lifecycle_entry(chart),
+    }, sort_keys=True, default=str))
+
+
+def _digest_entries(decisions: list) -> list[dict]:
+    """Per-decision mutation-identity entries backing _mutation_state_digest."""
+    return sorted(
+        (
+            {
+                "id": d.get("id"),
+                "updated_at": d.get("updated_at"),
+                "claimed_by": d.get("claimed_by"),
+                "claimed_at": d.get("claimed_at"),
+                "assets": _safe_assets(d.get("assets")),
+            }
+            for d in decisions if isinstance(d, dict)
+        ),
+        key=lambda x: str(x.get("id") or ""),
+    )
+
+
+def _chart_base_revision(chart: dict, decisions: list) -> str:
+    """Fallback marker base when the caller supplied no revision."""
+    return _sha(json.dumps({
+        "id": chart.get("id"),
+        "status": chart.get("status"),
+        "decisions": [
+            {"id": d.get("id"), "status": d.get("status")}
+            for d in decisions if isinstance(d, dict)
+        ],
+        # Parked-only mutations (park-question / remove-question) change no
+        # decision status or digest; without the parked set here the drain's
+        # foreign-change predicate never fires and the parent rollup keeps a
+        # stale parked count until an unrelated event.
+        "parked": _parked_keys(chart),
+        # Same for chart-only lifecycle transitions (abandon/reopen/
+        # final-briefing): they must trip the foreign-change predicate so
+        # the holder drains them before releasing the lock.
+        "lifecycle": _chart_lifecycle_entry(chart),
+    }, sort_keys=True, default=str))
+
+
+def _projection_state(tracker: dict) -> dict:
+    raw = dict_(tracker.get("projection"))
+    markers = raw.get("event_markers")
+    if not isinstance(markers, list):
+        markers = []
+    return {
+        "revision": raw.get("revision"),
+        "event_markers": list(markers),
+        "completed_steps": list(raw.get("completed_steps") or []),
+        "degraded": raw.get("degraded"),
+    }
+
+
+def _find_event_marker(tracker: dict, key: str) -> Optional[dict]:
+    for entry in _projection_state(tracker).get("event_markers") or []:
+        if isinstance(entry, dict) and entry.get("key") == key:
+            return entry
+    return None
+
+
+def _has_event_marker(tracker: dict, key: str) -> bool:
+    return _find_event_marker(tracker, key) is not None
+
+
+def _has_event_receipt(flow_dir: Path, chart_id: str, event: str,
+                       revision: str) -> bool:
+    """True when a sync receipt already records this event+revision.
+
+    Success receipts (and the repair receipt written on the marker-dedupe
+    path) carry details.revision, so repair itself is idempotent. Fails
+    open (False) on unreadable state: an extra repair receipt is harmless;
+    a permanently missing one is not.
+    """
+    token_fname = subject_marker_token("chart", chart_id).replace(":", "-")
+    runs = Path(flow_dir) / "sync-runs"
+    try:
+        paths = list(runs.glob(f"sync-{token_fname}-*.json"))
+    except OSError:
+        return False
+    for p in paths:
+        try:
+            obj = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(obj, dict) or obj.get("event") != event:
+            continue
+        details = obj.get("details")
+        if isinstance(details, dict) and details.get("revision") == revision:
+            return True
+    return False
+
+
+def _append_event_marker(
+    tracker: dict,
+    *,
+    event: str,
+    revision: str,
+    evidence: str,
+    completed_steps: list,
+    status: str,
+) -> dict:
+    key = _event_marker_key(event, revision, evidence)
+    if _has_event_marker(tracker, key):
+        return tracker
+    state = _projection_state(tracker)
+    markers = list(state["event_markers"])
+    markers.append({
+        "key": key,
+        "event": event,
+        "revision": revision,
+        "evidence": evidence,
+        "completed_steps": list(completed_steps),
+        "status": status,
+        "at": now_iso(),
+    })
+    tracker = dict(tracker)
+    tracker["projection"] = {
+        "revision": revision,
+        "event_markers": markers,
+        "completed_steps": list(completed_steps),
+        "degraded": state.get("degraded"),
+    }
+    return tracker
+
+
+def _safe_gist(answer: Any, *, max_len: int = 240) -> str:
+    """One-line safe gist; never copy credentials or destructive command strings."""
+    if answer is None:
+        return ""
+    if isinstance(answer, dict):
+        text = str(answer.get("gist") or answer.get("summary") or answer.get("body") or "")
+    else:
+        text = str(answer)
+    text = " ".join(text.split())
+    # Redact obvious secrets / guard-triggering patterns by reference only.
+    lowered = text.lower()
+    if any(
+        tok in lowered
+        for tok in (
+            "password=",
+            "api_key=",
+            "secret=",
+            "authorization:",
+            "rm -rf",
+            "curl | sh",
+        )
+    ):
+        return "[redacted - see local decision record]"
+    if len(text) > max_len:
+        return text[: max_len - 1] + "..."
+    return text
+
+
+def _safe_assets(assets: Any) -> list[dict]:
+    out = []
+    if not isinstance(assets, list):
+        return out
+    for a in assets:
+        if not isinstance(a, dict):
+            continue
+        kind = a.get("kind")
+        ref = a.get("reference") or a.get("path") or a.get("url")
+        summary = a.get("summary") or a.get("display") or ""
+        if not ref:
+            continue
+        ref_s = str(ref)
+        if any(x in ref_s.lower() for x in ("password=", "token=", "secret=")):
+            continue
+        out.append({
+            "kind": kind,
+            "reference": ref_s,
+            "summary": _safe_gist(summary, max_len=120),
+        })
+    return out
+
+
+def build_decision_body(decision: dict) -> str:
+    """Owned body block for a decision child issue."""
+    did = decision.get("id") or ""
+    title = decision.get("title") or ""
+    dtype = decision.get("type") or ""
+    attendance = decision.get("attendance") or ""
+    status = decision.get("status") or "open"
+    gist = _safe_gist(decision.get("answer"))
+    assets = _safe_assets(decision.get("assets"))
+    lines = [
+        DECISION_BLOCK_OPEN,
+        f"**Decision:** {did} - {title}",
+        f"**Type:** {dtype}",
+        f"**Attendance:** {attendance}",
+        f"**Local status:** {status}",
+    ]
+    if decision.get("claimed_by"):
+        lines.append(f"**Claimed by:** {decision.get('claimed_by')} (local claim; not provider workflow)")
+    if gist:
+        lines.append(f"**Gist:** {gist}")
+    if assets:
+        lines.append("**Evidence:**")
+        for a in assets:
+            lines.append(f"- [{a.get('kind') or 'ref'}] {a['reference']}"
+                         + (f" - {a['summary']}" if a.get("summary") else ""))
+    blocked = decision.get("blocked_by") or []
+    if blocked:
+        lines.append(f"**Blocked by (local):** {', '.join(str(x) for x in blocked)}")
+    # depends_on stays local provenance - never projected as blocking edge.
+    depends = decision.get("depends_on") or []
+    if depends:
+        lines.append(
+            f"**Depends on (local provenance only; not a blocking edge):** "
+            f"{', '.join(str(x) for x in depends)}"
+        )
+    lines.append(DECISION_BLOCK_CLOSE)
+    return "\n".join(lines) + "\n"
+
+
+def _count_decisions(chart: dict, decisions: list[dict]) -> dict:
+    status_index = {
+        d["id"]: d.get("status")
+        for d in decisions
+        if isinstance(d, dict) and d.get("id")
+    }
+    open_decs = [d for d in decisions if isinstance(d, dict) and d.get("status") == "open"]
+
+    def is_blocked(d: dict) -> bool:
+        for b in d.get("blocked_by") or []:
+            st = status_index.get(b)
+            if st is None or st == "open":
+                return True
+        return False
+
+    blocked = [d for d in open_decs if is_blocked(d)]
+    claimed = [d for d in open_decs if d.get("claimed_by")]
+    actionable = [d for d in open_decs if not is_blocked(d) and not d.get("claimed_by")]
+    resolved = [d for d in decisions if isinstance(d, dict) and d.get("status") == "resolved"]
+    superseded = [d for d in decisions if isinstance(d, dict) and d.get("status") == "superseded"]
+    oos = [d for d in decisions if isinstance(d, dict) and d.get("status") == "out-of-scope"]
+    parked = chart.get("parked_questions") or []
+    if not isinstance(parked, list):
+        parked = []
+    return {
+        "actionable": len(actionable),
+        "blocked": len(blocked),
+        "claimed": len(claimed),
+        "resolved": len(resolved),
+        "superseded": len(superseded),
+        "out_of_scope": len(oos),
+        "parked": len(parked),
+        "frontier": [
+            {"id": d.get("id"), "title": d.get("title")}
+            for d in actionable
+        ],
+        "latest_resolved": None,
+    }
+
+
+def build_parent_rollup(chart: dict, decisions: list[dict]) -> str:
+    counts = _count_decisions(chart, decisions)
+    resolved = [
+        d for d in decisions
+        if isinstance(d, dict) and d.get("status") == "resolved"
+    ]
+    latest = None
+    if resolved:
+        # Prefer updated_at / created order; fall back to id order.
+        def sort_key(d: dict) -> str:
+            return str(d.get("updated_at") or d.get("created") or d.get("id") or "")
+
+        latest = max(resolved, key=sort_key)
+        counts["latest_resolved"] = {
+            "id": latest.get("id"),
+            "title": latest.get("title"),
+            "gist": _safe_gist(latest.get("answer")),
+        }
+    lines = [
+        CHART_ROLLUP_OPEN,
+        f"**Chart:** {chart.get('id')} - {chart.get('title')}",
+        f"**Outcome:** {chart.get('outcome') or ''}",
+        f"**Status:** {chart.get('status') or 'open'}",
+        (
+            f"**Counts:** actionable={counts['actionable']} "
+            f"blocked={counts['blocked']} claimed={counts['claimed']} "
+            f"resolved={counts['resolved']} superseded={counts['superseded']} "
+            f"out-of-scope={counts['out_of_scope']} parked={counts['parked']}"
+        ),
+    ]
+    lr = counts.get("latest_resolved")
+    if lr:
+        lines.append(
+            f"**Latest resolved:** {lr['id']} - {lr['title']}"
+            + (f" - {lr['gist']}" if lr.get("gist") else "")
+        )
+    frontier = counts.get("frontier") or []
+    if frontier:
+        lines.append("**Frontier:**")
+        for f in frontier:
+            lines.append(f"- {f.get('id')} - {f.get('title')}")
+    else:
+        lines.append("**Frontier:** (empty)")
+    lines.append(CHART_ROLLUP_CLOSE)
+    return "\n".join(lines) + "\n"
+
+
+def _upsert_owned_block(body: str, open_m: str, close_m: str, content: str) -> str:
+    body = body or ""
+    if open_m in body and close_m in body:
+        start = body.index(open_m)
+        end = body.index(close_m) + len(close_m)
+        return body[:start] + content.rstrip("\n") + body[end:]
+    if body and not body.endswith("\n"):
+        body += "\n"
+    return body + content
+
+
+def _load_chart_bundle(flow_dir: Path, chart_id: str) -> Result:
+    loaded = load_subject(flow_dir, "chart", chart_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    path, chart, tracker = loaded
+    decisions: list[dict] = []
+    for entry in chart.get("decisions") or []:
+        if not isinstance(entry, dict) or not entry.get("id"):
+            continue
+        did = entry["id"]
+        dloaded = load_subject(flow_dir, "decision", did)
+        if isinstance(dloaded, TrackerError):
+            # Compact entry only if full sidecar missing.
+            decisions.append(dict(entry))
+            continue
+        _dp, ddata, _dt = dloaded
+        # Merge compact claim fields if sidecar lags.
+        for k in ("claimed_by", "claimed_at", "status", "title", "type", "attendance"):
+            if entry.get(k) is not None and ddata.get(k) is None:
+                ddata[k] = entry.get(k)
+        decisions.append(ddata)
+    return path, chart, tracker, decisions
+
+
+def _link_fields(created: dict) -> dict:
+    return {
+        "id": created["id"],
+        "identifier": created.get("identifier"),
+        "url": created.get("url"),
+        "linkState": "linked",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Created-but-unlinked identity recovery (create-first home, verbs.py pattern):
+# a remote create that lands but whose local link write fails must leave a
+# durable, reconcileable identity - otherwise the next projection re-creates
+# a duplicate remote issue.
+# ---------------------------------------------------------------------------
+
+def _pending_identity_path(flow_dir: Path, kind: str, subject_id: str) -> Path:
+    return Path(flow_dir) / "create-first" / f"chart-{kind}-{subject_id}.json"
+
+
+def _record_pending_identity(flow_dir: Path, kind: str, subject_id: str,
+                             fields: dict) -> Optional[TrackerError]:
+    """Durable identity record, ONE retry on write failure.
+
+    Returns the write error when the record could not be persisted; the
+    caller then decides whether the failure receipt still covers recovery
+    (see _receipt_identity_fields) or must refuse retryably-unsafe state."""
+    path = _pending_identity_path(flow_dir, kind, subject_id)
+    payload = {
+        "kind": kind,
+        "subjectId": subject_id,
+        "id": fields.get("id"),
+        "identifier": fields.get("identifier"),
+        "url": fields.get("url"),
+        "recordedAt": now_iso(),
+    }
+    err = atomic_write_json(path, payload)
+    if err is not None:
+        err = atomic_write_json(path, payload)
+    return err
+
+
+def _clear_pending_identity(flow_dir: Path, kind: str, subject_id: str) -> None:
+    with contextlib.suppress(OSError):
+        _pending_identity_path(flow_dir, kind, subject_id).unlink()
+
+
+def _tombstone_pending_identity(flow_dir: Path, kind: str,
+                                subject_id: str) -> None:
+    """Retire a recorded identity after a durable collision.
+
+    An EXISTING pending file with a null id suppresses BOTH adoption
+    sources (file and receipt fallback), so the next projection creates
+    fresh instead of re-adopting the collided identity from an immutable
+    failure receipt forever. Best-effort: an unwritable tombstone means the
+    next projection collides loudly again - never silently duplicates."""
+    atomic_write_json(_pending_identity_path(flow_dir, kind, subject_id), {
+        "kind": kind,
+        "subjectId": subject_id,
+        "id": None,
+        "reason": "durable_collision",
+        "supersededAt": now_iso(),
+    })
+
+
+def _receipt_identity_fields(flow_dir: Path, kind: str,
+                             subject_id: str) -> Optional[dict]:
+    """Failure-receipt fallback when no pending-identity file exists.
+
+    The create-ok/link-fail receipt carries the created identity in its
+    details (id/identifier/url plus the create-*-remote step). Only the
+    LATEST receipt for the chart token is consulted: every later projection
+    - success or a different failure - writes a newer receipt without that
+    step, so a stale identity is never adopted after the subject moved on
+    (e.g. a deliberate unlink)."""
+    chart_id = subject_id if kind == "chart" else subject_id.rsplit(".D", 1)[0]
+    token_fname = subject_marker_token("chart", chart_id).replace(":", "-")
+    runs = Path(flow_dir) / "sync-runs"
+    try:
+        paths = list(runs.glob(f"sync-{token_fname}-*.json"))
+    except OSError:
+        return None
+    latest: Optional[dict] = None
+    latest_key = ("", "")
+    for p in sorted(paths):
+        try:
+            obj = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        key = (str(obj.get("timestamp") or ""), p.name)
+        if key >= latest_key:
+            latest_key = key
+            latest = obj
+    if latest is None:
+        return None
+    details = latest.get("details")
+    if not isinstance(details, dict):
+        return None
+    step = ("create-parent-remote" if kind == "chart"
+            else f"create-child-remote:{subject_id}")
+    if step not in (details.get("completed_steps") or []):
+        return None
+    rid = details.get("id")
+    if not isinstance(rid, str) or not rid.strip():
+        return None
+    return {
+        "id": rid,
+        "identifier": details.get("identifier"),
+        "url": details.get("url"),
+        "linkState": "linked",
+    }
+
+
+def _pending_identity_fields(flow_dir: Path, kind: str,
+                             subject_id: str) -> Optional[dict]:
+    path = _pending_identity_path(flow_dir, kind, subject_id)
+    if path.exists():
+        try:
+            obj = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+        rid = obj.get("id")
+        if not isinstance(rid, str) or not rid.strip():
+            # Tombstone (durable-collision supersession): suppress the
+            # receipt fallback too - the next projection creates fresh.
+            return None
+        return {
+            "id": rid,
+            "identifier": obj.get("identifier"),
+            "url": obj.get("url"),
+            "linkState": "linked",
+        }
+    # No pending file at all (its write may itself have failed): fall back
+    # to the last failure receipt's recorded created identity.
+    return _receipt_identity_fields(flow_dir, kind, subject_id)
+
+
+def _link_subject(flow_dir: Path, kind: str, subject_id: str, mutate, *,
+                  collision_id: str) -> Result:
+    """Link write with ONE transient-failure retry: the write contends with
+    chart WAL/config locks, so a lock timeout is often momentary."""
+    linked = locked_subject_write(
+        flow_dir, kind, subject_id, mutate, collision_id=collision_id,
+    )
+    if isinstance(linked, TrackerError):
+        linked = locked_subject_write(
+            flow_dir, kind, subject_id, mutate, collision_id=collision_id,
+        )
+    return linked
+
+
+def _identity_error(err: TrackerError, fields: dict) -> TrackerError:
+    """Ride the created identity into the error details (verbs.py pattern)."""
+    return dataclasses.replace(err, details={
+        **(err.details or {}),
+        "id": fields.get("id"),
+        "identifier": fields.get("identifier"),
+        "url": fields.get("url"),
+    })
+
+
+def _refuse_unpersisted_identity(err: TrackerError, *, kind: str,
+                                 subject_id: str, fields: dict,
+                                 pend_err: Optional[TrackerError]
+                                 ) -> TrackerError:
+    """Escalate when NOTHING durable names a created remote issue.
+
+    The pending-identity write failed (twice) AND the failure receipt could
+    not be written (fail_result marked receipt_status "unwritten"): a retry
+    would see an unlinked subject and create a duplicate. Refuse retry;
+    the identity rides the error message and details as the last copy."""
+    if pend_err is None:
+        return err
+    if (err.details or {}).get("receipt_status") != "unwritten":
+        return err
+    ident = fields.get("identifier") or fields.get("id")
+    return dataclasses.replace(
+        err,
+        subtype="created_identity_unpersisted",
+        auto_retryable=False,
+        message=(
+            f"remote issue {ident} was created for {kind} {subject_id} but "
+            "neither the local link, the pending-identity record, nor the "
+            "failure receipt could be written; link it manually "
+            f"({fields.get('url') or ident}) before retrying - a blind "
+            "retry would create a duplicate"
+        ),
+        details={
+            **(err.details or {}),
+            "pending_write_failed": {
+                "class": pend_err.cls.value,
+                "subtype": pend_err.subtype,
+                "message": pend_err.message,
+            },
+        },
+    )
+
+
+def _create_issue(
+    config: dict,
+    execute: Execute,
+    *,
+    title: str,
+    body: str,
+) -> Result:
+    return provider_create(config, execute, title=title, body=body)
+
+
+def _wire_read(
+    config: dict,
+    execute: Execute,
+    locator: dict,
+) -> Result:
+    from ..wire import dispatch as wire_dispatch  # noqa: PLC0415
+
+    return wire_dispatch("read", config, locator=locator, execute=execute)
+
+
+def _wire_update(
+    config: dict,
+    execute: Execute,
+    locator: dict,
+    *,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+) -> Result:
+    from ..wire import dispatch as wire_dispatch  # noqa: PLC0415
+
+    return wire_dispatch(
+        "update", config, locator=locator, title=title, body=body,
+        execute=execute,
+    )
+
+
+def _project_hierarchy(
+    config: dict,
+    execute: Execute,
+    *,
+    parent_loc: dict,
+    child_loc: dict,
+    caps: dict,
+) -> Result:
+    """Parent/child hierarchy where subIssues is supported; else degraded flat.
+
+    GitHub: chart parent + decision child via sub_issues (hierarchy, not
+    blocked-by). Linear/GitLab/Jira: no subIssues we consume - labelled/linked
+    flat issues with explicit degradation.
+    """
+    if not caps.get("subIssues"):
+        return {
+            "projected": False,
+            "degraded": {
+                "capability": "subIssues",
+                "form": "flat_linked",
+                "note": (
+                    "provider has no native parent/child hierarchy; "
+                    "chart parent and decision children remain labelled/linked flat issues"
+                ),
+            },
+        }
+    provider = tracker_type(config)
+    if provider != "github":
+        return {
+            "projected": False,
+            "degraded": {
+                "capability": "subIssues",
+                "form": "flat_linked",
+                "note": f"{provider} hierarchy not implemented; flat linked issues",
+            },
+        }
+    from ..relate.providers import github_set  # noqa: PLC0415
+
+    # github_set treats to=parent (blocker in dep terms) and from=child.
+    # For chart hierarchy we want chart=parent, decision=child.
+    out = github_set(
+        config,
+        execute,
+        from_id=str(child_loc["durable"]),
+        to_id=str(parent_loc["durable"]),
+        from_display=str(child_loc["display"]),
+        to_display=str(parent_loc["display"]),
+    )
+    if isinstance(out, TrackerError):
+        return out
+    # Hierarchy form is intentional for chart parent/child - strip the
+    # blocked-by degradation note github_set attaches for dep projection.
+    if isinstance(out, dict):
+        out = dict(out)
+        out["form"] = "sub_issues"
+        out["kind"] = "hierarchy"
+        out.pop("degraded", None)
+    return out
+
+
+def _hierarchy_marker_key(parent_loc: dict, child_loc: dict) -> str:
+    """Durable per-child hierarchy-step key on the decision's relation ledger."""
+    return "hier:" + dep_relation_key(
+        str(child_loc["durable"]), str(parent_loc["durable"]),
+    )
+
+
+def _ensure_hierarchy(
+    flow_dir: Path,
+    config: dict,
+    execute: Execute,
+    *,
+    chart_id: str,
+    did: str,
+    dtracker: dict,
+    parent_loc: dict,
+    child_loc: dict,
+    caps: dict,
+) -> Result:
+    """Idempotently assert parent/child hierarchy for a linked child.
+
+    A ledger marker records completion, so a create-ok/hierarchy-fail retry
+    re-attempts hierarchy for already-linked children instead of silently
+    taking the body-update-only branch and orphaning the child.
+    """
+    key = _hierarchy_marker_key(parent_loc, child_loc)
+    if ledger_has(dtracker, key):
+        return {"projected": True, "already": True, "form": "sub_issues"}
+    hier = _project_hierarchy(
+        config, execute, parent_loc=parent_loc, child_loc=child_loc, caps=caps,
+    )
+    if isinstance(hier, dict) and hier.get("projected"):
+        def _mark_hier(t: dict, _key=key):
+            t = ledger_append(
+                t, key=_key, dep_spec=chart_id,
+                from_tracker_id=str(child_loc["durable"]),
+                to_tracker_id=str(parent_loc["durable"]),
+                rel_type="hierarchy", source="flow",
+            )
+            return ledger_finalize(t, key=_key)
+
+        # Marker write failure is non-fatal: hierarchy is idempotent and the
+        # unmarked step is simply re-asserted on the next projection.
+        locked_subject_write(flow_dir, "decision", did, _mark_hier)
+    return hier
+
+
+def _project_blocking(
+    config: dict,
+    execute: Execute,
+    *,
+    from_loc: dict,
+    to_loc: dict,
+    caps: dict,
+    dep_subject: str,
+) -> Result:
+    """Project blocked_by only. depends_on is NEVER an indistinguishable block."""
+    provider = tracker_type(config)
+    if provider == "github" or not caps.get("blockedBy"):
+        return {
+            "projected": False,
+            "degraded": {
+                "capability": "blockedBy",
+                "form": "local_provenance",
+                "note": (
+                    "native blocking unsupported or github hierarchy-only; "
+                    "blocked_by kept as local provenance and owned body text only"
+                ),
+            },
+        }
+    from ..relate import providers as RP  # noqa: PLC0415
+
+    from_id = str(from_loc["durable"])
+    to_id = str(to_loc["durable"])
+    from_display = str(from_loc["display"])
+    to_display = str(to_loc["display"])
+
+    if provider == "linear":
+        present = RP.linear_probe(config, execute, from_id=from_id, to_id=to_id)
+        if isinstance(present, TrackerError):
+            return present
+        if present is True:
+            return {"projected": True, "already": True, "form": "blocks"}
+        return RP.linear_set(
+            config, execute,
+            from_id=from_id, to_id=to_id,
+            from_display=from_display, to_display=to_display,
+        )
+    if provider == "jira":
+        present = RP.jira_probe(config, execute, from_id=from_id, to_id=to_id)
+        if isinstance(present, TrackerError):
+            return present
+        if present is True:
+            return {"projected": True, "already": True, "form": "blocks"}
+        return RP.jira_set(
+            config, execute,
+            from_id=from_id, to_id=to_id,
+            from_display=from_display, to_display=to_display,
+        )
+    if provider == "gitlab":
+        # Probe first (linear/jira parity): a ledger-write-failure retry
+        # re-asserts an edge the previous run already created, and GitLab's
+        # link create is not idempotent (409 on duplicates).
+        present = RP.gitlab_probe_pair(
+            config, execute,
+            from_display=from_display, to_display=to_display,
+        )
+        if isinstance(present, TrackerError):
+            return present
+        if present is True:
+            return {"projected": True, "already": True, "form": "blocks"}
+        return RP.gitlab_set(
+            config, execute,
+            from_id=from_id, to_id=to_id,
+            from_display=from_display, to_display=to_display,
+            blocked_by=True, plan=None,
+        )
+    return {
+        "projected": False,
+        "degraded": {
+            "capability": "blockedBy",
+            "form": "local_provenance",
+            "note": f"unknown provider {provider!r} for blocking projection",
+        },
+    }
+
+
+def _remove_blocking(
+    config: dict,
+    execute: Execute,
+    *,
+    from_loc: dict,
+    to_id: str,
+    caps: dict,
+) -> Result:
+    """Remove one stale flow-owned native blocks edge (from was blocked by to).
+
+    GitHub never projects native blocking (local provenance only), so there is
+    nothing remote to remove - the ledger entry alone is stale. Providers
+    without removal support report explicit degradation and KEEP the ledger
+    entry (dropping it would silently disown a live stale relation).
+    """
+    provider = tracker_type(config)
+    if provider == "github":
+        return {"removed": False, "already_absent": True}
+    from ..relate import providers as RP  # noqa: PLC0415
+
+    from_id = str(from_loc["durable"])
+    if caps.get("blockedBy"):
+        if provider == "linear":
+            return RP.linear_remove(config, execute, from_id=from_id,
+                                    to_id=to_id)
+        if provider == "jira":
+            return RP.jira_remove(config, execute, from_id=from_id,
+                                  to_id=to_id)
+        if provider == "gitlab":
+            return RP.gitlab_remove(
+                config, execute, from_id=from_id,
+                from_display=str(from_loc["display"]), to_id=to_id,
+            )
+    return {
+        "removed": False,
+        "degraded": {
+            "capability": "blockedBy",
+            "form": "stale_native_relation",
+            "note": (
+                f"{provider!r} native blocking removal unavailable; "
+                "stale flow-owned relation remains remotely"
+            ),
+        },
+    }
+
+
+def _decision_title(decision: dict) -> str:
+    did = decision.get("id") or ""
+    title = decision.get("title") or did
+    return f"{did}: {title}"[:200]
+
+
+def _chart_title(chart: dict) -> str:
+    cid = chart.get("id") or ""
+    title = chart.get("title") or cid
+    return f"[chart] {cid}: {title}"[:200]
+
+
+def project_chart(
+    flow_dir: Path,
+    chart_id: str,
+    *,
+    event: str,
+    revision: Optional[str] = None,
+    evidence: Optional[str] = None,
+    execute: Execute = default_execute,
+) -> Result:
+    """Project one chart lifecycle event. Local state already committed.
+
+    The whole remote read/update span runs under a dedicated cross-process
+    projection lock (chart_projection_lock - NOT the chart WAL lock, which
+    local mutations must never wait on across network latency). Chart +
+    decision state is reloaded INSIDE the lock, so two overlapping chart
+    commands cannot interleave a stale projection over a newer one: the
+    later entrant re-projects the newest committed state (convergent).
+    Best-effort: lock timeout is a CONFLICT/lock_timeout TrackerError; it
+    never blocks or fails the local mutation result.
+
+    Returns a data dict (success/skip/partial) or TrackerError with completed_steps.
+    Never raises. Never rolls back local chart files.
+    """
+    flow_dir = Path(flow_dir)
+    config = read_config(flow_dir)
+    gate = projection_gate(config)
+    if not gate["active"]:
+        return {
+            "projected": False,
+            "skipped": gate["skipped"],
+            "reason": gate["reason"],
+            "chart_id": chart_id,
+            "event": event,
+            "completed_steps": [],
+        }
+
+    if event not in CHART_EVENTS and not event.startswith("chart."):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"unknown chart projection event {event!r}",
+            subtype="event",
+        )
+
+    from ..config_lock import ConfigLockTimeout  # noqa: PLC0415
+
+    try:
+        with chart_projection_lock(flow_dir):
+            result: Result = {}
+            for _ in range(_PROJECTION_DRAIN_LIMIT):
+                result = _project_chart_locked(
+                    flow_dir, config, gate, chart_id,
+                    event=event, revision=revision, evidence=evidence,
+                    execute=execute,
+                )
+                if not (isinstance(result, dict)
+                        and result.get("stale_revision")):
+                    return result
+                # Holder drain: a chart mutation committed locally while this
+                # holder was mid-remote-span (the mutation's own projection
+                # attempt may have timed out on this very lock). Re-project
+                # the newer persisted state before releasing the lock - the
+                # marker was keyed on the state actually pushed, so the
+                # re-entry projects instead of deduping. This is what keeps
+                # contended projections convergent even when a waiter gives
+                # up: whatever it committed, the holder drains it here.
+            # Drains exhausted under sustained mutation pressure: return the
+            # last successful projection, naming the remaining unprojected
+            # revision (stale_revision) so the caller can see the tracker is
+            # one step behind; the next projection event picks it up.
+            result = dict(result)
+            result["drain_exhausted"] = True
+            return result
+    except ConfigLockTimeout as exc:
+        return TrackerError(
+            ErrorClass.CONFLICT, str(exc), subtype="lock_timeout",
+            details={"completed_steps": []},
+        )
+
+
+def _project_chart_locked(
+    flow_dir: Path,
+    config: dict,
+    gate: dict,
+    chart_id: str,
+    *,
+    event: str,
+    revision: Optional[str],
+    evidence: Optional[str],
+    execute: Execute,
+) -> Result:
+    """project_chart body; caller holds chart_projection_lock."""
+    bundle = _load_chart_bundle(flow_dir, chart_id)
+    if isinstance(bundle, TrackerError):
+        return bundle
+    chart_path, chart, chart_tracker, decisions = bundle
+    supplied_revision = revision
+    start_skeleton = _chart_base_revision(chart, decisions)
+    base_revision = revision or start_skeleton
+    # Extend the marker revision with the projection-side state digest
+    # (claims, assets, per-decision mutation identity - see
+    # _mutation_state_digest for why the base revision alone dedupes wrongly).
+    revision = _sha(
+        f"{base_revision}\x00{_mutation_state_digest(chart, decisions)}"
+    )
+    evidence_supplied = evidence is not None
+    evidence = evidence or revision[:16]
+    marker_key = _event_marker_key(event, revision, evidence)
+
+    marker = _find_event_marker(chart_tracker, marker_key)
+    if marker is not None:
+        deduped: dict[str, Any] = {
+            "projected": True,
+            "deduped": True,
+            "chart_id": chart_id,
+            "event": event,
+            "revision": revision,
+            "completed_steps": list(
+                _projection_state(chart_tracker).get("completed_steps") or []
+            ),
+            "tracker_id": chart_tracker.get("id"),
+        }
+        # Receipt repair: the success marker persists BEFORE the aggregate
+        # receipt, so a receipt write that failed after the marker landed
+        # would otherwise never be retried - every retry exits here. Write
+        # the missing receipt from the marker's recorded outcome; idempotent
+        # because the repair receipt carries details.revision, which the
+        # next dedupe finds. A failed repair write leaves the state as-is
+        # for the next retry to converge.
+        if not _has_event_receipt(flow_dir, chart_id, event, revision):
+            rerr = write_aggregate_receipt(
+                flow_dir,
+                spec_id=subject_marker_token("chart", chart_id),
+                event=event,
+                status=str(marker.get("status") or "pushed"),
+                tracker_id=chart_tracker.get("id"),
+                transport=gate["provider"],
+                note="chart projection receipt repaired on marker dedupe",
+                details={
+                    "revision": revision,
+                    "evidence": marker.get("evidence") or evidence,
+                    "repaired": True,
+                },
+            )
+            if rerr is None:
+                deduped["receipt_repaired"] = True
+        return deduped
+
+    provider = gate["provider"]
+    caps = caps_of(config)
+    completed: list = []
+    statuses: list = []
+    degraded_parts: list = []
+    steps: dict[str, Any] = {}
+    # Decision ids whose sidecar THIS holder wrote (link adoption, hierarchy
+    # marker, relation ledger). The end-of-pass marker recompute absorbs only
+    # these self-inflicted updated_at bumps; any other digest change is a
+    # foreign mutation the drain loop must re-project.
+    self_wrote: set[str] = set()
+
+    parent_body = build_parent_rollup(chart, decisions)
+    parent_title = _chart_title(chart)
+
+    # --- parent create-if-unlinked ---
+    parent_state = chart_tracker.get("linkState") or (
+        "linked" if chart_tracker.get("id") else "unlinked"
+    )
+    if parent_state == "unlinked" or not chart_tracker.get("id"):
+        # A prior run may have created the remote issue and failed only the
+        # local link write - adopt that identity instead of re-creating.
+        adopted = _pending_identity_fields(flow_dir, "chart", chart_id)
+        if adopted is not None:
+            fields = adopted
+        else:
+            created = _create_issue(
+                config, execute, title=parent_title, body=parent_body,
+            )
+            if isinstance(created, TrackerError):
+                # Persist nothing remote; still write partial receipt intent
+                # locally only if something already completed (nothing yet).
+                return created
+            fields = _link_fields(created)
+
+        def _link_parent(t: dict):
+            hit = subject_collision(
+                flow_dir, fields["id"], except_kind="chart", except_id=chart_id,
+            )
+            if hit:
+                return hit
+            t = dict(t)
+            t.update(fields)
+            return t
+
+        linked = _link_subject(
+            flow_dir, "chart", chart_id, _link_parent, collision_id=fields["id"],
+        )
+        if isinstance(linked, TrackerError):
+            pend_err: Optional[TrackerError] = None
+            if adopted is not None and linked.subtype == "durable_collision":
+                # The recorded identity now belongs to another subject; a
+                # tombstone (not a bare clear) retires receipt evidence
+                # too, so the next projection creates fresh.
+                _tombstone_pending_identity(flow_dir, "chart", chart_id)
+            else:
+                # Remote create succeeded; persist the identity durably so
+                # the NEXT projection adopts it instead of duplicating.
+                pend_err = _record_pending_identity(
+                    flow_dir, "chart", chart_id, fields,
+                )
+            err = fail_result(
+                _identity_error(linked, fields),
+                completed=(["create-parent-remote"] if adopted is None else []),
+                statuses=(["pushed"] if adopted is None else []),
+                flow_dir=flow_dir,
+                spec_id=subject_marker_token("chart", chart_id),
+                event=event,
+                tracker_id=fields.get("id"),
+                transport=provider,
+                degraded=None,
+            )
+            return _refuse_unpersisted_identity(
+                err, kind="chart", subject_id=chart_id, fields=fields,
+                pend_err=pend_err,
+            )
+        _clear_pending_identity(flow_dir, "chart", chart_id)
+        chart_tracker = linked
+        completed.append("create-parent" if adopted is None else "adopt-parent")
+        statuses.append("pushed")
+        steps["create_parent"] = {
+            "kind": "created" if adopted is None else "adopted", **fields,
+        }
+    else:
+        # Hygiene: a pending identity must never outlive a completed link
+        # (it could be wrongly adopted after a later staleLink unlink).
+        _clear_pending_identity(flow_dir, "chart", chart_id)
+        steps["create_parent"] = {
+            "kind": "already_linked",
+            "id": chart_tracker.get("id"),
+            "identifier": chart_tracker.get("identifier"),
+        }
+
+    parent_loc = locator_of(chart_tracker)
+    if isinstance(parent_loc, TrackerError):
+        return fail_result(
+            parent_loc, completed=completed, statuses=statuses,
+            flow_dir=flow_dir,
+            spec_id=subject_marker_token("chart", chart_id),
+            event=event, tracker_id=chart_tracker.get("id"),
+            transport=provider,
+        )
+
+    # --- children create/update (pass one: every child gets a locator) ---
+    child_results = []
+    edge_children: list[str] = []
+    for decision in decisions:
+        if not isinstance(decision, dict) or not decision.get("id"):
+            continue
+        did = decision["id"]
+        dloaded = load_subject(flow_dir, "decision", did)
+        if isinstance(dloaded, TrackerError):
+            # Ensure tracker block exists on compact-only entries by skipping remote.
+            child_results.append({"id": did, "skipped": "decision_missing"})
+            continue
+        dpath, ddata, dtracker = dloaded
+        dbody = build_decision_body(ddata)
+        dtitle = _decision_title(ddata)
+        dstate = dtracker.get("linkState") or (
+            "linked" if dtracker.get("id") else "unlinked"
+        )
+        if dstate == "unlinked" or not dtracker.get("id"):
+            adopted = _pending_identity_fields(flow_dir, "decision", did)
+            if adopted is not None:
+                fields = adopted
+            else:
+                created = _create_issue(
+                    config, execute, title=dtitle, body=dbody,
+                )
+                if isinstance(created, TrackerError):
+                    return fail_result(
+                        created, completed=completed, statuses=statuses,
+                        flow_dir=flow_dir,
+                        spec_id=subject_marker_token("chart", chart_id),
+                        event=event, tracker_id=chart_tracker.get("id"),
+                        transport=provider,
+                        degraded=collect_degraded(*degraded_parts),
+                    )
+                fields = _link_fields(created)
+
+            def _link_child(t: dict, _fields=fields, _did=did):
+                hit = subject_collision(
+                    flow_dir, _fields["id"],
+                    except_kind="decision", except_id=_did,
+                )
+                if hit:
+                    return hit
+                t = dict(t)
+                t.update(_fields)
+                return t
+
+            linked = _link_subject(
+                flow_dir, "decision", did, _link_child, collision_id=fields["id"],
+            )
+            if isinstance(linked, TrackerError):
+                pend_err = None
+                if adopted is not None and linked.subtype == "durable_collision":
+                    _tombstone_pending_identity(flow_dir, "decision", did)
+                else:
+                    pend_err = _record_pending_identity(
+                        flow_dir, "decision", did, fields,
+                    )
+                extra = [] if adopted is not None else [
+                    f"create-child-remote:{did}",
+                ]
+                err = fail_result(
+                    _identity_error(linked, fields),
+                    completed=completed + extra,
+                    statuses=statuses + (["pushed"] if extra else []),
+                    flow_dir=flow_dir,
+                    spec_id=subject_marker_token("chart", chart_id),
+                    event=event, tracker_id=fields.get("id"),
+                    transport=provider,
+                )
+                return _refuse_unpersisted_identity(
+                    err, kind="decision", subject_id=did, fields=fields,
+                    pend_err=pend_err,
+                )
+            _clear_pending_identity(flow_dir, "decision", did)
+            dtracker = linked
+            self_wrote.add(did)
+            completed.append(
+                f"create-child:{did}" if adopted is None
+                else f"adopt-child:{did}"
+            )
+            statuses.append("pushed")
+            # hierarchy after both sides linked
+            child_loc = locator_of(dtracker)
+            if not isinstance(child_loc, TrackerError):
+                hier = _ensure_hierarchy(
+                    flow_dir, config, execute,
+                    chart_id=chart_id, did=did, dtracker=dtracker,
+                    parent_loc=parent_loc, child_loc=child_loc, caps=caps,
+                )
+                if isinstance(hier, TrackerError):
+                    return fail_result(
+                        hier, completed=completed, statuses=statuses,
+                        flow_dir=flow_dir,
+                        spec_id=subject_marker_token("chart", chart_id),
+                        event=event, tracker_id=chart_tracker.get("id"),
+                        transport=provider,
+                    )
+                if isinstance(hier, dict) and hier.get("degraded"):
+                    degraded_parts.append(hier["degraded"])
+                elif isinstance(hier, dict) and hier.get("projected"):
+                    if not hier.get("already"):
+                        self_wrote.add(did)
+                    completed.append(f"hierarchy:{did}")
+            child_results.append({
+                "id": did,
+                "kind": "created" if adopted is None else "adopted",
+                **fields,
+            })
+            edge_children.append(did)
+        else:
+            # Update owned body block (claim/release/resolve refresh).
+            _clear_pending_identity(flow_dir, "decision", did)
+            child_loc = locator_of(dtracker)
+            if isinstance(child_loc, TrackerError):
+                return fail_result(
+                    child_loc, completed=completed, statuses=statuses,
+                    flow_dir=flow_dir,
+                    spec_id=subject_marker_token("chart", chart_id),
+                    event=event, tracker_id=chart_tracker.get("id"),
+                    transport=provider,
+                )
+            # Read current body first; a failed read must abort this step -
+            # updating on top of an unread body would replace real remote
+            # content with only the flow-owned block.
+            current = _wire_read(config, execute, child_loc)
+            if isinstance(current, TrackerError):
+                return fail_result(
+                    current, completed=completed, statuses=statuses,
+                    flow_dir=flow_dir,
+                    spec_id=subject_marker_token("chart", chart_id),
+                    event=event, tracker_id=chart_tracker.get("id"),
+                    transport=provider,
+                )
+            cur_body = ""
+            if isinstance(current, dict):
+                cur_body = current.get("body") or ""
+            new_body = _upsert_owned_block(
+                cur_body, DECISION_BLOCK_OPEN, DECISION_BLOCK_CLOSE, dbody,
+            )
+            updated = _wire_update(
+                config, execute, child_loc, title=dtitle, body=new_body,
+            )
+            if isinstance(updated, TrackerError):
+                return fail_result(
+                    updated, completed=completed, statuses=statuses,
+                    flow_dir=flow_dir,
+                    spec_id=subject_marker_token("chart", chart_id),
+                    event=event, tracker_id=chart_tracker.get("id"),
+                    transport=provider,
+                )
+            completed.append(f"update-child:{did}")
+            statuses.append("updated")
+            # Re-assert hierarchy for linked children whose hierarchy step is
+            # not marked complete (create-ok/hierarchy-fail retry path). Only
+            # attempted where the provider supports it; degraded providers
+            # already reported flat_linked at create.
+            if caps.get("subIssues"):
+                hier = _ensure_hierarchy(
+                    flow_dir, config, execute,
+                    chart_id=chart_id, did=did, dtracker=dtracker,
+                    parent_loc=parent_loc, child_loc=child_loc, caps=caps,
+                )
+                if isinstance(hier, TrackerError):
+                    return fail_result(
+                        hier, completed=completed, statuses=statuses,
+                        flow_dir=flow_dir,
+                        spec_id=subject_marker_token("chart", chart_id),
+                        event=event, tracker_id=chart_tracker.get("id"),
+                        transport=provider,
+                    )
+                if isinstance(hier, dict) and hier.get("degraded"):
+                    degraded_parts.append(hier["degraded"])
+                elif (
+                    isinstance(hier, dict)
+                    and hier.get("projected")
+                    and not hier.get("already")
+                ):
+                    self_wrote.add(did)
+                    completed.append(f"hierarchy:{did}")
+                    statuses.append("pushed")
+            child_results.append({
+                "id": did, "kind": "updated",
+                "id_tracker": dtracker.get("id"),
+                "identifier": dtracker.get("identifier"),
+            })
+            edge_children.append(did)
+
+    steps["children"] = child_results
+
+    # --- blocking edges (pass two: every child linked before any edge) ---
+    # A single interleaved pass silently skips an edge whose blocker comes
+    # LATER in D-number order (D1 blocked_by D2 on an initial map) and then
+    # records the event marker anyway - the retry dedupes instead of
+    # converging. Projecting after pass one guarantees both locators exist.
+    for did in edge_children:
+        dloaded2 = load_subject(flow_dir, "decision", did)
+        if isinstance(dloaded2, TrackerError):
+            continue
+        _p2, ddata2, dtr = dloaded2
+        from_loc = locator_of(dtr)
+        if isinstance(from_loc, TrackerError):
+            continue
+        desired_keys: set[str] = set()
+        blockers_resolved = True
+        for blocker in ddata2.get("blocked_by") or []:
+            b_loaded = load_subject(flow_dir, "decision", str(blocker))
+            if isinstance(b_loaded, TrackerError):
+                blockers_resolved = False
+                continue
+            _bp, _bd, btr = b_loaded
+            to_loc = locator_of(btr)
+            if isinstance(to_loc, TrackerError):
+                blockers_resolved = False
+                continue
+            key = dep_relation_key(
+                str(from_loc["durable"]), str(to_loc["durable"]),
+            )
+            desired_keys.add(key)
+            if ledger_has(dtr, key):
+                continue
+            rel = _project_blocking(
+                config, execute,
+                from_loc=from_loc, to_loc=to_loc, caps=caps,
+                dep_subject=str(blocker),
+            )
+            if isinstance(rel, TrackerError):
+                return fail_result(
+                    rel, completed=completed, statuses=statuses,
+                    flow_dir=flow_dir,
+                    spec_id=subject_marker_token("chart", chart_id),
+                    event=event, tracker_id=chart_tracker.get("id"),
+                    transport=provider,
+                    degraded=collect_degraded(*degraded_parts),
+                )
+            if isinstance(rel, dict) and rel.get("degraded"):
+                degraded_parts.append(rel["degraded"])
+            elif isinstance(rel, dict) and rel.get("projected"):
+                completed.append(f"blocks:{did}->{blocker}")
+                statuses.append("pushed")
+
+                def _ledger(t: dict, _key=key, _blocker=blocker,
+                            _from=from_loc, _to=to_loc):
+                    t = ledger_append(
+                        t, key=_key, dep_spec=str(_blocker),
+                        from_tracker_id=str(_from["durable"]),
+                        to_tracker_id=str(_to["durable"]),
+                        rel_type="blocks", source="flow",
+                    )
+                    return ledger_finalize(t, key=_key)
+
+                ledgered = locked_subject_write(
+                    flow_dir, "decision", did, _ledger,
+                )
+                self_wrote.add(did)
+                if isinstance(ledgered, TrackerError):
+                    # The native edge landed but flow ownership did not
+                    # persist. Without the ledger entry a later rewire cannot
+                    # attribute (and remove) the remote edge - swallowing the
+                    # failure while the event marker records success would
+                    # orphan it permanently. Partial failure instead: no
+                    # marker, so the retry re-asserts the relation (the
+                    # provider probe reports it already present) and lands
+                    # the ledger entry.
+                    return fail_result(
+                        ledgered, completed=completed, statuses=statuses,
+                        flow_dir=flow_dir,
+                        spec_id=subject_marker_token("chart", chart_id),
+                        event=event, tracker_id=chart_tracker.get("id"),
+                        transport=provider,
+                        degraded=collect_degraded(*degraded_parts),
+                    )
+
+        # Reconcile stale flow-owned native blocking (wire-decision repoint
+        # or clear): entries the ledger attributes to flow whose edge is no
+        # longer in blocked_by are removed remotely, then dropped from the
+        # ledger. Relations the ledger does not attribute to flow are never
+        # touched. Skipped when any listed blocker failed to resolve - a
+        # desired key we could not compute must not be judged stale.
+        if not blockers_resolved:
+            continue
+        for entry in list(dtr.get("depRelations") or []):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("source") != "flow" or entry.get("type") != "blocks":
+                continue
+            if entry.get("status") == "pending":
+                continue
+            key = entry.get("key")
+            if not key or key in desired_keys:
+                continue
+            to_id = str(entry.get("to_tracker_id") or "")
+            if not to_id:
+                continue
+            if str(entry.get("from_tracker_id") or "") != str(from_loc["durable"]):
+                # Identity drift: never address remote relations by an old
+                # (relinked-away) identity.
+                continue
+            rem = _remove_blocking(
+                config, execute, from_loc=from_loc, to_id=to_id, caps=caps,
+            )
+            if isinstance(rem, TrackerError):
+                return fail_result(
+                    rem, completed=completed, statuses=statuses,
+                    flow_dir=flow_dir,
+                    spec_id=subject_marker_token("chart", chart_id),
+                    event=event, tracker_id=chart_tracker.get("id"),
+                    transport=provider,
+                    degraded=collect_degraded(*degraded_parts),
+                )
+            if isinstance(rem, dict) and rem.get("degraded"):
+                # Keep the ledger entry: the stale native edge remains and
+                # flow still owns it.
+                degraded_parts.append(rem["degraded"])
+                continue
+            if isinstance(rem, dict):
+                if rem.get("removed"):
+                    completed.append(f"unblock:{did}-x>{entry.get('dep_spec')}")
+                    statuses.append("pushed")
+
+                def _drop(t: dict, _key=key):
+                    return ledger_drop(t, key=_key)
+
+                dropped = locked_subject_write(flow_dir, "decision", did, _drop)
+                self_wrote.add(did)
+                if isinstance(dropped, TrackerError):
+                    # The native edge is gone but the ledger entry survived.
+                    # Recording success would freeze the stale entry: a later
+                    # re-add of the same edge is suppressed by ledger_has and
+                    # never re-created remotely. Partial failure instead: no
+                    # marker, so the retry re-runs removal (the provider
+                    # reports already_absent) and lands the ledger drop.
+                    return fail_result(
+                        dropped, completed=completed, statuses=statuses,
+                        flow_dir=flow_dir,
+                        spec_id=subject_marker_token("chart", chart_id),
+                        event=event, tracker_id=chart_tracker.get("id"),
+                        transport=provider,
+                        degraded=collect_degraded(*degraded_parts),
+                    )
+
+    # --- parent rollup refresh ---
+    # Claim/release may refresh owned block/counts but never masquerade as
+    # provider workflow status.
+    parent_current = _wire_read(config, execute, parent_loc)
+    if isinstance(parent_current, TrackerError):
+        # Never rebuild the parent body from an unread remote state.
+        return fail_result(
+            parent_current, completed=completed, statuses=statuses,
+            flow_dir=flow_dir,
+            spec_id=subject_marker_token("chart", chart_id),
+            event=event, tracker_id=chart_tracker.get("id"),
+            transport=provider,
+            degraded=collect_degraded(*degraded_parts),
+        )
+    parent_cur_body = ""
+    if isinstance(parent_current, dict):
+        parent_cur_body = parent_current.get("body") or ""
+    parent_new_body = _upsert_owned_block(
+        parent_cur_body, CHART_ROLLUP_OPEN, CHART_ROLLUP_CLOSE, parent_body,
+    )
+    # Skip status/workflow transitions for claim/release events.
+    parent_upd = _wire_update(
+        config, execute, parent_loc, title=parent_title, body=parent_new_body,
+    )
+    if isinstance(parent_upd, TrackerError):
+        return fail_result(
+            parent_upd, completed=completed, statuses=statuses,
+            flow_dir=flow_dir,
+            spec_id=subject_marker_token("chart", chart_id),
+            event=event, tracker_id=chart_tracker.get("id"),
+            transport=provider,
+            degraded=collect_degraded(*degraded_parts),
+        )
+    completed.append("parent-rollup")
+    statuses.append("updated")
+    steps["parent_rollup"] = {"kind": "updated"}
+
+    degraded = collect_degraded(*degraded_parts)
+    receipt_status = (
+        "pushed" if any(s in ("pushed", "updated") for s in statuses) else "noop"
+    )
+    # Worst-status ranking via helpers
+    from .helpers import worst_status  # noqa: PLC0415
+
+    receipt_status = worst_status(statuses) if statuses else "noop"
+
+    # Projection-side sidecar writes (link adoption, ledger entries) bump the
+    # decision sidecars' updated_at AFTER the entry digest was computed. Key
+    # the success marker on the post-projection state instead: an identical
+    # retry (same sidecar bytes) recomputes the same key and dedupes, while
+    # any committed mutation since - including one returning the graph to a
+    # prior state - mints a fresh marker.
+    # ONLY this holder's own writes may be absorbed that way. A foreign chart
+    # mutation committed during the remote span must not be folded into the
+    # marker: the pushed remote content predates it, so absorbing it would
+    # make that mutation's own projection (or any retry) dedupe against
+    # content that was never pushed - the tracker stays stale indefinitely.
+    # On foreign change the marker stays keyed on the state actually
+    # projected, and stale_revision names the remaining state so
+    # project_chart's drain loop re-projects it before releasing the lock.
+    stale_revision = None
+    end_bundle = _load_chart_bundle(flow_dir, chart_id)
+    if not isinstance(end_bundle, TrackerError):
+        _ep, end_chart, _et, end_decisions = end_bundle
+        start_by_id = {
+            str(e.get("id")): e for e in _digest_entries(decisions)
+        }
+        end_by_id = {
+            str(e.get("id")): e for e in _digest_entries(end_decisions)
+        }
+        foreign = (
+            _chart_base_revision(end_chart, end_decisions) != start_skeleton
+            or set(end_by_id) != set(start_by_id)
+            or any(
+                did not in self_wrote and entry != start_by_id[did]
+                for did, entry in end_by_id.items()
+            )
+        )
+        if foreign:
+            stale_revision = _sha(
+                f"{supplied_revision or _chart_base_revision(end_chart, end_decisions)}"
+                f"\x00{_mutation_state_digest(end_chart, end_decisions)}"
+            )
+        else:
+            revision = _sha(
+                f"{base_revision}"
+                f"\x00{_mutation_state_digest(end_chart, end_decisions)}"
+            )
+            if not evidence_supplied:
+                evidence = revision[:16]
+
+    def _mark(t: dict):
+        t = _append_event_marker(
+            t, event=event, revision=revision, evidence=evidence,
+            completed_steps=completed, status=receipt_status,
+        )
+        if degraded is not None:
+            proj = dict_(t.get("projection"))
+            proj["degraded"] = degraded
+            t = dict(t)
+            t["projection"] = proj
+        return t
+
+    marked = locked_subject_write(flow_dir, "chart", chart_id, _mark)
+    if isinstance(marked, TrackerError):
+        # Remote work done; still try aggregate receipt with completed steps.
+        rerr = write_aggregate_receipt(
+            flow_dir,
+            spec_id=subject_marker_token("chart", chart_id),
+            event=event,
+            status=receipt_status,
+            tracker_id=chart_tracker.get("id"),
+            transport=provider,
+            degraded=degraded,
+            note=f"chart projection partial marker-fail ({', '.join(completed)})",
+            details={"completed_steps": completed, "marker_error": marked.message},
+        )
+        return fail_result(
+            marked, completed=completed, statuses=statuses,
+            flow_dir=flow_dir,
+            spec_id=subject_marker_token("chart", chart_id),
+            event=event, tracker_id=chart_tracker.get("id"),
+            transport=provider, degraded=degraded,
+        )
+
+    rerr = write_aggregate_receipt(
+        flow_dir,
+        spec_id=subject_marker_token("chart", chart_id),
+        event=event,
+        status=receipt_status,
+        tracker_id=(marked.get("id") if isinstance(marked, dict) else None),
+        transport=provider,
+        degraded=degraded,
+        note=f"chart projection ({', '.join(completed)})",
+        details={"revision": revision, "evidence": evidence},
+    )
+    if rerr:
+        return fail_result(
+            rerr, completed=completed, statuses=statuses,
+            flow_dir=flow_dir,
+            spec_id=subject_marker_token("chart", chart_id),
+            event=event,
+            tracker_id=marked.get("id") if isinstance(marked, dict) else None,
+            transport=provider, degraded=degraded,
+        )
+
+    data = {
+        "op": "chart_project",
+        "projected": True,
+        "chart_id": chart_id,
+        "event": event,
+        "revision": revision,
+        "steps": steps,
+        "tracker_id": marked.get("id") if isinstance(marked, dict) else None,
+    }
+    if stale_revision is not None:
+        data["stale_revision"] = stale_revision
+    return ok_result(data, statuses=statuses, completed=completed,
+                     degraded=degraded)
+
+
+# ---------------------------------------------------------------------------
+# Locator / URL re-entry (strictly local)
+# ---------------------------------------------------------------------------
+
+def _normalize_url(raw: str) -> Optional[str]:
+    """Normalize scheme/host case; strip provider-approved cosmetic suffixes.
+
+    Rejects credential-bearing URLs. Returns None when unusable.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return None
+    # Bare identifiers are not URLs.
+    if "://" not in text and not text.startswith("//"):
+        return None
+    if "://" not in text:
+        text = "https:" + text
+    try:
+        parsed = urlparse(text)
+    except ValueError:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    if parsed.scheme and parsed.scheme.lower() not in ("http", "https"):
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    path = unquote(parsed.path or "")
+    # Provider-approved cosmetic suffixes: trailing slash, .html
+    while path.endswith("/"):
+        path = path[:-1]
+    if path.endswith(".html"):
+        path = path[:-5]
+    # Drop fragments and query for ledger match (cosmetic).
+    return f"https://{host}{path}"
+
+
+def _configured_hosts(config: dict, provider: Optional[str]) -> set[str]:
+    hosts: set[str] = set()
+    if provider in _DEFAULT_HOSTS:
+        hosts.update(_DEFAULT_HOSTS[provider])
+    per = dict_(dict_(config.get("tracker")).get("perTracker"))
+    for key in ("host", "baseUrl"):
+        raw = per.get(key)
+        if isinstance(raw, str) and raw.strip():
+            try:
+                p = urlparse(raw if "://" in raw else f"https://{raw}")
+                if p.hostname:
+                    hosts.add(p.hostname.lower())
+            except ValueError:
+                continue
+    # Also accept resolved destination hosts.
+    dest = dict_(dict_(dict_(config.get("tracker")).get("resolved")).get("destination"))
+    for key in ("host", "baseUrl"):
+        raw = dest.get(key)
+        if isinstance(raw, str) and raw.strip():
+            try:
+                p = urlparse(raw if "://" in raw else f"https://{raw}")
+                if p.hostname:
+                    hosts.add(p.hostname.lower())
+            except ValueError:
+                continue
+    return hosts
+
+
+def _host_allowed(url: str, config: dict) -> bool:
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    provider = tracker_type(config)
+    allowed = _configured_hosts(config, provider)
+    if not allowed:
+        # No tracker configured: still allow known public hosts for local ledger
+        # matches (host check is secondary to ledger membership).
+        allowed = set()
+        for hs in _DEFAULT_HOSTS.values():
+            allowed.update(hs)
+    return host in allowed
+
+
+def _ledger_entries(flow_dir: Path) -> list[dict]:
+    """Build local provenance ledger rows from chart/decision tracker blocks."""
+    from ..subjects import iter_all_subject_trackers  # noqa: PLC0415
+
+    rows = []
+    for kind, sid, tracker in iter_all_subject_trackers(flow_dir):
+        if kind == "spec":
+            continue
+        if not isinstance(tracker, dict):
+            continue
+        durable = tracker.get("id")
+        ident = tracker.get("identifier")
+        url = tracker.get("url")
+        if not durable and not ident and not url:
+            continue
+        rows.append({
+            "kind": kind,
+            "subject_id": sid,
+            "id": durable,
+            "identifier": ident,
+            "url": url,
+            "normalized_url": _normalize_url(str(url)) if url else None,
+            "linkState": tracker.get("linkState"),
+        })
+    return rows
+
+
+def locate_selector(flow_dir: Path, selector: str, *, config: Optional[dict] = None
+                    ) -> Result:
+    """Resolve chart/D-ID, stored identifier, or stored URL via local ledger only.
+
+    Zero mutation. No network. Structured failures for unsafe/unknown cases.
+    """
+    flow_dir = Path(flow_dir)
+    config = config if config is not None else read_config(flow_dir)
+    sel = (selector or "").strip()
+    if not sel:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "selector required",
+            subtype="selector",
+            details={"code": "unresolved_locator"},
+        )
+
+    # Credential-bearing URL rejection before any ledger work.
+    if "://" in sel or sel.startswith("//"):
+        try:
+            parsed = urlparse(sel if "://" in sel else "https:" + sel)
+        except ValueError:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                "malformed selector URL",
+                subtype="selector",
+                details={"code": "unresolved_locator"},
+            )
+        if parsed.username or parsed.password:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                "credential-bearing URLs are rejected",
+                subtype="credentials",
+                details={"code": "unresolved_locator"},
+            )
+
+    # Canonical chart / decision ids resolve without ledger.
+    if re.fullmatch(r"fn-\d+", sel, re.I):
+        loaded = load_subject(flow_dir, "chart", sel.lower())
+        if isinstance(loaded, TrackerError):
+            return TrackerError(
+                ErrorClass.NOT_FOUND,
+                f"chart {sel!r} not found",
+                subtype="chart",
+                details={"code": "unresolved_locator"},
+            )
+        _p, chart, _t = loaded
+        return {
+            "kind": "chart",
+            "chart_id": chart.get("id"),
+            "title": chart.get("title"),
+            "status": chart.get("status"),
+            "record_path": f".flow/charts/{chart.get('id')}.md",
+            "decision_id": None,
+            "history": None,
+        }
+
+    dparse = parse_decision_id(sel)
+    if dparse:
+        chart_id, n = dparse
+        did = f"{chart_id}.D{n}"
+        loaded = load_subject(flow_dir, "decision", did)
+        if isinstance(loaded, TrackerError):
+            return TrackerError(
+                ErrorClass.NOT_FOUND,
+                f"decision {did!r} not found",
+                subtype="decision",
+                details={"code": "unresolved_locator"},
+            )
+        _p, dec, _t = loaded
+        return _decision_locate_result(flow_dir, dec)
+
+    rows = _ledger_entries(flow_dir)
+    if not rows:
+        return TrackerError(
+            ErrorClass.UNRESOLVED,
+            "no stored tracker locators in chart ledger",
+            subtype="locator",
+            details={"code": "unresolved_locator"},
+        )
+
+    matches: list[dict] = []
+    norm_url = _normalize_url(sel)
+    for row in rows:
+        if row.get("id") and str(row["id"]) == sel:
+            matches.append(row)
+            continue
+        if row.get("identifier") and str(row["identifier"]) == sel:
+            matches.append(row)
+            continue
+        if norm_url and row.get("normalized_url") == norm_url:
+            matches.append(row)
+            continue
+        # Identifier case-fold for display keys like WOR-17
+        if row.get("identifier") and str(row["identifier"]).casefold() == sel.casefold():
+            matches.append(row)
+
+    if norm_url and not _host_allowed(norm_url, config):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "URL host/project is not the configured tracker host",
+            subtype="wrong_host",
+            details={"code": "unresolved_locator", "url": norm_url},
+        )
+
+    # Dedup matches by subject
+    uniq: dict[tuple, dict] = {}
+    for m in matches:
+        uniq[(m["kind"], m["subject_id"])] = m
+    matches = list(uniq.values())
+
+    if not matches:
+        return TrackerError(
+            ErrorClass.UNRESOLVED,
+            "selector not found in local chart provenance ledger",
+            subtype="locator",
+            details={"code": "unresolved_locator"},
+        )
+    if len(matches) > 1:
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            "selector matches multiple chart/decision locators",
+            subtype="ambiguous",
+            details={
+                "code": "unresolved_locator",
+                "matches": [
+                    {"kind": m["kind"], "subject_id": m["subject_id"]}
+                    for m in matches
+                ],
+            },
+        )
+
+    row = matches[0]
+    # Stale parent: durable id present but linkState not linked / missing parent chart
+    if row.get("linkState") == "identifier_only":
+        return TrackerError(
+            ErrorClass.STALE_ID,
+            "stored locator is identifier-only (stale/incomplete link)",
+            subtype="stale_id",
+            details={"code": "stale_id", "subject_id": row["subject_id"]},
+        )
+
+    if row["kind"] == "chart":
+        loaded = load_subject(flow_dir, "chart", row["subject_id"])
+        if isinstance(loaded, TrackerError):
+            return TrackerError(
+                ErrorClass.STALE_ID,
+                "chart parent for stored locator is missing",
+                subtype="stale_parent",
+                details={"code": "stale_id", "subject_id": row["subject_id"]},
+            )
+        _p, chart, _t = loaded
+        return {
+            "kind": "chart",
+            "chart_id": chart.get("id"),
+            "title": chart.get("title"),
+            "status": chart.get("status"),
+            "record_path": f".flow/charts/{chart.get('id')}.md",
+            "decision_id": None,
+            "history": None,
+            "locator": {
+                "id": row.get("id"),
+                "identifier": row.get("identifier"),
+                "url": row.get("url"),
+            },
+        }
+
+    # decision
+    loaded = load_subject(flow_dir, "decision", row["subject_id"])
+    if isinstance(loaded, TrackerError):
+        return TrackerError(
+            ErrorClass.STALE_ID,
+            "decision for stored locator is missing",
+            subtype="stale_id",
+            details={"code": "stale_id", "subject_id": row["subject_id"]},
+        )
+    _p, dec, _t = loaded
+    result = _decision_locate_result(flow_dir, dec)
+    if isinstance(result, dict):
+        result["locator"] = {
+            "id": row.get("id"),
+            "identifier": row.get("identifier"),
+            "url": row.get("url"),
+        }
+    return result
+
+
+def _decision_locate_result(flow_dir: Path, dec: dict) -> Result:
+    did = dec.get("id")
+    chart_id = dec.get("chart")
+    status = dec.get("status") or "open"
+    record = dec.get("record_path") or (
+        f".flow/charts/{chart_id}/{dec.get('n')}.md" if chart_id else None
+    )
+    base = {
+        "kind": "decision",
+        "chart_id": chart_id,
+        "decision_id": did,
+        "title": dec.get("title"),
+        "status": status,
+        "record_path": record,
+        "history": None,
+        "replacement": None,
+        "frontier": None,
+    }
+    if status in ("resolved", "superseded", "out-of-scope"):
+        # Historical: never silently select replacement work.
+        replacement = dec.get("superseded_by")
+        frontier = None
+        if chart_id:
+            cl = load_subject(flow_dir, "chart", chart_id)
+            if not isinstance(cl, TrackerError):
+                _cp, chart, _ct = cl
+                # Compact frontier from chart decisions list, using the same
+                # actionable predicate as the canonical frontier computation:
+                # open AND unblocked AND unclaimed (blocked decisions are not
+                # selectable frontier options).
+                compact = [
+                    d for d in (chart.get("decisions") or [])
+                    if isinstance(d, dict)
+                ]
+                frontier = _count_decisions(chart, compact)["frontier"]
+        base["history"] = {
+            "status": status,
+            "gist": _safe_gist(dec.get("answer")),
+            "superseded_by": replacement,
+        }
+        base["replacement"] = replacement
+        base["frontier"] = frontier
+    return base

--- a/.flow/bin/flowctl_tracker/facade/helpers.py
+++ b/.flow/bin/flowctl_tracker/facade/helpers.py
@@ -1,0 +1,468 @@
+"""Shared helpers for the lifecycle facade (fn-140.7)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from ..lifecycle.helpers import (Execute, Result, dict_, load_spec,
+                                 merged_tracker, tracker_type,
+                                 write_sync_receipt)
+from ..lifecycle.linkstate import derive_link_state
+from ..types import ErrorClass, TrackerError
+
+OPS = frozenset({"push", "pull", "reconcile", "comment"})
+
+# required / forbidden input names (flow_file / body_file) per op — epic table.
+OP_INPUTS = {
+    "push": {
+        "require": frozenset({"flow_file", "body_file"}),
+        "forbid": frozenset({"comments_file", "source_body_file", "pr_url"}),
+    },
+    "pull": {
+        "require": frozenset({"flow_file", "body_file", "comments_file"}),
+        "forbid": frozenset({"source_body_file", "comment_file", "pr_url"}),
+    },
+    "reconcile": {
+        "require": frozenset({
+            "flow_file", "body_file", "comments_file", "source_body_file",
+        }),
+        "forbid": frozenset({"comment_file"}),
+    },
+    "comment": {
+        "require": frozenset({"body_file"}),
+        "forbid": frozenset({
+            "flow_file", "comments_file", "source_body_file", "comment_file",
+            "pr_url",
+        }),
+    },
+}
+
+# Aggregate receipt status severity — higher = worse.
+_STATUS_RANK = {
+    "errored": 100,
+    "diverged": 90,
+    "deferred": 80,
+    "queued": 70,
+    "updated": 50,
+    "merged": 45,
+    "pushed": 40,
+    "pulled": 40,
+    "noop": 10,
+}
+
+_MARKER_RE = re.compile(
+    r"<!--\s*flow-next:sync\s+"
+    r"issue=(?P<issue>\S+)\s+"
+    r"spec=(?P<spec>\S+)\s+"
+    r"evt=(?P<evt>\S+)\s+"
+    r"evidence=(?P<evidence>\S+)\s*-->"
+)
+
+# Strip Linear/GitHub mention markup before marker parse (comments-sync.md).
+_MENTION_RE = re.compile(r"<issue[^>]*>|</issue>")
+
+# One marker field: exactly what _MARKER_RE's field classes accept (\S+).
+_MARKER_FIELD_RE = re.compile(r"\S+")
+
+
+def marker_component_error(name: str, value: Any) -> Optional[TrackerError]:
+    """Reject marker components the emitted marker cannot round-trip through
+    _MARKER_RE. Marker fields are single whitespace-free tokens; a value with
+    embedded whitespace posts fine the first time, but every retry fails
+    comments_have_marker() and posts another copy - the idempotency guarantee
+    breaks silently. Reject rather than encode: the marker is a dedup
+    identity, and encoding would change the identity of markers already
+    posted by earlier flow-next versions."""
+    if isinstance(value, str) and _MARKER_FIELD_RE.fullmatch(value):
+        return None
+    return TrackerError(
+        ErrorClass.INVALID_INPUT,
+        f"{name} {value!r} cannot round-trip the sync dedup marker: marker "
+        "fields must be a single whitespace-free token (no spaces, tabs, or "
+        "newlines); pass one token, e.g. a sha or dotted event name",
+        subtype=name,
+        details={"field": name, "value": value},
+    )
+
+
+def validate_inputs(op: str, *, flow_file: Optional[str],
+                    body_file: Optional[str], comments_file: Optional[str],
+                    source_body_file: Optional[str],
+                    event: Optional[str], comment_file: Optional[str] = None,
+                    pr_url: Optional[str] = None,
+                    status_only: bool = False,
+                    ) -> Optional[TrackerError]:
+    if op not in OPS:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"--op must be one of {sorted(OPS)}, got {op!r}",
+                            subtype="op")
+    if not event or not str(event).strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "--event is required", subtype="event")
+    if status_only and op != "push":
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "--status-only is valid only with --op push",
+            subtype="args",
+        )
+    # The event is a marker field (and a receipt/claim key): reject values
+    # the emitted marker could not round-trip BEFORE any wire call.
+    bad_event = marker_component_error("event", str(event))
+    if bad_event:
+        return bad_event
+    rules = OP_INPUTS[op]
+    present = {
+        "flow_file": flow_file is not None,
+        "body_file": body_file is not None,
+        "comments_file": comments_file is not None,
+        "source_body_file": source_body_file is not None,
+        "comment_file": comment_file is not None,
+        "pr_url": pr_url is not None,
+    }
+    for name in sorted(rules["forbid"]):
+        if present[name]:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"--op {op} forbids --{name.replace('_', '-')}",
+                subtype="args",
+            )
+    for name in sorted(rules["require"]):
+        if not present[name]:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"--op {op} requires --{name.replace('_', '-')}",
+                subtype="args",
+            )
+    if pr_url is not None and event != "makePr":
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "--pr-url is only valid for --op reconcile --event makePr",
+            subtype="pr_url",
+        )
+    return None
+
+
+def read_text_file(path: Optional[str], *, label: str) -> Result:
+    if path is None:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"{label} is required", subtype="args")
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"cannot read {label}: {exc}", subtype=label)
+
+
+def read_comments_file(path: Optional[str]) -> Result:
+    """Read the agent-approved normalized comment snapshot."""
+    raw = read_text_file(path, label="--comments-file")
+    if isinstance(raw, TrackerError):
+        return raw
+    try:
+        value = json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"--comments-file is not valid JSON: {exc}",
+            subtype="comments_file",
+        )
+    if not isinstance(value, list):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "--comments-file must contain a JSON array",
+            subtype="comments_file",
+        )
+    return value
+
+
+def comments_snapshot(comments: Any) -> Result:
+    """Stable fields whose change invalidates an agent-produced comment fold."""
+    if not isinstance(comments, list):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "normalized comments response is not an array",
+            subtype="comments_shape",
+        )
+    out = []
+    for comment in comments:
+        if not isinstance(comment, dict):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "normalized comment is not an object",
+                subtype="comments_shape",
+            )
+        out.append({
+            "id": comment.get("id"),
+            "body": comment.get("body"),
+            "parent_identity": comment.get("parent_identity"),
+        })
+    return out
+
+
+def live_comments_snapshot(payload: Any) -> Result:
+    """Reject incomplete live listings before validating an agent fold."""
+    if not isinstance(payload, dict):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "normalized comment-list response is not an object",
+            subtype="comments_shape",
+        )
+    if payload.get("truncated"):
+        return TrackerError(
+            ErrorClass.CAPABILITY,
+            "tracker comment listing is truncated; refusing to commit an "
+            "incomplete local fold",
+            subtype="comments_truncated",
+        )
+    return comments_snapshot(payload.get("comments"))
+
+
+def local_spec_md(flow_dir: Path, spec_id: str) -> Result:
+    """Read `.flow/specs/<id>.md` (flow half for pull). Never composes content."""
+    path = Path(flow_dir) / "specs" / f"{spec_id}.md"
+    if not path.is_file():
+        return TrackerError(ErrorClass.NOT_FOUND,
+                            f"spec markdown {spec_id!r} not found at {path}",
+                            subtype="spec_md")
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"cannot read spec markdown: {exc}",
+                            subtype="spec_md")
+
+
+def on_mcp_rung(config: dict) -> bool:
+    """Linear MCP create rung: flowctl cannot create; agent must via persist-external.
+
+    Prefer an explicit perTracker transport preference when present; else
+    detect as linear + no LINEAR_API_KEY (no shell-reachable GraphQL).
+    """
+    if tracker_type(config) != "linear":
+        return False
+    per = dict_(dict_(config.get("tracker")).get("perTracker"))
+    preferred = per.get("preferredTransport") or per.get("transport")
+    if isinstance(preferred, str):
+        low = preferred.strip().lower()
+        if low == "mcp":
+            return True
+        if low in ("graphql", "http", "api", "linear-graphql"):
+            return False
+    return not bool(os.environ.get("LINEAR_API_KEY", "").strip())
+
+
+def locator_of(tracker: dict) -> Result:
+    durable = tracker.get("id")
+    display = tracker.get("identifier")
+    if not isinstance(durable, str) or not durable.strip():
+        return TrackerError(ErrorClass.UNRESOLVED, "tracker.id missing",
+                            subtype="durable")
+    if not isinstance(display, str) or not display.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "tracker.identifier (display) required",
+                            subtype="locator")
+    return {"durable": durable.strip(), "display": display.strip()}
+
+
+def load_tracker(flow_dir: Path, spec_id: str) -> Result:
+    loaded = load_spec(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    path, spec_data = loaded
+    tracker = merged_tracker(spec_data)
+    return path, spec_data, tracker
+
+
+def format_marker(*, issue: str, spec_id: str, event: str,
+                  evidence: str = "none") -> str:
+    return (f"<!-- flow-next:sync issue={issue} spec={spec_id} "
+            f"evt={event} evidence={evidence} -->")
+
+
+def normalize_comment_body(body: str) -> str:
+    return _MENTION_RE.sub("", body or "")
+
+
+def marker_match(body: str, *, issue: str, spec: str, event: str,
+                 evidence: str) -> bool:
+    """Match on the FULL marker identity: issue + spec + event + evidence.
+    Two specs may intentionally share one issue (`sync set-tracker-id
+    --force`); ignoring the captured spec field would treat spec A's marker
+    as spec B's and silently drop B's comment as a false dedup. Markers have
+    carried spec= since the wave-1 shape, so matching on it does not orphan
+    markers already posted."""
+    text = normalize_comment_body(body)
+    m = _MARKER_RE.search(text)
+    if not m:
+        return False
+    return (m.group("issue") == issue
+            and m.group("spec") == spec
+            and m.group("evt") == event
+            and m.group("evidence") == evidence)
+
+
+def comments_have_marker(comments: list, *, issue: str, spec: str,
+                         event: str, evidence: str) -> bool:
+    for c in comments:
+        if not isinstance(c, dict):
+            continue
+        if marker_match(c.get("body") or "", issue=issue, spec=spec,
+                        event=event, evidence=evidence):
+            return True
+    return False
+
+
+def parse_evidence(body: str) -> str:
+    """Parse the leading `evidence=<token>` line; else return `none`."""
+    if not body:
+        return "none"
+    first = body.splitlines()[0].strip() if body.splitlines() else ""
+    if first.lower().startswith("evidence="):
+        val = first.split("=", 1)[1].strip()
+        return val or "none"
+    return "none"
+
+
+def require_evidence(body: str, *, label: str) -> Result:
+    """Require a stable comment identity before any remote mutation.
+
+    ``none`` used to be accepted as a shared fallback marker. That made every
+    evidence-less occurrence of the same lifecycle event collapse into one
+    comment, so later task completions could appear successfully synchronized
+    without posting. Synthesized lifecycle comments are repeatable; their
+    first line therefore must carry a caller-owned, whitespace-free identity.
+    """
+    evidence = parse_evidence(body)
+    if evidence.lower() == "none":
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"{label} must start with evidence=<token>; use a stable "
+            "event-specific commit or content fingerprint so separate "
+            "lifecycle occurrences do not deduplicate together",
+            subtype="evidence",
+            details={"field": "evidence", "label": label},
+        )
+    bad_evidence = marker_component_error("evidence", evidence)
+    if bad_evidence:
+        return bad_evidence
+    return evidence
+
+
+def strip_evidence_line(body: str) -> str:
+    lines = body.splitlines()
+    if lines and lines[0].strip().lower().startswith("evidence="):
+        return "\n".join(lines[1:]).lstrip("\n")
+    return body
+
+
+def worst_status(statuses: list[str]) -> str:
+    if not statuses:
+        return "noop"
+    return max(statuses, key=lambda s: _STATUS_RANK.get(s, 0))
+
+
+def step_status_from_sync_body(out: dict) -> str:
+    kind = out.get("kind")
+    if kind == "pulled":
+        return "pulled"
+    if kind == "noop":
+        return "noop"
+    return "pushed"
+
+
+def step_status_from_status(out: dict) -> str:
+    kind = out.get("kind")
+    if kind == "defer":
+        return "deferred"
+    if kind == "noop":
+        return "noop"
+    if kind == "applied_local":
+        return "pulled"
+    if kind == "applied":
+        return "updated"
+    return "updated"
+
+
+def write_aggregate_receipt(flow_dir: Path, *, spec_id: str, event: str,
+                            status: str, tracker_id: Optional[str],
+                            transport: Optional[str],
+                            degraded: Optional[dict] = None,
+                            note: Optional[str] = None,
+                            details: Optional[dict] = None
+                            ) -> Optional[TrackerError]:
+    return write_sync_receipt(
+        flow_dir, spec_id=spec_id, status=status,
+        tracker_id=tracker_id, event=event, transport=transport,
+        note=note, degraded=degraded, details=details,
+    )
+
+
+def completion_review_configured(config: dict,
+                                 spec_data: Optional[dict] = None) -> bool:
+    """Same effective-backend precedence as the status verb (spec
+    default_review > FLOW_REVIEW_BACKEND > config review.backend)."""
+    from ..status.verb import _completion_review_configured  # noqa: PLC0415
+    return _completion_review_configured(config, spec_data)
+
+
+def load_tasks(flow_dir: Path, spec_id: str) -> list:
+    tasks_dir = Path(flow_dir) / "tasks"
+    if not tasks_dir.is_dir():
+        return []
+    out = []
+    for path in sorted(tasks_dir.glob(f"{spec_id}.*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict):
+            out.append({"id": data.get("id"), "status": data.get("status") or "todo"})
+    return out
+
+
+def compute_status_to(flow_dir: Path, spec_id: str, config: dict,
+                      spec_data: dict, execute: Execute) -> str:
+    from ..status.policy import flow_to_normalized, merge_evidence  # noqa: PLC0415
+    pr = merge_evidence(config, spec_data, execute)
+    return flow_to_normalized(
+        spec_data, pr, completion_review_configured(config, spec_data),
+        tasks=load_tasks(flow_dir, spec_id),
+    )
+
+
+def link_state_of(tracker: dict) -> str:
+    return derive_link_state(tracker)
+
+
+def collect_degraded(*parts: Any) -> Optional[dict]:
+    """First structured degradation across step results - including the
+    NESTED write payload: the status verb reports label degradation under
+    result["write"]["degraded"], which the top-level check silently lost."""
+    for p in parts:
+        if isinstance(p, list):
+            nested = collect_degraded(*p)
+            if nested:
+                return nested
+            continue
+        if not isinstance(p, dict):
+            continue
+        if p.get("degraded"):
+            return p["degraded"]
+        write = p.get("write")
+        if isinstance(write, dict) and write.get("degraded"):
+            return write["degraded"]
+        for key in ("relations", "steps"):
+            nested = p.get(key)
+            if isinstance(nested, dict):
+                found = collect_degraded(*nested.values())
+            elif isinstance(nested, list):
+                found = collect_degraded(*nested)
+            else:
+                found = None
+            if found:
+                return found
+    return None

--- a/.flow/bin/flowctl_tracker/facade/ops.py
+++ b/.flow/bin/flowctl_tracker/facade/ops.py
@@ -1,0 +1,1348 @@
+"""Four facade ops: push / pull / reconcile / comment (fn-140.7).
+
+Compose lifecycle + syncbody + status + wire. Never compose judgment content.
+Internal granular calls suppress receipts; this module writes one aggregate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import (Execute, Result, atomic_write_json,
+                                 leaf_is_safe, read_config, tracker_type)
+from ..lifecycle.linkstate import complete_identifier_only, require_durable
+from ..lifecycle.verbs import (_claim_is_stale, _ensure_create_first_ignored,
+                               _release_claim)
+from ..relate import relate
+from ..resolve_verb import bound_executor
+from ..syncbody import sync_body
+from ..status.policy import validate_conflict_tiebreak
+from ..types import ErrorClass, TrackerError
+from ..wire import dispatch as wire_dispatch
+from ..wire import link_pr as wire_link_pr
+from ..wire import validate_pr_url
+from .helpers import (collect_degraded, comments_have_marker,
+                      comments_snapshot, format_marker, link_state_of,
+                      live_comments_snapshot, load_tracker, local_spec_md,
+                      locator_of,
+                      require_evidence,
+                      read_comments_file, read_text_file,
+                      step_status_from_sync_body, strip_evidence_line,
+                      worst_status, write_aggregate_receipt)
+from .projections import project_readiness
+from .steps import create_if_unlinked, fail_result, ok_result, run_status
+
+
+def _relation_status(out: dict) -> str:
+    return {
+        "applied": "pushed",
+        "noop": "noop",
+        "queued": "queued",
+    }.get(str(out.get("kind")), "updated")
+
+
+def _project_relations(flow_dir: Path, spec_id: str, *, event: str,
+                       execute: Execute, completed: list,
+                       statuses: list) -> Result:
+    """Project every linked depends_on_epics edge without granular receipts."""
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec, _tracker = loaded
+    results = []
+    for dep in spec.get("depends_on_epics") or []:
+        if not isinstance(dep, str) or not dep or dep == spec_id:
+            continue
+        linked = load_tracker(flow_dir, dep)
+        if isinstance(linked, TrackerError):
+            results.append({
+                "kind": "noop", "reason": "dependency_unresolved",
+                "dep_spec": dep,
+            })
+            statuses.append("noop")
+            continue
+        dep_tracker = linked[2]
+        if link_state_of(dep_tracker) != "linked":
+            results.append({
+                "kind": "noop", "reason": "dependency_unlinked",
+                "dep_spec": dep,
+            })
+            statuses.append("noop")
+            continue
+        out = relate(
+            flow_dir, spec_id, blocked_by=dep, event=event,
+            execute=execute, write_receipt=False,
+        )
+        if isinstance(out, TrackerError):
+            return out
+        completed.append(f"relation:{dep}")
+        statuses.append(_relation_status(out))
+        results.append(out)
+    completed.append("relations")
+    if not results:
+        statuses.append("noop")
+    return {"kind": "projected", "relations": results}
+
+
+def _fail_if_evidence(err: TrackerError, *, completed: list, statuses: list,
+                      flow_dir: Path, spec_id: str, event: str,
+                      transport: str,
+                      tracker_id: Optional[str] = None,
+                      degraded: Any = None) -> TrackerError:
+    """Route through fail_result whenever remote-mutation evidence exists -
+    either facade-level completed steps or verb-level completed_steps riding
+    the error's details (lifecycle_create's partial-failure shape: the issue
+    exists but the locked link write failed). A direct return there writes no
+    event-tagged aggregate receipt, so sync check reports the lifecycle event
+    missing and an automated caller may retry without durable evidence of
+    what landed. Failures with NOTHING landed (pre-flight, claim conflicts,
+    the MCP external-action instruction) stay receipt-less: there is no
+    remote mutation for a receipt to evidence."""
+    prior = (err.details or {}).get("completed_steps")
+    if not completed and not prior:
+        return err
+    if tracker_id is None:
+        tracker_id = (err.details or {}).get("id")
+    tracker_id = None if tracker_id is None else str(tracker_id)
+    if degraded is None:
+        degraded = (err.details or {}).get("degraded")
+    return fail_result(
+        err, completed=completed, statuses=statuses,
+        flow_dir=flow_dir, spec_id=spec_id, event=event,
+        tracker_id=tracker_id, transport=transport, degraded=degraded,
+    )
+
+
+def _facade_claim_path(flow_dir: Path, spec_id: str) -> Path:
+    return Path(flow_dir) / "create-first" / f"facade-{spec_id}.json"
+
+
+def _claim_facade(flow_dir: Path, spec_id: str, rec_path: Path,
+                  provider: str, *, op: str) -> Optional[TrackerError]:
+    """Reserve the WHOLE multi-step facade sequence under one spec-identity
+    claim taken BEFORE the first step and released only when the sequence
+    finishes. The inner per-step claims (`spec-<id>`, `syncbody-<id>`,
+    `status-<id>`) each cover only their own step; BETWEEN steps no claim is
+    live, so `sync set-tracker-id` - which honors live per-spec claims -
+    could relink the spec after sync_body() returned but before run_status()
+    acquired its claim. The body would then land on the OLD issue while the
+    status step targets the NEW one, and the final receipt (which reloads the
+    link) would record only the new id, presenting the split mutations as one
+    successful push. This outer claim, keyed `facade-<spec-id>` (distinct
+    from every inner key, so the nested step claims cannot self-refuse and
+    config_lock is never held across steps), keeps the relink out of the
+    entire sequence: flowctl's relink scan includes the facade key. Under the
+    lock: a live claim from another process refuses (facade_in_flight,
+    retryable), a stale claim (dead pid on this host past the stale window,
+    _claim_is_stale's owner rules) is reclaimed by overwriting, and OUR
+    pending claim lands durably before any remote I/O."""
+    flow_dir = Path(flow_dir)
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"a tracker facade operation for spec {spec_id!r} is "
+                        "already in flight in another process; retry after "
+                        "it finishes",
+                        subtype=("comment_in_flight"
+                                 if op == "facade-comment"
+                                 else "facade_in_flight"),
+                        details={"specId": spec_id,
+                                 "claim": {"pid": prior.get("pid"),
+                                           "host": prior.get("host"),
+                                           "claimedAt": prior.get("claimedAt")}},
+                        auto_retryable=True)
+                # A STALE pending claim (crashed run) is reclaimed by
+                # overwriting it with OURS - same rule as create-first.
+            claim = {"specId": spec_id, "status": "pending", "op": op,
+                     "pid": os.getpid(), "host": socket.gethostname(),
+                     "claimedAt": time.time(), "transport": provider}
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    return None
+
+
+def op_push(flow_dir: Path, spec_id: str, *, flow_file: str, body_file: str,
+            event: str, comment_file: Optional[str] = None,
+            status_only: bool = False,
+            execute: Execute = default_execute) -> Result:
+    config = read_config(flow_dir)
+    conflict_tiebreak = validate_conflict_tiebreak(config)
+    if isinstance(conflict_tiebreak, TrackerError):
+        return conflict_tiebreak
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    flow_body = read_text_file(flow_file, label="--flow-file")
+    if isinstance(flow_body, TrackerError):
+        return flow_body
+    tracker_body = read_text_file(body_file, label="--body-file")
+    if isinstance(tracker_body, TrackerError):
+        return tracker_body
+    comment_text = None
+    comment_evidence = None
+    if comment_file is not None:
+        raw_comment = read_text_file(comment_file, label="--comment-file")
+        if isinstance(raw_comment, TrackerError):
+            return raw_comment
+        comment_evidence = require_evidence(
+            raw_comment, label="--comment-file")
+        if isinstance(comment_evidence, TrackerError):
+            return comment_evidence
+        comment_text = strip_evidence_line(raw_comment)
+
+    # One spec-identity claim across the whole create -> sync-body -> status
+    # -> receipt sequence, so a relink cannot split the push across two
+    # issues in a between-steps gap (see _claim_facade).
+    rec_path = _facade_claim_path(flow_dir, spec_id)
+    claimed = _claim_facade(flow_dir, spec_id, rec_path, provider,
+                            op="facade-push")
+    if claimed is not None:
+        # Nothing landed: claim refusals stay receipt-less.
+        return claimed
+    try:
+        return _push_sequence(
+            flow_dir, spec_id, flow_body=flow_body,
+            tracker_body=tracker_body, config=config, provider=provider,
+            event=event, comment_text=comment_text,
+            comment_evidence=comment_evidence,
+            status_only=status_only, execute=execute)
+    finally:
+        # Release on every exit: the aggregate receipt, not the claim file,
+        # is the durable record of what landed.
+        _release_claim(rec_path)
+
+
+def _push_sequence(flow_dir: Path, spec_id: str, *, flow_body: str,
+                   tracker_body: str, config: dict, provider: str,
+                   event: str, comment_text: Optional[str],
+                   comment_evidence: Optional[str],
+                   status_only: bool, execute: Execute) -> Result:
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec_data, tracker = loaded
+    title = str(spec_data.get("title") or spec_id)
+
+    completed: list = []
+    statuses: list = []
+    degraded = None
+    steps: dict[str, Any] = {}
+
+    created = create_if_unlinked(
+        flow_dir, spec_id, title=title, body=tracker_body,
+        flow_body=flow_body, config=config,
+        event=event, execute=execute, completed=completed, statuses=statuses,
+    )
+    if isinstance(created, TrackerError):
+        return _fail_if_evidence(
+            created, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider,
+        )
+    steps["create"] = created
+    degraded = collect_degraded(created) or degraded
+
+    if not status_only:
+        body_out = sync_body(
+            flow_dir, spec_id, flow_file_body=flow_body, direction="push",
+            tracker_body=tracker_body, event=event, execute=execute,
+            sync_title=True, write_receipt=False,
+        )
+        if isinstance(body_out, TrackerError):
+            prior = list((body_out.details or {}).get("completed_steps") or [])
+            if prior:
+                completed.append("sync-body-partial")
+            loaded_p = load_tracker(flow_dir, spec_id)
+            tid = (loaded_p[2].get("id")
+                   if not isinstance(loaded_p, TrackerError) else None)
+            return fail_result(
+                body_out, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=tid, transport=provider, degraded=degraded,
+            )
+        completed.append("sync-body")
+        statuses.append(step_status_from_sync_body(body_out))
+        steps["sync_body"] = body_out
+        degraded = collect_degraded(body_out) or degraded
+
+    status_out = run_status(
+        flow_dir, spec_id, config=config, event=event, execute=execute,
+        completed=completed, statuses=statuses,
+    )
+    if isinstance(status_out, TrackerError):
+        loaded_p = load_tracker(flow_dir, spec_id)
+        tid = loaded_p[2].get("id") if not isinstance(loaded_p, TrackerError) else None
+        return fail_result(
+            status_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=tid, transport=provider, degraded=degraded,
+        )
+    steps["status"] = status_out
+    degraded = collect_degraded(status_out) or degraded
+
+    if not status_only:
+        relations_out = _project_relations(
+            flow_dir, spec_id, event=event, execute=execute,
+            completed=completed, statuses=statuses,
+        )
+        if isinstance(relations_out, TrackerError):
+            loaded_p = load_tracker(flow_dir, spec_id)
+            tid = (loaded_p[2].get("id")
+                   if not isinstance(loaded_p, TrackerError) else None)
+            return fail_result(
+                relations_out, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=tid, transport=provider, degraded=degraded,
+            )
+        steps["relations"] = relations_out
+        degraded = collect_degraded(relations_out) or degraded
+
+    if comment_text is not None and comment_evidence is not None:
+        comment_out = _project_push_comment(
+            flow_dir, spec_id, comment_text=comment_text,
+            evidence=comment_evidence, config=config, provider=provider,
+            event=event, execute=execute, completed=completed,
+            statuses=statuses,
+        )
+        if isinstance(comment_out, TrackerError):
+            loaded_p = load_tracker(flow_dir, spec_id)
+            tid = (loaded_p[2].get("id")
+                   if not isinstance(loaded_p, TrackerError) else None)
+            return fail_result(
+                comment_out, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=tid, transport=provider, degraded=degraded,
+            )
+        steps["comment"] = comment_out
+
+    loaded2 = load_tracker(flow_dir, spec_id)
+    tracker_id = None
+    if not isinstance(loaded2, TrackerError):
+        tracker_id = loaded2[2].get("id")
+
+    receipt_status = worst_status(statuses)
+    rerr = write_aggregate_receipt(
+        flow_dir, spec_id=spec_id, event=event, status=receipt_status,
+        tracker_id=tracker_id, transport=provider, degraded=degraded,
+        note=f"facade push ({', '.join(completed)})",
+    )
+    if rerr:
+        return fail_result(
+            rerr, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=tracker_id, transport=provider, degraded=degraded,
+        )
+
+    return ok_result({
+        "op": "push",
+        "status_only": status_only,
+        "steps": steps,
+        "tracker_id": tracker_id,
+    }, statuses=statuses, completed=completed, degraded=degraded)
+
+
+def op_pull(flow_dir: Path, spec_id: str, *, flow_file: str, body_file: str,
+            comments_file: str, event: str,
+            execute: Execute = default_execute) -> Result:
+    config = read_config(flow_dir)
+    conflict_tiebreak = validate_conflict_tiebreak(config)
+    if isinstance(conflict_tiebreak, TrackerError):
+        return conflict_tiebreak
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, _spec, tracker = loaded
+    durable = require_durable(tracker)
+    if isinstance(durable, TrackerError):
+        return durable
+    flow_body = read_text_file(flow_file, label="--flow-file")
+    if isinstance(flow_body, TrackerError):
+        return flow_body
+    tracker_body = read_text_file(body_file, label="--body-file")
+    if isinstance(tracker_body, TrackerError):
+        return tracker_body
+    expected_comments = read_comments_file(comments_file)
+    if isinstance(expected_comments, TrackerError):
+        return expected_comments
+    expected_comments = comments_snapshot(expected_comments)
+    if isinstance(expected_comments, TrackerError):
+        return expected_comments
+
+    # Hold one identity claim across the inner sync-body transaction AND the
+    # aggregate receipt. Otherwise a relink can land after sync_body releases
+    # its claim but before the event receipt is written, making sync check
+    # treat old-issue work as having served the newly linked issue.
+    rec_path = _facade_claim_path(flow_dir, spec_id)
+    claimed = _claim_facade(flow_dir, spec_id, rec_path, provider,
+                            op="facade-pull")
+    if claimed is not None:
+        return claimed
+    try:
+        return _pull_sequence(
+            flow_dir, spec_id, event=event, config=config, provider=provider,
+            durable=durable, flow_body=flow_body,
+            tracker_body=tracker_body, expected_comments=expected_comments,
+            execute=execute)
+    finally:
+        _release_claim(rec_path)
+
+
+def _pull_sequence(flow_dir: Path, spec_id: str, *, event: str,
+                   config: dict, provider: str, durable: str, flow_body: str,
+                   tracker_body: str, expected_comments: list,
+                   execute: Execute) -> Result:
+    """Read, merge, and receipt one pull while the facade claim is live."""
+    completed: list = []
+    statuses: list = []
+    ex = bound_executor(config, execute)
+    degraded = None
+
+    # The wire read runs INSIDE sync_body's claimed transaction, against the
+    # transaction's own locator - a pre-claim read could pair an older
+    # snapshot with a newer base (two pulls overlapping a remote edit) or,
+    # after a set-tracker-id repoint in the gap, commit the old issue's body
+    # under the new locator. The successful read result threads back out
+    # through this holder so it is never re-read - and so does the
+    # transaction's OWN locator: `durable` above was captured pre-claim, so
+    # after a repoint in the gap it names the OLD issue while the read and
+    # paired base target the NEW one. The receipt and the returned tracker_id
+    # must record the identity the transaction actually used.
+    read_holder: dict[str, Any] = {}
+
+    def _tracker_read(txn_locator: dict) -> Any:
+        read_holder["locator"] = dict(txn_locator)
+        out = wire_dispatch("read", config, locator=txn_locator, execute=ex)
+        if isinstance(out, TrackerError):
+            return out
+        read_holder["read"] = out
+
+        readiness = project_readiness(
+            flow_dir, spec_id, issue=out, config=config, provider=provider,
+            locator=txn_locator, execute=ex,
+        )
+        read_holder["readiness"] = readiness
+
+        comments_out = wire_dispatch(
+            "comment-list", config, locator=txn_locator, execute=ex)
+        if isinstance(comments_out, TrackerError):
+            return comments_out
+        current_comments = live_comments_snapshot(comments_out)
+        if isinstance(current_comments, TrackerError):
+            return current_comments
+        read_holder["comments"] = comments_out
+        if current_comments != expected_comments:
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                "tracker comments changed after the pull fold was prepared; "
+                "refusing to commit a stale local form",
+                subtype="comments_changed",
+                details={
+                    "expected": expected_comments,
+                    "found": current_comments,
+                },
+                auto_retryable=True,
+            )
+
+        local_body = local_spec_md(flow_dir, spec_id)
+        if isinstance(local_body, TrackerError):
+            return local_body
+        if local_body != flow_body:
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                "the final pull flow form has not been written to the local "
+                "spec; write the agent-approved fold before committing its base",
+                subtype="flow_form_not_applied",
+                auto_retryable=True,
+            )
+        return out
+
+    body_out = sync_body(
+        flow_dir, spec_id, flow_file_body=flow_body, direction="pull",
+        expected_tracker_body=tracker_body,
+        event=event, execute=execute, write_receipt=False,
+        tracker_read=_tracker_read,
+    )
+    read_out = read_holder.get("read")
+    # Receipt identity = the transaction's locator (captured at the read,
+    # post-claim). Fall back to the pre-claim durable only when the
+    # transaction never reached its read - those paths landed no wire I/O
+    # under any identity.
+    txn_locator = read_holder.get("locator")
+    txn_durable = (txn_locator or {}).get("durable") or durable
+    if read_out is not None:
+        completed.append("wire-read")
+        statuses.append("pulled")
+    readiness_out = read_holder.get("readiness")
+    if isinstance(readiness_out, dict):
+        completed.append("readiness")
+        statuses.append(
+            "updated" if readiness_out.get("kind") == "updated" else "noop")
+        degraded = collect_degraded(readiness_out) or degraded
+    comments_out = read_holder.get("comments")
+    if isinstance(comments_out, dict):
+        completed.append("comments")
+        statuses.append("pulled")
+    if isinstance(body_out, TrackerError):
+        if read_out is None:
+            # The claim refusal, the transaction's locator failure, or the
+            # read itself failed: nothing landed, stay receipt-less.
+            return body_out
+        return fail_result(
+            body_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=txn_durable, transport=provider,
+            degraded=degraded,
+        )
+    completed.append("sync-body")
+    statuses.append(step_status_from_sync_body(body_out))
+    degraded = collect_degraded(body_out) or degraded
+
+    status_out = run_status(
+        flow_dir, spec_id, config=config, event=event, execute=execute,
+        completed=completed, statuses=statuses,
+    )
+    if isinstance(status_out, TrackerError):
+        return fail_result(
+            status_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=txn_durable, transport=provider, degraded=degraded,
+        )
+    degraded = collect_degraded(status_out) or degraded
+
+    receipt_status = worst_status(statuses)
+    rerr = write_aggregate_receipt(
+        flow_dir, spec_id=spec_id, event=event, status=receipt_status,
+        tracker_id=txn_durable, transport=provider,
+        note=f"facade pull ({', '.join(completed)})",
+        degraded=degraded,
+    )
+    if rerr:
+        return fail_result(
+            rerr, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=txn_durable, transport=provider,
+            degraded=degraded,
+        )
+
+    return ok_result({
+        "op": "pull",
+        "wire_read": {
+            "id": read_out.get("id") if isinstance(read_out, dict) else None,
+            "title": read_out.get("title") if isinstance(read_out, dict) else None,
+            "body": read_out.get("body") if isinstance(read_out, dict) else None,
+        },
+        "comments": comments_out,
+        "readiness": readiness_out,
+        "status": status_out,
+        "sync_body": body_out,
+        "tracker_id": txn_durable,
+    }, statuses=statuses, completed=completed,
+        degraded=degraded)
+
+
+def op_reconcile(flow_dir: Path, spec_id: str, *, flow_file: str,
+                 body_file: str, comments_file: str,
+                 source_body_file: str, event: str,
+                 pr_url: Optional[str] = None,
+                 execute: Execute = default_execute) -> Result:
+    config = read_config(flow_dir)
+    conflict_tiebreak = validate_conflict_tiebreak(config)
+    if isinstance(conflict_tiebreak, TrackerError):
+        return conflict_tiebreak
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    if pr_url is not None:
+        invalid_pr_url = validate_pr_url(pr_url)
+        if invalid_pr_url is not None:
+            return invalid_pr_url
+
+    flow_body = read_text_file(flow_file, label="--flow-file")
+    if isinstance(flow_body, TrackerError):
+        return flow_body
+    tracker_body = read_text_file(body_file, label="--body-file")
+    if isinstance(tracker_body, TrackerError):
+        return tracker_body
+    source_tracker_body = read_text_file(
+        source_body_file, label="--source-body-file")
+    if isinstance(source_tracker_body, TrackerError):
+        return source_tracker_body
+    expected_comments = read_comments_file(comments_file)
+    if isinstance(expected_comments, TrackerError):
+        return expected_comments
+    expected_comments = comments_snapshot(expected_comments)
+    if isinstance(expected_comments, TrackerError):
+        return expected_comments
+
+    # Same multi-step gap as op_push (identifier-only completion ->
+    # wire-read -> sync-body -> status -> receipt): hold ONE spec-identity
+    # claim across the whole sequence so a relink cannot split it across two
+    # issues between steps (see _claim_facade).
+    rec_path = _facade_claim_path(flow_dir, spec_id)
+    claimed = _claim_facade(flow_dir, spec_id, rec_path, provider,
+                            op="facade-reconcile")
+    if claimed is not None:
+        # Nothing landed: claim refusals stay receipt-less.
+        return claimed
+    try:
+        return _reconcile_sequence(
+            flow_dir, spec_id, flow_body=flow_body, tracker_body=tracker_body,
+            source_tracker_body=source_tracker_body,
+            expected_comments=expected_comments,
+            config=config, provider=provider, event=event, pr_url=pr_url,
+            execute=execute)
+    finally:
+        _release_claim(rec_path)
+
+
+def _reconcile_sequence(flow_dir: Path, spec_id: str, *, flow_body: str,
+                        tracker_body: str, source_tracker_body: str,
+                        expected_comments: list,
+                        config: dict, provider: str,
+                        event: str, pr_url: Optional[str],
+                        execute: Execute) -> Result:
+    completed: list = []
+    statuses: list = []
+    steps: dict[str, Any] = {}
+    degraded = None
+
+    # Complete identifier_only BEFORE the sequence (single named entry point).
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec_data, tracker = loaded
+    title = str(spec_data.get("title") or spec_id)
+
+    # Reconcile is also a first-touch lifecycle operation. Establish the
+    # durable identity and paired ancestor before any require_durable/read
+    # step; otherwise an unlinked spec fails without reaching the provider.
+    created = create_if_unlinked(
+        flow_dir, spec_id, title=title, body=tracker_body,
+        flow_body=flow_body, config=config, event=event, execute=execute,
+        completed=completed, statuses=statuses,
+    )
+    if isinstance(created, TrackerError):
+        return _fail_if_evidence(
+            created, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider,
+        )
+    steps["create"] = created
+    degraded = collect_degraded(created) or degraded
+
+    if link_state_of(tracker) == "identifier_only":
+        done = complete_identifier_only(flow_dir, spec_id, execute=execute)
+        if isinstance(done, TrackerError):
+            # No remote mutation lands on this path today (read-only resolve
+            # + local link write), so this stays a direct return - but the
+            # helper keeps the receipt invariant self-enforcing should the
+            # verb ever grow partial-success evidence.
+            return _fail_if_evidence(
+                done, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                transport=provider, degraded=degraded,
+            )
+        completed.append("complete-identifier-only")
+        statuses.append("updated")
+        steps["complete_identifier_only"] = done
+
+    # After a completed identifier_only upgrade, the reload/durable/locator
+    # failures below are partial successes - same receipt discipline.
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return _fail_if_evidence(
+            loaded, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider, degraded=degraded,
+        )
+    _path, _spec, tracker = loaded
+    durable = require_durable(tracker)
+    if isinstance(durable, TrackerError):
+        return _fail_if_evidence(
+            durable, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider, tracker_id=tracker.get("id"),
+            degraded=degraded,
+        )
+    locator = locator_of(tracker)
+    if isinstance(locator, TrackerError):
+        return _fail_if_evidence(
+            locator, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider, tracker_id=tracker.get("id"),
+            degraded=degraded,
+        )
+
+    ex = bound_executor(config, execute)
+    read_out = wire_dispatch("read", config, locator=locator, execute=ex)
+    if isinstance(read_out, TrackerError):
+        return fail_result(
+            read_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    completed.append("wire-read")
+    steps["wire_read"] = {
+        "id": read_out.get("id") if isinstance(read_out, dict) else None}
+
+    readiness_out = project_readiness(
+        flow_dir, spec_id, issue=read_out, config=config, provider=provider,
+        locator=locator, execute=ex,
+    )
+    completed.append("readiness")
+    statuses.append(
+        "updated" if readiness_out.get("kind") == "updated" else "noop")
+    steps["readiness"] = readiness_out
+    degraded = collect_degraded(readiness_out) or degraded
+
+    comments_out = wire_dispatch(
+        "comment-list", config, locator=locator, execute=ex)
+    if isinstance(comments_out, TrackerError):
+        return fail_result(
+            comments_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    current_comments = live_comments_snapshot(comments_out)
+    if isinstance(current_comments, TrackerError):
+        return fail_result(
+            current_comments, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    if current_comments != expected_comments:
+        return fail_result(
+            TrackerError(
+                ErrorClass.CONFLICT,
+                "tracker comments changed after the reconcile fold was "
+                "prepared; refusing to commit stale forms",
+                subtype="comments_changed",
+                details={"expected": expected_comments,
+                         "found": current_comments},
+                auto_retryable=True,
+            ),
+            completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    completed.append("comments")
+    statuses.append("pulled")
+    steps["comments"] = comments_out
+
+    if pr_url is not None:
+        pr_link_out = wire_link_pr(
+            provider, config, locator, ex, url=pr_url)
+        if isinstance(pr_link_out, TrackerError):
+            return fail_result(
+                pr_link_out, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=durable, transport=provider, degraded=degraded,
+            )
+        completed.append("pr-link")
+        statuses.append(
+            "updated" if pr_link_out.get("linked") else "noop")
+        steps["pr_link"] = pr_link_out
+        degraded = collect_degraded(pr_link_out) or degraded
+
+    local_body = local_spec_md(flow_dir, spec_id)
+    if isinstance(local_body, TrackerError):
+        return fail_result(
+            local_body, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    if local_body != flow_body:
+        return fail_result(
+            TrackerError(
+                ErrorClass.CONFLICT,
+                "the final reconcile flow form has not been written to the "
+                "local spec; write the agent-approved merge before syncing",
+                subtype="flow_form_not_applied",
+                auto_retryable=True,
+            ),
+            completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+
+    relations_out = _project_relations(
+        flow_dir, spec_id, event=event, execute=execute,
+        completed=completed, statuses=statuses,
+    )
+    if isinstance(relations_out, TrackerError):
+        return fail_result(
+            relations_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    steps["relations"] = relations_out
+    degraded = collect_degraded(relations_out) or degraded
+
+    body_out = sync_body(
+        flow_dir, spec_id, flow_file_body=flow_body,
+        tracker_body=tracker_body, direction="push",
+        expected_tracker_body=source_tracker_body,
+        sync_title=True, event=event, execute=execute, write_receipt=False,
+    )
+    if isinstance(body_out, TrackerError):
+        prior = list((body_out.details or {}).get("completed_steps") or [])
+        if prior:
+            completed.append("sync-body-partial")
+        return fail_result(
+            body_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    completed.append("sync-body")
+    statuses.append(step_status_from_sync_body(body_out))
+    steps["sync_body"] = body_out
+    degraded = collect_degraded(body_out) or degraded
+
+    status_out = run_status(
+        flow_dir, spec_id, config=config, event=event, execute=execute,
+        completed=completed, statuses=statuses,
+    )
+    if isinstance(status_out, TrackerError):
+        return fail_result(
+            status_out, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    steps["status"] = status_out
+    degraded = collect_degraded(status_out) or degraded
+
+    receipt_status = worst_status(statuses)
+    rerr = write_aggregate_receipt(
+        flow_dir, spec_id=spec_id, event=event, status=receipt_status,
+        tracker_id=durable, transport=provider, degraded=degraded,
+        note=f"facade reconcile ({', '.join(completed)})",
+    )
+    if rerr:
+        return fail_result(
+            rerr, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+
+    return ok_result({
+        "op": "reconcile",
+        "steps": steps,
+        "tracker_id": durable,
+    }, statuses=statuses, completed=completed, degraded=degraded)
+
+
+def _comment_claim_path(flow_dir: Path, *, issue: str, spec: str,
+                        event: str, evidence: str) -> Path:
+    """Claim record keyed on the dedup-marker identity - issue + spec +
+    event + evidence, exactly the quadruple comments_have_marker matches on.
+    Spec is part of the key so two specs sharing one issue (`sync
+    set-tracker-id --force`) can claim concurrently without false back-off;
+    the sha256 keeps the filename hex-safe regardless of the spec slug."""
+    payload = "\0".join([issue, spec, event, evidence])
+    key = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return Path(flow_dir) / "create-first" / f"comment-{key}.json"
+
+
+def _claim_comment_marker(flow_dir: Path, spec_id: str, rec_path: Path,
+                          provider: str, *, event: str,
+                          marker: str) -> Optional[TrackerError]:
+    """Reserve the dedup marker under the shared writer lock BEFORE the
+    marker scan and comment-add (create-first's claim pattern, keyed on the
+    marker identity). Two concurrent comment facades for the same issue,
+    event and evidence could both finish the scan before either posts - the
+    providers do not make list-then-create atomic - so both would add the
+    same marked comment. Under the lock: a live claim from another process
+    refuses (comment_in_flight, retryable - after the winner posts, the
+    retry's scan sees the marker and dedups to a noop), a stale claim (dead
+    pid on this host past the stale window, _claim_is_stale's owner rules)
+    is reclaimed by overwriting, and OUR pending claim lands durably before
+    any remote read or mutation. The claim is always released when the
+    invocation finishes (success or failure): the marker on the remote
+    issue, not the claim file, is the durable dedup record."""
+    flow_dir = Path(flow_dir)
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"comment for this marker ({event}) is already in "
+                        "flight in another process; retry after it finishes "
+                        "(the dedup scan then sees the winner's marker)",
+                        subtype="comment_in_flight",
+                        details={"specId": spec_id, "marker": marker,
+                                 "claim": {"pid": prior.get("pid"),
+                                           "host": prior.get("host"),
+                                           "claimedAt": prior.get("claimedAt")}},
+                        auto_retryable=True)
+                # A STALE pending claim (crashed run) is reclaimed by
+                # overwriting it with OURS - same rule as create-first.
+            claim = {"specId": spec_id, "status": "pending",
+                     "marker": marker, "event": event,
+                     "pid": os.getpid(), "host": socket.gethostname(),
+                     "claimedAt": time.time(), "transport": provider}
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    return None
+
+
+def _recheck_comment_identity(flow_dir: Path, spec_id: str,
+                              locator: dict) -> Optional[TrackerError]:
+    """Wave-11 revalidation, comment edition: the marker claim serializes
+    sibling comment facades, NOT `sync set-tracker-id`. If a relink lands
+    after this invocation loaded its locator, the dedup scan and comment-add
+    below would validate and post against the OLD issue while the spec now
+    points at a new one - and the aggregate receipt would record the old
+    tracker id. Under the shared writer lock (the same lock the link writers
+    hold - since PR #246 that includes `sync set-tracker-id` itself, whose
+    reload-mutate-write runs entirely inside it), reload the tracker block
+    and compare its durable/display identity against the locator this
+    invocation loaded; on drift refuse with structured CONFLICT
+    (identity_changed, the sibling subtype) BEFORE any wire call. Because the
+    relink writer holds the same lock, a relink cannot interleave with this
+    reload: it commits entirely before the recheck (detected here) or
+    entirely after it. What is deliberately NOT guaranteed: the lock is
+    released before the wire calls (locks never span network I/O anywhere in
+    this codebase), so a relink landing after a passed recheck serializes
+    strictly after it and the wire call targets the identity that was
+    current at recheck time. The claim taken above is keyed on the OLD issue
+    id, so the caller's finally releases it and no claim remains for the
+    stale key."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            loaded = load_tracker(flow_dir, spec_id)
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, _spec, tracker = loaded
+    now = locator_of(tracker)
+    if isinstance(now, TrackerError) or now != locator:
+        now_id = tracker.get("id")
+        now_display = tracker.get("identifier")
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"spec {spec_id!r} tracker identity changed while the comment "
+            f"facade was in flight (invocation loaded "
+            f"{locator.get('display')!r}/{locator.get('durable')!r}, spec "
+            f"now has {now_display!r}/{now_id!r}); refusing to post to the "
+            "old issue; re-run the comment against the new link",
+            subtype="identity_changed",
+            details={"specId": spec_id,
+                     "transaction": dict(locator),
+                     "current": {"durable": now_id,
+                                 "display": now_display}})
+    return None
+
+
+def _project_push_comment(flow_dir: Path, spec_id: str, *,
+                          comment_text: str, evidence: str,
+                          config: dict, provider: str, event: str,
+                          execute: Execute, completed: list,
+                          statuses: list) -> Result:
+    """Post/dedup one judgment-bearing comment inside the push facade claim.
+
+    The caller already completed create/link and paired-base work. This helper
+    adds only the marker-claimed list -> optional add sequence, leaving the
+    push facade to write the single aggregate receipt for status, relations,
+    and comment together.
+    """
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, _spec, tracker = loaded
+    durable = require_durable(tracker)
+    if isinstance(durable, TrackerError):
+        return durable
+    locator = locator_of(tracker)
+    if isinstance(locator, TrackerError):
+        return locator
+
+    marker = format_marker(
+        issue=str(durable), spec_id=spec_id, event=event, evidence=evidence)
+    marker_rec_path = _comment_claim_path(
+        flow_dir, issue=str(durable), spec=spec_id, event=event,
+        evidence=evidence)
+    claimed = _claim_comment_marker(
+        flow_dir, spec_id, marker_rec_path, provider, event=event,
+        marker=marker)
+    if claimed is not None:
+        return claimed
+
+    try:
+        drift = _recheck_comment_identity(flow_dir, spec_id, locator)
+        if drift is not None:
+            return drift
+        ex = bound_executor(config, execute)
+        listed = wire_dispatch(
+            "comment-list", config, locator=locator, execute=ex)
+        if isinstance(listed, TrackerError):
+            return listed
+        comments = listed.get("comments") if isinstance(listed, dict) else None
+        if not isinstance(comments, list):
+            comments = []
+
+        if comments_have_marker(
+                comments, issue=str(durable), spec=spec_id,
+                event=event, evidence=evidence):
+            completed.append("comment-dedup")
+            statuses.append("noop")
+            return {
+                "posted": False,
+                "deduped": True,
+                "marker": marker,
+                "tracker_id": durable,
+            }
+
+        if isinstance(listed, dict) and listed.get("truncated"):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "comment dedup scan truncated at drain cap; "
+                "marker absence unproven, refusing to post",
+                subtype="dedup_truncated",
+                details={
+                    "truncated": True,
+                    "event": event,
+                    "issue": str(durable),
+                },
+            )
+
+        drift = _recheck_comment_identity(flow_dir, spec_id, locator)
+        if drift is not None:
+            return drift
+        posted_body = f"{marker}\n\n{comment_text}"
+        added = wire_dispatch(
+            "comment-add", config, locator=locator, body=posted_body,
+            execute=ex)
+        if isinstance(added, TrackerError):
+            return added
+        completed.append("comment-add")
+        statuses.append("updated")
+        return {
+            "posted": True,
+            "deduped": False,
+            "marker": marker,
+            "comment": added,
+            "tracker_id": durable,
+        }
+    finally:
+        _release_claim(marker_rec_path)
+
+
+def op_comment(flow_dir: Path, spec_id: str, *, body_file: str, event: str,
+               execute: Execute = default_execute) -> Result:
+    config = read_config(flow_dir)
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    raw_body = read_text_file(body_file, label="--body-file")
+    if isinstance(raw_body, TrackerError):
+        return raw_body
+    evidence = require_evidence(raw_body, label="--body-file")
+    if isinstance(evidence, TrackerError):
+        return evidence
+    comment_text = strip_evidence_line(raw_body)
+
+    # One spec-identity claim across the whole create -> marker scan ->
+    # comment-add -> receipt sequence. The marker claim below is issue-keyed
+    # and starts only after create_if_unlinked(), so it cannot prevent a
+    # relink from redirecting the remainder of a newly-created comment facade
+    # to another issue. The outer facade claim is spec-keyed and is honored by
+    # set-tracker-id.
+    facade_rec_path = _facade_claim_path(flow_dir, spec_id)
+    claimed = _claim_facade(flow_dir, spec_id, facade_rec_path, provider,
+                            op="facade-comment")
+    if claimed is not None:
+        return claimed
+    try:
+        return _comment_sequence(
+            flow_dir, spec_id, comment_text=comment_text, evidence=evidence,
+            config=config, provider=provider, event=event, execute=execute)
+    finally:
+        _release_claim(facade_rec_path)
+
+
+def _comment_sequence(flow_dir: Path, spec_id: str, *, comment_text: str,
+                      evidence: str, config: dict, provider: str, event: str,
+                      execute: Execute) -> Result:
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec_data, tracker = loaded
+    title = str(spec_data.get("title") or spec_id)
+
+    # Create body: local md when present, else the comment text (never compose).
+    create_body = local_spec_md(flow_dir, spec_id)
+    if isinstance(create_body, TrackerError):
+        create_body = comment_text
+
+    completed: list = []
+    statuses: list = []
+    degraded = None
+    steps: dict[str, Any] = {}
+
+    created = create_if_unlinked(
+        flow_dir, spec_id, title=title, body=create_body,
+        flow_body=create_body, config=config,
+        event=event, execute=execute, completed=completed, statuses=statuses,
+    )
+    if isinstance(created, TrackerError):
+        return _fail_if_evidence(
+            created, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider,
+        )
+    steps["create"] = created
+    degraded = collect_degraded(created) or degraded
+
+    # After a landed create, the reload/durable/locator failures below are
+    # partial successes too - the same receipt discipline applies.
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return _fail_if_evidence(
+            loaded, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider, degraded=degraded,
+        )
+    _path, _spec, tracker = loaded
+
+    # MCP create continuation persists the durable identity outside this
+    # facade, so create_if_unlinked correctly no-ops on the retry but no body
+    # ancestor exists yet. A comment must repair that explicit baseless state
+    # before list/add; otherwise a later reconcile can overwrite an intervening
+    # tracker edit through the no-base bootstrap.
+    if (tracker.get("mergeBaseFlow") is None
+            or tracker.get("mergeBaseTracker") is None):
+        seeded = sync_body(
+            flow_dir, spec_id, flow_file_body=create_body, direction="pull",
+            event=event, execute=execute, write_receipt=False,
+        )
+        if isinstance(seeded, TrackerError):
+            return fail_result(
+                seeded, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=tracker.get("id"), transport=provider,
+                degraded=degraded,
+            )
+        if "paired-base" not in completed:
+            completed.append("paired-base")
+            statuses.append(step_status_from_sync_body(seeded))
+        steps["paired_base"] = seeded
+
+    durable = require_durable(tracker)
+    if isinstance(durable, TrackerError):
+        return _fail_if_evidence(
+            durable, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider, tracker_id=tracker.get("id"),
+            degraded=degraded,
+        )
+    locator = locator_of(tracker)
+    if isinstance(locator, TrackerError):
+        return _fail_if_evidence(
+            locator, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            transport=provider, tracker_id=tracker.get("id"),
+            degraded=degraded,
+        )
+
+    # Serialize the whole list-then-create sequence behind a local marker
+    # claim taken BEFORE the scan: the providers do not make it atomic, so
+    # two concurrent facades could both prove marker absence and both post.
+    marker = format_marker(
+        issue=str(durable), spec_id=spec_id, event=event, evidence=evidence)
+    marker_rec_path = _comment_claim_path(
+        flow_dir, issue=str(durable), spec=spec_id, event=event,
+        evidence=evidence)
+    claimed = _claim_comment_marker(
+        flow_dir, spec_id, marker_rec_path, provider, event=event,
+        marker=marker)
+    if claimed is not None:
+        return fail_result(
+            claimed, completed=completed, statuses=statuses,
+            flow_dir=flow_dir, spec_id=spec_id, event=event,
+            tracker_id=durable, transport=provider, degraded=degraded,
+        )
+    try:
+        # `sync set-tracker-id` can repoint the spec between the locator
+        # load above and here; the marker claim does not coordinate with the
+        # link writer. Revalidate the spec identity before any wire call so
+        # the post (and the receipt's tracker id) never targets the old
+        # issue; the finally below releases the now-stale-keyed claim. The
+        # relink writer holds the same lock, so it cannot interleave with
+        # this recheck - it lands wholly before (refused here) or wholly
+        # after (re-checked again just before comment-add below).
+        drift = _recheck_comment_identity(flow_dir, spec_id, locator)
+        if drift is not None:
+            return _fail_if_evidence(
+                drift, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                transport=provider, tracker_id=str(durable),
+                degraded=degraded,
+            )
+        ex = bound_executor(config, execute)
+        listed = wire_dispatch(
+            "comment-list", config, locator=locator, execute=ex)
+        if isinstance(listed, TrackerError):
+            return fail_result(
+                listed, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=durable, transport=provider, degraded=degraded,
+            )
+        comments = listed.get("comments") if isinstance(listed, dict) else None
+        if not isinstance(comments, list):
+            comments = []
+
+        if comments_have_marker(comments, issue=str(durable), spec=spec_id,
+                                event=event, evidence=evidence):
+            completed.append("comment-dedup")
+            statuses.append("noop")
+            receipt_status = worst_status(statuses)
+            rerr = write_aggregate_receipt(
+                flow_dir, spec_id=spec_id, event=event, status=receipt_status,
+                tracker_id=durable, transport=provider, degraded=degraded,
+                note=f"facade comment dedup ({event}/{evidence})",
+            )
+            if rerr:
+                return fail_result(
+                    rerr, completed=completed, statuses=statuses,
+                    flow_dir=flow_dir, spec_id=spec_id, event=event,
+                    tracker_id=durable, transport=provider,
+                    degraded=degraded,
+                )
+            return ok_result({
+                "op": "comment",
+                "posted": False,
+                "deduped": True,
+                "marker": marker,
+                "steps": steps,
+                "tracker_id": durable,
+            }, statuses=statuses, completed=completed, degraded=degraded)
+
+        # Marker not found - but a truncated scan proves nothing about
+        # absence. Posting here would duplicate on high-comment issues;
+        # refuse instead (same contract as relate's truncated drain:
+        # absence unproven).
+        if isinstance(listed, dict) and listed.get("truncated"):
+            return fail_result(
+                TrackerError(
+                    ErrorClass.TRANSPORT,
+                    "comment dedup scan truncated at drain cap; "
+                    "marker absence unproven, refusing to post",
+                    subtype="dedup_truncated",
+                    details={"truncated": True, "event": event,
+                             "issue": str(durable)},
+                ),
+                completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=durable, transport=provider, degraded=degraded,
+            )
+
+        # Last locked recheck before the mutating wire call: the dedup scan
+        # above is network I/O, so a relink can land while it runs. Re-read
+        # the spec identity under the lock immediately before posting; the
+        # residual window is recheck-to-add only (a relink there serializes
+        # strictly after this check - locks never span network I/O).
+        drift = _recheck_comment_identity(flow_dir, spec_id, locator)
+        if drift is not None:
+            return _fail_if_evidence(
+                drift, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                transport=provider, tracker_id=str(durable),
+                degraded=degraded,
+            )
+
+        posted_body = f"{marker}\n\n{comment_text}"
+        added = wire_dispatch(
+            "comment-add", config, locator=locator, body=posted_body,
+            execute=ex)
+        if isinstance(added, TrackerError):
+            return fail_result(
+                added, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=durable, transport=provider, degraded=degraded,
+            )
+        completed.append("comment-add")
+        statuses.append("updated")
+        steps["comment_add"] = added
+
+        receipt_status = worst_status(statuses)
+        rerr = write_aggregate_receipt(
+            flow_dir, spec_id=spec_id, event=event, status=receipt_status,
+            tracker_id=durable, transport=provider, degraded=degraded,
+            note=f"facade comment ({event})",
+        )
+        if rerr:
+            return fail_result(
+                rerr, completed=completed, statuses=statuses,
+                flow_dir=flow_dir, spec_id=spec_id, event=event,
+                tracker_id=durable, transport=provider, degraded=degraded,
+            )
+
+        return ok_result({
+            "op": "comment",
+            "posted": True,
+            "deduped": False,
+            "marker": marker,
+            "comment": added,
+            "steps": steps,
+            "tracker_id": durable,
+        }, statuses=statuses, completed=completed, degraded=degraded)
+    finally:
+        # Release OUR pending claim on every exit (posted, dedup noop,
+        # refusal, transport failure): the remote marker is the durable
+        # dedup record, and a lingering claim would only force the next
+        # invocation to wait out the stale window.
+        _release_claim(marker_rec_path)

--- a/.flow/bin/flowctl_tracker/facade/projections.py
+++ b/.flow/bin/flowctl_tracker/facade/projections.py
@@ -1,0 +1,279 @@
+"""Deterministic pull-side projections owned by the lifecycle facade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from ..config_lock import ConfigLockTimeout, config_lock
+from ..lifecycle.helpers import (Execute, Result, atomic_write_json, dict_,
+                                 load_spec, merged_tracker, now_iso)
+from ..types import ErrorClass, TrackerError
+from ..wire import (_PAGE_SIZE, _destination, _gh_repo, _gl_project, _jira,
+                    _jira_base, _rest_drain, github, gitlab, linear)
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _error_data(err: TrackerError) -> dict:
+    return {
+        "class": err.cls.value,
+        "subtype": err.subtype,
+        "message": err.message,
+        "details": err.details,
+    }
+
+
+def _ready_state(config: dict) -> str | None:
+    value = dict_(config.get("tracker")).get("readyState")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _status_name(provider: str, issue: dict) -> str | None:
+    raw = issue.get("raw") if isinstance(issue.get("raw"), dict) else {}
+    if provider == "linear":
+        state = raw.get("state") if isinstance(raw.get("state"), dict) else {}
+        value = state.get("name")
+    elif provider == "jira":
+        fields = raw.get("fields") if isinstance(raw.get("fields"), dict) else {}
+        status = fields.get("status") if isinstance(fields.get("status"), dict) else {}
+        value = status.get("name")
+    else:
+        value = None
+    return str(value) if value is not None else None
+
+
+def _desired(provider: str, issue: dict, ready_state: str
+             ) -> bool | TrackerError:
+    if provider in {"github", "gitlab"}:
+        labels = issue.get("labels")
+        if not isinstance(labels, list):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "normalized issue labels are malformed; readiness untouched",
+                subtype="readiness_shape",
+            )
+        return _norm(ready_state) in {_norm(label) for label in labels}
+    status_name = _status_name(provider, issue)
+    if status_name is None:
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "normalized issue status is missing; readiness untouched",
+            subtype="readiness_shape",
+        )
+    return _norm(status_name) == _norm(ready_state)
+
+
+def _config_exists(provider: str, config: dict, ready_state: str,
+                   execute: Execute) -> bool | TrackerError:
+    """Prove a false match is genuine, not stale readyState config."""
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+
+    if provider == "github":
+        repo = _gh_repo(dest)
+        if isinstance(repo, TrackerError):
+            return repo
+        out = github._cli(  # noqa: SLF001 - same package transport primitive
+            execute, "github", config, "facade-readiness-exists", "GET",
+            f"repos/{repo}/labels/{quote(ready_state, safe='')}",
+            idempotent=True,
+        )
+        if isinstance(out, TrackerError):
+            if out.cls is ErrorClass.NOT_FOUND:
+                return False
+            return out
+        return isinstance(out, dict) and _norm(out.get("name")) == _norm(ready_state)
+
+    if provider == "gitlab":
+        project = _gl_project(dest)
+        if isinstance(project, TrackerError):
+            return project
+        def fetch_labels_page(page: int) -> Result:
+            query = urlencode({
+                'search': ready_state,
+                'per_page': _PAGE_SIZE,
+                'page': page,
+            })
+            return gitlab._cli(  # noqa: SLF001 - package transport primitive
+                execute, "gitlab", config, "facade-readiness-exists", "GET",
+                f"projects/{project}/labels?{query}", idempotent=True,
+            )
+
+        drained = _rest_drain(fetch_labels_page)
+        if isinstance(drained, TrackerError):
+            return drained
+        labels, truncated = drained
+        exists = any(
+            isinstance(label, dict)
+            and _norm(label.get("name")) == _norm(ready_state)
+            for label in labels
+        )
+        if exists:
+            return True
+        if truncated:
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "gitlab labels pages truncated at drain cap; readyState "
+                "absence unproven",
+                subtype="readiness_truncated",
+            )
+        return False
+
+    if provider == "linear":
+        team_id = dest.get("teamId")
+        if not isinstance(team_id, str) or not team_id:
+            return TrackerError(
+                ErrorClass.UNRESOLVED, "linear destination missing teamId",
+                subtype="destination")
+        out = linear._gql(  # noqa: SLF001 - same package transport primitive
+            execute, "facade-readiness-exists",
+            "query($team: ID!) { workflowStates(first: 100, "
+            "filter: { team: { id: { eq: $team } } }) { "
+            "nodes { name } pageInfo { hasNextPage } } }",
+            {"team": team_id}, idempotent=True,
+        )
+        if isinstance(out, TrackerError):
+            return out
+        conn = out.get("workflowStates") if isinstance(out, dict) else None
+        if not isinstance(conn, dict) or not isinstance(conn.get("nodes"), list):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "linear workflow states response is malformed",
+                subtype="readiness_shape")
+        page = conn.get("pageInfo") if isinstance(conn.get("pageInfo"), dict) else {}
+        if page.get("hasNextPage"):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "linear workflow states listing is truncated; readiness untouched",
+                subtype="readiness_truncated")
+        return any(
+            isinstance(state, dict)
+            and _norm(state.get("name")) == _norm(ready_state)
+            for state in conn["nodes"]
+        )
+
+    if provider == "jira":
+        project = dest.get("projectKey")
+        if not isinstance(project, str) or not project:
+            return TrackerError(
+                ErrorClass.UNRESOLVED, "jira destination missing projectKey",
+                subtype="destination")
+        base = _jira_base(config, dest)
+        if isinstance(base, TrackerError):
+            return base
+        api_version = dest.get("apiVersion") or 2
+        out = _jira(
+            execute, "facade-readiness-exists", "GET",
+            f"{base}/rest/api/{api_version}/project/"
+            f"{quote(project, safe='')}/statuses",
+            idempotent=True,
+        )
+        if isinstance(out, TrackerError):
+            return out
+        if not isinstance(out, list):
+            return TrackerError(
+                ErrorClass.TRANSPORT, "jira project statuses response is malformed",
+                subtype="readiness_shape")
+        names = {
+            _norm(status.get("name"))
+            for issue_type in out if isinstance(issue_type, dict)
+            for status in (
+                issue_type.get("statuses")
+                if isinstance(issue_type.get("statuses"), list) else []
+            )
+            if isinstance(status, dict)
+        }
+        return _norm(ready_state) in names
+
+    return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+
+def _persist_ready(flow_dir: Path, spec_id: str, *, desired: bool,
+                   expected_id: str | None, expected_identifier: str | None
+                   ) -> Result:
+    try:
+        with config_lock(flow_dir):
+            loaded = load_spec(flow_dir, spec_id)
+            if isinstance(loaded, TrackerError):
+                return loaded
+            path, spec = loaded
+            tracker = merged_tracker(spec)
+            if (tracker.get("id") != expected_id
+                    or tracker.get("identifier") != expected_identifier):
+                return TrackerError(
+                    ErrorClass.CONFLICT,
+                    "tracker identity changed during readiness projection",
+                    subtype="identity_drift",
+                    details={
+                        "expected": {
+                            "id": expected_id,
+                            "identifier": expected_identifier,
+                        },
+                        "found": {
+                            "id": tracker.get("id"),
+                            "identifier": tracker.get("identifier"),
+                        },
+                    },
+                )
+            changed = bool(spec.get("ready", False)) != desired
+            if changed:
+                spec = dict(spec)
+                spec["ready"] = desired
+                spec["updated_at"] = now_iso()
+                err = atomic_write_json(path, spec)
+                if err:
+                    return err
+            return {"kind": "updated" if changed else "noop",
+                    "ready": desired, "changed": changed}
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+def project_readiness(flow_dir: Path, spec_id: str, *, issue: dict,
+                      config: dict, provider: str, locator: dict,
+                      execute: Execute) -> dict:
+    """Project readyState without aborting body/status/comment reconciliation."""
+    ready_state = _ready_state(config)
+    if ready_state is None:
+        return {"kind": "skipped", "reason": "readyState_unset"}
+
+    desired = _desired(provider, issue, ready_state)
+    if isinstance(desired, TrackerError):
+        return {"kind": "noop", "reason": "unreadable_issue",
+                "degraded": _error_data(desired)}
+
+    if not desired:
+        exists = _config_exists(provider, config, ready_state, execute)
+        if isinstance(exists, TrackerError):
+            return {"kind": "noop", "reason": "readiness_probe_failed",
+                    "degraded": _error_data(exists)}
+        if not exists:
+            return {
+                "kind": "noop",
+                "reason": "stale_readyState",
+                "readyState": ready_state,
+                "degraded": {
+                    "kind": "stale_readyState",
+                    "message": (
+                        f"configured readyState {ready_state!r} was not found; "
+                        "local ready flag untouched"
+                    ),
+                },
+            }
+
+    out = _persist_ready(
+        flow_dir, spec_id, desired=bool(desired),
+        expected_id=locator.get("durable"),
+        expected_identifier=locator.get("display"),
+    )
+    if isinstance(out, TrackerError):
+        return {"kind": "noop", "reason": "readiness_write_failed",
+                "degraded": _error_data(out)}
+    return {**out, "readyState": ready_state}

--- a/.flow/bin/flowctl_tracker/facade/steps.py
+++ b/.flow/bin/flowctl_tracker/facade/steps.py
@@ -1,0 +1,136 @@
+"""Shared step helpers for facade ops (fn-140.7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from ..lifecycle.helpers import Execute, Result
+from ..lifecycle.verbs import create as lifecycle_create
+from ..status.verb import status as status_verb
+from ..types import ErrorClass, TrackerError
+from .helpers import (compute_status_to, link_state_of, load_tracker,
+                      on_mcp_rung, step_status_from_status, worst_status,
+                      write_aggregate_receipt)
+
+
+def ok_result(data: dict, *, statuses: list, completed: list,
+              degraded: Optional[dict] = None) -> dict:
+    data = dict(data)
+    data["completed_steps"] = list(completed)
+    data["receipt_status"] = worst_status(statuses)
+    if degraded is not None:
+        data["degraded"] = degraded
+    return data
+
+
+def fail_result(err: TrackerError, *, completed: list,
+                statuses: Optional[list] = None,
+                flow_dir: Optional[Path] = None, spec_id: Optional[str] = None,
+                event: Optional[str] = None, tracker_id: Optional[str] = None,
+                transport: Optional[str] = None,
+                degraded: Optional[dict] = None) -> TrackerError:
+    """Attach completed_steps; write ONE aggregate receipt on partial success."""
+    details = dict(err.details or {})
+    prior = list(details.get("completed_steps") or [])
+    merged = list(completed)
+    for step in prior:
+        if step not in merged:
+            merged.append(step)
+    details["completed_steps"] = merged
+    rank_statuses = list(statuses or []) + ["errored"]
+    receipt_status = worst_status(rank_statuses)
+    details["receipt_status"] = receipt_status
+    if flow_dir is not None and spec_id and event:
+        rerr = write_aggregate_receipt(
+            flow_dir, spec_id=spec_id, event=event, status=receipt_status,
+            tracker_id=tracker_id, transport=transport, degraded=degraded,
+            note=f"facade partial ({', '.join(merged)})",
+            # The error's structured details ride into the receipt verbatim
+            # (completed_steps, created identity) - durable evidence of what
+            # landed, so an automated retry is not flying blind.
+            details=details,
+        )
+        if rerr is not None:
+            # The remote mutation landed but the receipt write itself failed:
+            # ZERO receipts exist for this event, so sync check will report
+            # the lifecycle event missing. Say so honestly - receipt_status
+            # "errored" would claim an errored receipt was written. The
+            # original error, completed_steps and identity evidence stay
+            # verbatim; the write failure rides alongside, structured.
+            details["receipt_status"] = "unwritten"
+            details["receipt_write_failed"] = {
+                "class": rerr.cls.value,
+                "subtype": rerr.subtype,
+                "message": rerr.message,
+            }
+    return TrackerError(
+        err.cls, err.message, subtype=err.subtype,
+        details=details, auto_retryable=err.auto_retryable,
+        retry_after_s=err.retry_after_s,
+    )
+
+
+def create_if_unlinked(flow_dir: Path, spec_id: str, *, title: str, body: str,
+                       flow_body: str,
+                       config: dict, event: str, execute: Execute,
+                       completed: list, statuses: list) -> Result:
+    """No-op when linked/identifier_only; create + seed when unlinked.
+
+    MCP rung + unlinked → external_action_required (no tracker request).
+
+    A landed create is not complete until a fresh server readback seeds both
+    merge-base halves atomically. In particular, comment-first and
+    reconcile-first have no later body write that can safely establish the
+    ancestor before a tracker-side edit occurs.
+    """
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, _spec, tracker = loaded
+    state = link_state_of(tracker)
+    if state != "unlinked":
+        return {"kind": "already_linked", "linkState": state,
+                "id": tracker.get("id"), "identifier": tracker.get("identifier")}
+
+    if on_mcp_rung(config):
+        return TrackerError(
+            ErrorClass.EXTERNAL_ACTION_REQUIRED,
+            "Linear MCP rung: agent must create the issue, then "
+            "persist-external",
+            subtype="mcp_create",
+            details={
+                "action": "create",
+                "payload": {"title": title, "body": body},
+            },
+        )
+
+    out = lifecycle_create(
+        flow_dir, spec_id, title=title, body=body, event=event,
+        flow_body=flow_body, execute=execute, write_receipt=False,
+    )
+    if isinstance(out, TrackerError):
+        return out
+    completed.append("create")
+    completed.append("paired-base")
+    statuses.append("pushed")
+    return {"kind": "created", **out}
+
+
+def run_status(flow_dir: Path, spec_id: str, *, config: dict, event: str,
+               execute: Execute, completed: list, statuses: list) -> Result:
+    """Call status with --to from flow_to_normalized. noop/defer non-fatal."""
+    loaded = load_tracker(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec_data, _tracker = loaded
+    to = compute_status_to(flow_dir, spec_id, config, spec_data, execute)
+    out = status_verb(
+        flow_dir, spec_id, to=to, event=event, execute=execute,
+        write_receipt=False,
+    )
+    if isinstance(out, TrackerError):
+        return out
+    completed.append("status")
+    statuses.append(step_status_from_status(out))
+    return out

--- a/.flow/bin/flowctl_tracker/lifecycle/__init__.py
+++ b/.flow/bin/flowctl_tracker/lifecycle/__init__.py
@@ -1,0 +1,106 @@
+"""Spec-aware create / create-first / persist-external verbs (fn-140.2).
+
+Wire verbs touch no local state. These three do: they write the spec-json
+tracker block and (except create-first) an event-tagged sync receipt under
+`.flow/sync-runs/`. create-first is the fn-134 exception — no spec yet, so
+recovery lives at `.flow/create-first/<key>.json` and there is no receipt.
+
+`linkState` is the exhaustive enum that replaces today's ambiguous
+`tracker.id: null` (= unlinked). Legacy records without the field migrate on
+read via `derive_link_state`. Commands that need a durable id call
+`require_durable`; the .7 facade's `--op reconcile` calls
+`complete_identifier_only` — there is no separate `tracker reconcile` verb.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..types import ErrorClass, TrackerError
+from .helpers import ACTIVE, Execute, dict_, read_config, tracker_type
+from .linkstate import (complete_identifier_only, derive_link_state,
+                        require_durable)
+from .verbs import (compute_create_first_key, create, create_first,
+                    persist_external)
+
+__all__ = [
+    "complete_identifier_only",
+    "compute_create_first_key",
+    "create",
+    "create_first",
+    "derive_link_state",
+    "persist_external",
+    "require_durable",
+    "run",
+]
+
+
+def run(flow_dir, verb: str, *, spec_id: Optional[str] = None,
+        title: Optional[str] = None, body_file: Optional[str] = None,
+        event: Optional[str] = None, retry_key: Optional[str] = None,
+        identifier: Optional[str] = None, durable_id: Optional[str] = None,
+        url: Optional[str] = None, source: Optional[str] = None,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """Thin envelope shell — never raises across the boundary."""
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        t = dict_(config.get("tracker")).get("type")
+        if t is not None and t not in ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}",
+                subtype="provider"))
+        return envelope.inactive()
+
+    body = None
+    if body_file is not None:
+        try:
+            body = Path(body_file).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"cannot read --body-file: {exc}",
+                subtype="body_file"))
+
+    try:
+        if verb == "create":
+            if not spec_id or title is None or body is None:
+                return envelope.failure(TrackerError(
+                    ErrorClass.INVALID_INPUT,
+                    "create requires <spec-id> --title --body-file",
+                    subtype="args"))
+            out = create(flow_dir, spec_id, title=title, body=body,
+                         event=event, execute=execute)
+        elif verb == "create-first":
+            if title is None or body is None or not retry_key:
+                return envelope.failure(TrackerError(
+                    ErrorClass.INVALID_INPUT,
+                    "create-first requires --title --body-file --retry-key",
+                    subtype="args"))
+            out = create_first(flow_dir, title=title, body=body,
+                               retry_key=retry_key, execute=execute)
+        elif verb == "persist-external":
+            if not spec_id or not identifier or not source:
+                return envelope.failure(TrackerError(
+                    ErrorClass.INVALID_INPUT,
+                    "persist-external requires <spec-id> --identifier --source",
+                    subtype="args"))
+            out = persist_external(
+                flow_dir, spec_id, identifier=identifier,
+                durable_id=durable_id, url=url, source=source,
+                execute=execute, event=event)
+        else:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown lifecycle verb {verb!r}",
+                subtype="verb"))
+    except Exception as exc:  # noqa: BLE001 - boundary must never raise
+        return envelope.failure(TrackerError(
+            ErrorClass.TRANSPORT, f"lifecycle verb raised: {exc}",
+            subtype="unexpected"))
+
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/lifecycle/helpers.py
+++ b/.flow/bin/flowctl_tracker/lifecycle/helpers.py
@@ -1,0 +1,287 @@
+"""Shared plumbing for lifecycle verbs (fn-140.2). Never raises across the boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+from ..types import ErrorClass, Request, Response, TrackerError
+
+Result = Union[dict, TrackerError]
+Execute = Callable[[Request], Union[Response, TrackerError]]
+
+ACTIVE = frozenset({"github", "gitlab", "linear", "jira"})
+LINK_STATES = frozenset({"unlinked", "identifier_only", "linked"})
+CREATE_FIRST_KEY_RE = re.compile(r"[0-9a-f]{16}")
+
+#: Spec ids are lowercase slug tokens (fn-12, fn-12-add-auth, wor-17-slug).
+#: The shape gate is the FIRST containment defence: "../../victim" reproduced
+#: an arbitrary-file overwrite before this existed.
+SPEC_ID_RE = re.compile(r"^[a-z][a-z0-9]*-[0-9]+(?:-[a-z0-9][a-z0-9-]*)?$")
+
+
+def validate_spec_id(spec_id) -> Optional[TrackerError]:
+    if not isinstance(spec_id, str) or not SPEC_ID_RE.fullmatch(spec_id):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"invalid spec id {spec_id!r}",
+                            subtype="spec_id")
+    return None
+
+
+def leaf_is_safe(base_dir: Path, leaf: Path) -> Optional[TrackerError]:
+    """Containment + no-follow, mirroring flowctl's _flow_leaf_is_safe policy:
+    the leaf must resolve INSIDE base_dir and no component below base_dir may
+    be a symlink (a committed symlink at `.flow/create-first` or a spec leaf
+    redirected the write out of tree - reproduced)."""
+    import stat as stat_mod
+    try:
+        base_real = base_dir.resolve()
+        target_real = leaf.resolve()
+    except OSError:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"unresolvable path {leaf}", subtype="path")
+    if base_real != target_real and base_real not in target_real.parents:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"{leaf} escapes {base_dir}", subtype="path")
+    probe = leaf
+    while True:
+        try:
+            st = os.lstat(probe)
+            if stat_mod.S_ISLNK(st.st_mode):
+                return TrackerError(ErrorClass.INVALID_INPUT,
+                                    f"{probe} is a symlink; refusing to write "
+                                    "through it", subtype="path")
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+        if probe == base_dir or probe.parent == probe:
+            break
+        probe = probe.parent
+    return None
+
+
+def dict_(value: Any) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def tracker_type(config: dict) -> Optional[str]:
+    t = dict_(config.get("tracker")).get("type")
+    return t if t in ACTIVE else None
+
+
+def destination(config: dict) -> Union[dict, TrackerError]:
+    dest = dict_(dict_(dict_(config.get("tracker")).get("resolved")).get("destination"))
+    if not dest:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "no resolved destination; run `flowctl tracker resolve` first",
+                            subtype="destination")
+    return dest
+
+
+def read_config(flow_dir: Path) -> dict:
+    try:
+        data = json.loads((Path(flow_dir) / "config.json").read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def atomic_write_json(path: Path, data: dict) -> Optional[TrackerError]:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
+                f.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+            os.replace(tmp, path)
+        except Exception:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+        return None
+    except OSError as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"atomic write failed: {exc}",
+                            subtype="write")
+
+
+def default_tracker() -> dict:
+    return {
+        "id": None, "identifier": None, "url": None, "lastSyncedAt": None,
+        "baseHashFlow": None, "baseHashTracker": None,
+        "mergeBaseFlow": None, "mergeBaseTracker": None,
+        "depRelations": [], "linkState": "unlinked",
+    }
+
+
+def derive_link_state(tracker_block: Any) -> str:
+    """LEGACY MIGRATION read. Explicit linkState wins; else migrate."""
+    block = dict_(tracker_block)
+    explicit = block.get("linkState")
+    if isinstance(explicit, str) and explicit in LINK_STATES:
+        return explicit
+    durable = block.get("id")
+    ident = block.get("identifier")
+    if durable is not None and str(durable).strip() != "":
+        return "linked"
+    if ident is not None and str(ident).strip() != "":
+        return "identifier_only"
+    return "unlinked"
+
+
+def merged_tracker(spec_data: Any) -> dict:
+    """Spec tracker block with schema defaults filled in.
+
+    linkState is derived from the RAW block, not defaulted: a legacy record
+    that predates the field ({"id": ..., "identifier": ...}) must migrate to
+    linked/identifier_only, and merging the explicit "unlinked" default first
+    would defeat derive_link_state's migration read (reproduced by review:
+    create duplicated the issue; status/relate/sync-body rejected the link)."""
+    raw = dict_(dict_(spec_data).get("tracker"))
+    merged = {**default_tracker(), **raw}
+    merged["linkState"] = derive_link_state(raw)
+    return merged
+
+
+def spec_path(flow_dir: Path, spec_id: str) -> Path:
+    return Path(flow_dir) / "specs" / f"{spec_id}.json"
+
+
+def load_spec(flow_dir: Path, spec_id: str) -> Union[tuple[Path, dict], TrackerError]:
+    bad = validate_spec_id(spec_id)
+    if bad:
+        return bad
+    path = spec_path(flow_dir, spec_id)
+    unsafe = leaf_is_safe(Path(flow_dir) / "specs", path)
+    if unsafe:
+        return unsafe
+    if not path.is_file():
+        return TrackerError(ErrorClass.NOT_FOUND, f"spec {spec_id!r} not found",
+                            subtype="spec")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"unreadable spec: {exc}",
+                            subtype="spec")
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.INVALID_INPUT, "spec json is not an object",
+                            subtype="spec")
+    return path, data
+
+
+def iter_tracker_states(flow_dir: Path):
+    specs = Path(flow_dir) / "specs"
+    if not specs.is_dir():
+        return
+    for path in sorted(specs.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        yield data.get("id", path.stem), dict_(data.get("tracker"))
+
+
+def collision(flow_dir: Path, durable_id: str, *, except_spec: Optional[str] = None
+              ) -> Optional[TrackerError]:
+    for owner_id, state in iter_tracker_states(flow_dir):
+        if except_spec is not None and owner_id == except_spec:
+            continue
+        if state.get("id") and str(state["id"]) == str(durable_id):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                f"Tracker id {durable_id} already linked to spec {owner_id}",
+                subtype="durable_collision",
+                details={"owner": owner_id, "durable": durable_id},
+            )
+    return None
+
+
+def write_tracker_block(path: Path, spec_data: dict, tracker: dict
+                        ) -> Optional[TrackerError]:
+    spec_data = dict(spec_data)
+    spec_data["tracker"] = tracker
+    spec_data["updated_at"] = now_iso()
+    return atomic_write_json(path, spec_data)
+
+
+def locked_tracker_write(flow_dir: Path, spec_id: str, mutate, *,
+                         collision_id: Optional[str] = None) -> Result:
+    """Reload + mutate + persist the tracker block, SERIALIZED under the
+    shared .flow writer lock (same pattern as relate._ledger_write and
+    status._persist_applied_state). The spec snapshot loaded before the
+    provider request must never be written back wholesale - that silently
+    erases a concurrent update to the same spec. `mutate` receives the
+    RELOADED merged tracker block and returns the block to persist; it must
+    touch only tracker-owned fields. `mutate` may instead return a
+    TrackerError to abort - nothing is persisted and the error propagates.
+    When `collision_id` is given, the durable-collision scan runs INSIDE this
+    critical section, atomically with the write: an unlocked pre-scan is a
+    check-then-lock race (two specs persisting the same durable id can both
+    pass the scan, then both serialized writes succeed, violating the
+    one-spec-per-durable-id invariant). Returns the persisted tracker block,
+    or a TrackerError - never raises."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            path, spec = reloaded
+            if collision_id is not None:
+                hit = collision(flow_dir, collision_id, except_spec=spec_id)
+                if hit:
+                    return hit
+            tracker = merged_tracker(spec)
+            tracker = mutate(tracker)
+            if isinstance(tracker, TrackerError):
+                return tracker
+            werr = write_tracker_block(path, spec, tracker)
+            if werr:
+                return werr
+            return tracker
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+def write_sync_receipt(flow_dir: Path, *, spec_id: str, status: str,
+                       tracker_id: Optional[str] = None,
+                       event: Optional[str] = None,
+                       transport: Optional[str] = None,
+                       note: Optional[str] = None,
+                       degraded: Optional[dict] = None,
+                       details: Optional[dict] = None) -> Optional[TrackerError]:
+    receipt = {
+        "type": "sync",
+        "id": spec_id,
+        "tracker_id": tracker_id,
+        "status": status,
+        "event": event,
+        "transport": transport,
+        "merges": [],
+        "note": note,
+        # Degradation is STRUCTURED, never a sentence in `note` (epic contract).
+        "degraded": degraded,
+        "timestamp": now_iso(),
+    }
+    if details is not None:
+        # Partial-failure evidence is STRUCTURED too: the error's details
+        # (completed_steps, created identity) verbatim, never prose in `note`.
+        receipt["details"] = details
+    runs = Path(flow_dir) / "sync-runs"
+    ts_slug = receipt["timestamp"].replace(":", "").replace("-", "").replace(".", "")
+    # Typed subject tokens (fn-135: "chart:fn-10") carry a colon, which is
+    # illegal in NTFS filenames (WinError 123). Sanitize the filename only;
+    # the receipt body keeps the exact subject id.
+    fname_id = str(spec_id).replace(":", "-")
+    return atomic_write_json(runs / f"sync-{fname_id}-{ts_slug}.json", receipt)

--- a/.flow/bin/flowctl_tracker/lifecycle/linkstate.py
+++ b/.flow/bin/flowctl_tracker/lifecycle/linkstate.py
@@ -1,0 +1,149 @@
+"""linkState enum + legacy migration + UUID completion helper (fn-140.2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Union
+
+from ..executor import execute as default_execute
+from ..types import ErrorClass, TrackerError
+# derive_link_state lives in helpers (merged_tracker needs it below the
+# defaults); re-exported here because this module is its public home.
+from .helpers import (Execute, Result, derive_link_state, dict_,
+                      load_spec, locked_tracker_write, merged_tracker,
+                      now_iso, read_config, tracker_type)
+
+
+def require_durable(tracker_block: Any) -> Union[str, TrackerError]:
+    """Messages distinguish identifier_only from unlinked."""
+    block = dict_(tracker_block)
+    state = derive_link_state(block)
+    if state == "linked":
+        durable = block.get("id")
+        if isinstance(durable, str) and durable.strip():
+            return durable.strip()
+        if durable is not None and str(durable).strip():
+            return str(durable)
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "linkState is linked but tracker.id is empty",
+                            subtype="durable")
+    if state == "identifier_only":
+        return TrackerError(
+            ErrorClass.UNRESOLVED,
+            "tracker linkState is identifier_only (display identifier present, "
+            "durable id missing); run `flowctl tracker sync <spec-id> "
+            "--op reconcile` to complete the UUID",
+            subtype="identifier_only",
+        )
+    return TrackerError(
+        ErrorClass.UNRESOLVED,
+        "tracker is unlinked (no durable id and no display identifier)",
+        subtype="unlinked",
+    )
+
+
+def resolve_linear_uuid(execute: Execute, identifier: str
+                        ) -> Union[dict, TrackerError]:
+    """GraphQL issue(id:) → {id, identifier, url}. Never fabricates a UUID."""
+    from ..wire import _gql  # noqa: PLC0415
+    data = _gql(execute, "lifecycle-resolve-uuid",
+                "query($id: String!) { issue(id: $id) { id identifier url } }",
+                {"id": identifier}, idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    issue = data.get("issue")
+    if issue is None:
+        return TrackerError(ErrorClass.NOT_FOUND,
+                            f"linear issue {identifier!r} not found",
+                            subtype="issue")
+    if not isinstance(issue, dict) or not isinstance(issue.get("id"), str) or not issue["id"]:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "GraphQL issue carries no durable id",
+                            subtype="malformed_body")
+    return {
+        "id": issue["id"],
+        "identifier": issue.get("identifier") or identifier,
+        "url": issue.get("url"),
+    }
+
+
+def complete_identifier_only(flow_dir, spec_id: str, *,
+                             execute: Execute = default_execute) -> Result:
+    """Resolve UUID via GraphQL; atomically set id + linkState linked.
+
+    Helper for the .7 `tracker sync --op reconcile` facade — NOT a CLI verb.
+    """
+    flow_dir = Path(flow_dir)
+    config = read_config(flow_dir)
+    if tracker_type(config) != "linear":
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "complete_identifier_only requires tracker.type=linear",
+                            subtype="provider")
+    loaded = load_spec(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec_data = loaded
+    tracker = merged_tracker(spec_data)
+    state = derive_link_state(tracker)
+    if state == "linked" and tracker.get("id"):
+        return {"id": tracker["id"], "identifier": tracker.get("identifier"),
+                "url": tracker.get("url"), "linkState": "linked",
+                "completed": False}
+    if state != "identifier_only":
+        return TrackerError(
+            ErrorClass.UNRESOLVED,
+            f"complete_identifier_only requires identifier_only, got {state}",
+            subtype=state,
+        )
+    identifier = tracker.get("identifier")
+    if not isinstance(identifier, str) or not identifier.strip():
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "identifier_only record has empty identifier",
+                            subtype="identifier")
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+    resolved = resolve_linear_uuid(ex, identifier.strip())
+    if isinstance(resolved, TrackerError):
+        return resolved
+    link_fields = {
+        "id": resolved["id"],
+        "identifier": resolved["identifier"],
+        "linkState": "linked",
+        "lastSyncedAt": now_iso(),
+    }
+    if resolved.get("url"):
+        link_fields["url"] = resolved["url"]
+    # Persist ONLY the link-owned fields onto a spec RELOADED under the shared
+    # writer lock - the pre-resolve snapshot must never be replayed wholesale
+    # (a concurrent flowctl update to the same spec landing while the GraphQL
+    # request was in flight would be silently erased; create/persist_external
+    # follow the same reload-merge rule). The durable-collision scan runs
+    # INSIDE the same critical section via collision_id: an unlocked pre-scan
+    # is a check-then-lock race - two specs completing/persisting the same
+    # durable id could both pass it, then both serialized writes succeed.
+    def _complete(t: dict):
+        # Re-check the link state INSIDE the lock (persist_external pattern):
+        # if the tracker identity changed while the GraphQL resolve was in
+        # flight (e.g. sync set-tracker-id wrote a durable id), an
+        # unconditional merge would silently repoint the spec to the
+        # resolution result for the OLD identifier. Refuse and persist
+        # nothing; the caller re-runs against the new state.
+        state = derive_link_state(t)
+        if state == "identifier_only" and t.get("identifier") == identifier:
+            return {**t, **link_fields}
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"spec {spec_id!r} tracker changed while UUID resolution was in "
+            f"flight (now {state}, identifier={t.get('identifier')!r}); "
+            "refusing to overwrite; re-run reconcile against the new state",
+            subtype="unlinked" if state == "unlinked" else "already_linked",
+            details={"linkState": state, "identifier": t.get("identifier"),
+                     "id": t.get("id")})
+
+    persisted = locked_tracker_write(
+        flow_dir, spec_id, _complete, collision_id=resolved["id"])
+    if isinstance(persisted, TrackerError):
+        return persisted
+    return {"id": persisted["id"], "identifier": persisted["identifier"],
+            "url": persisted.get("url"), "linkState": "linked",
+            "completed": True}

--- a/.flow/bin/flowctl_tracker/lifecycle/providers.py
+++ b/.flow/bin/flowctl_tracker/lifecycle/providers.py
@@ -1,0 +1,207 @@
+"""Per-provider create → normalized {id, identifier, url} (fn-140.2)."""
+
+from __future__ import annotations
+
+from ..types import ErrorClass, TrackerError
+from .helpers import Execute, Result, destination, tracker_type
+
+
+def create_github(config: dict, execute: Execute, *, title: str, body: str
+                  ) -> Result:
+    from ..wire import _cli, _gh_repo, _github_durable  # noqa: PLC0415
+    dest = destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    raw = _cli(execute, "github", config, "lifecycle-create", "POST",
+               f"repos/{repo}/issues", body={"title": title, "body": body})
+    if isinstance(raw, TrackerError):
+        return raw
+    if not isinstance(raw, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "github create returned no object",
+                            subtype="malformed_body")
+    durable = _github_durable(raw)
+    number = raw.get("number")
+    if durable is None or number is None:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "github create missing node_id/number",
+                            subtype="malformed_body")
+    acknowledged = raw.get("body")
+    if not isinstance(acknowledged, str):
+        acknowledged = body
+    return {"id": durable, "identifier": f"#{number}",
+            "url": raw.get("html_url") or raw.get("url"),
+            "bodyWritten": acknowledged}
+
+
+def create_gitlab(config: dict, execute: Execute, *, title: str, body: str
+                  ) -> Result:
+    from ..wire import _cli, _gl_project, _gitlab_durable  # noqa: PLC0415
+    dest = destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    raw = _cli(execute, "gitlab", config, "lifecycle-create", "POST",
+               f"projects/{pid}/issues",
+               body={"title": title, "description": body})
+    if isinstance(raw, TrackerError):
+        return raw
+    if not isinstance(raw, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab create returned no object",
+                            subtype="malformed_body")
+    durable = _gitlab_durable(raw)
+    iid = raw.get("iid")
+    if durable is None or iid is None:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "gitlab create missing id/iid",
+                            subtype="malformed_body")
+    refs = raw.get("references")
+    full = refs.get("full") if isinstance(refs, dict) else None
+    if isinstance(full, str) and full:
+        ident = full
+    else:
+        path = dest.get("projectPath")
+        ident = f"{path}#{iid}" if isinstance(path, str) and path else f"#{iid}"
+    acknowledged = raw.get("description")
+    if not isinstance(acknowledged, str):
+        acknowledged = body
+    return {"id": durable, "identifier": ident, "url": raw.get("web_url"),
+            "bodyWritten": acknowledged}
+
+
+def create_linear(config: dict, execute: Execute, *, title: str, body: str
+                  ) -> Result:
+    from ..wire import _gql  # noqa: PLC0415
+    dest = destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    team_id = dest.get("teamId")
+    if not isinstance(team_id, str) or not team_id:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "linear destination missing teamId",
+                            subtype="destination")
+    data = _gql(execute, "lifecycle-create",
+                "mutation($input: IssueCreateInput!) { "
+                "issueCreate(input: $input) { success "
+                "issue { id identifier url description } } }",
+                {"input": {"teamId": team_id, "title": title, "description": body}})
+    if isinstance(data, TrackerError):
+        return data
+    payload = data.get("issueCreate")
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return TrackerError(ErrorClass.TRANSPORT, "linear issueCreate reported failure",
+                            subtype="mutation_failed")
+    issue = payload.get("issue")
+    if not isinstance(issue, dict) or not issue.get("id"):
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "linear issueCreate missing issue.id",
+                            subtype="malformed_body")
+    acknowledged = issue.get("description")
+    if not isinstance(acknowledged, str):
+        acknowledged = body
+    return {"id": issue["id"], "identifier": issue.get("identifier"),
+            "url": issue.get("url"), "bodyWritten": acknowledged}
+
+
+def create_jira(config: dict, execute: Execute, *, title: str, body: str
+                ) -> Result:
+    from ..wire import _jira, _jira_base, _jira_issue_key  # noqa: PLC0415
+    dest = destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    project_id = dest.get("projectId")
+    issue_type_id = dest.get("issueTypeId")
+    if not project_id or not issue_type_id:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "jira destination missing projectId/issueTypeId",
+                            subtype="destination")
+    # fn-140 R16 intentionally pins Jira Cloud and DC body operations to v2:
+    # resolved_cache migrates perTracker apiVersion 3 -> 2 and destination
+    # resolution emits 2. This avoids an ADF boundary in the deterministic
+    # verb surface and gives byte-identical plain-string round trips.
+    #
+    # Jira rejects fields omitted from the selected issue type's CREATE
+    # screen. Include Description by default, but omit it when createmeta
+    # positively reports a non-empty field map without `description`.
+    # Unavailable/legacy createmeta keeps the common include behavior.
+    description_settable = True
+    meta = _jira(
+        execute, "lifecycle-create-meta", "GET",
+        f"{base}/rest/api/2/issue/createmeta"
+        f"?projectIds={project_id}&issuetypeIds={issue_type_id}"
+        "&expand=projects.issuetypes.fields",
+        idempotent=True,
+    )
+    if isinstance(meta, dict):
+        for project in meta.get("projects") or []:
+            if not isinstance(project, dict):
+                continue
+            for issue_type in project.get("issuetypes") or []:
+                if (not isinstance(issue_type, dict)
+                        or str(issue_type.get("id")) != str(issue_type_id)):
+                    continue
+                fields = issue_type.get("fields")
+                if isinstance(fields, dict) and fields and "description" not in fields:
+                    description_settable = False
+                break
+    fields = {
+        "project": {"id": str(project_id)},
+        "issuetype": {"id": str(issue_type_id)},
+        "summary": title,
+    }
+    if description_settable:
+        fields["description"] = body
+    raw = _jira(execute, "lifecycle-create", "POST",
+                f"{base}/rest/api/2/issue",
+                body={"fields": fields})
+    if isinstance(raw, TrackerError):
+        return raw
+    if not isinstance(raw, dict) or raw.get("id") is None or not raw.get("key"):
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "jira create missing id/key",
+                            subtype="malformed_body")
+    # Persist the server key verbatim, including DC custom keys
+    # (MY_LONG_PROJECT_KEY-7: underscores, >10 chars). UNVERIFIED on live Jira
+    # Data Center (Cloud cannot reproduce custom keys - fn-140 R17); verified
+    # against prose only.
+    key = _jira_issue_key(str(raw["key"]))
+    if isinstance(key, TrackerError):
+        return key
+    out = {"id": str(raw["id"]), "identifier": key,
+           "url": f"{base}/browse/{key}",
+           # The paired-base seed must describe what CREATE actually wrote,
+           # not what the caller asked to write. When Description is absent
+           # from the create screen, the local body remains a pending change
+           # for the following sync-body push.
+           "bodyWritten": body if description_settable else ""}
+    if not description_settable:
+        out["seedFlowBody"] = ""
+        out["degraded"] = {
+            "kind": "jira_create_field_omitted",
+            "field": "description",
+            "reason": "not_on_create_screen",
+        }
+    return out
+
+
+_CREATE = {
+    "github": create_github,
+    "gitlab": create_gitlab,
+    "linear": create_linear,
+    "jira": create_jira,
+}
+
+
+def provider_create(config: dict, execute: Execute, *, title: str, body: str
+                    ) -> Result:
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    return _CREATE[provider](config, execute, title=title, body=body)

--- a/.flow/bin/flowctl_tracker/lifecycle/verbs.py
+++ b/.flow/bin/flowctl_tracker/lifecycle/verbs.py
@@ -1,0 +1,818 @@
+"""create / create-first / persist-external verbs (fn-140.2)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from typing import Optional
+
+from ..executor import execute as default_execute
+from ..types import ErrorClass, TrackerError
+from .helpers import (CREATE_FIRST_KEY_RE, Execute, Result, atomic_write_json,
+                      leaf_is_safe,
+                      load_spec, merged_tracker, now_iso,
+                      read_config, tracker_type, write_sync_receipt)
+from .helpers import locked_tracker_write as _locked_tracker_write
+from .linkstate import derive_link_state, resolve_linear_uuid
+from .providers import provider_create
+
+
+def _claim_spec_operation(flow_dir: Path, spec_id: str, rec_path: Path,
+                          provider: str, *, operation: str,
+                          require_unlinked: bool,
+                          title: Optional[str] = None
+                          ) -> Optional[TrackerError]:
+    """Reserve a spec identity operation under the shared writer lock.
+
+    Create requires an unlinked spec. Persist-external also uses this same
+    spec-keyed claim but permits an idempotent linked state, holding the claim
+    through its receipt so relink/clear cannot split persistence from evidence.
+
+    Two concurrent creates against the same unlinked spec could both pass the
+    unlocked linkState check and both reach the provider mutation - two
+    remote issues, the later link write orphaning the first. Under the lock:
+    the linkState is re-checked from a RELOADED spec, a live claim from
+    another process refuses (create_in_flight), and OUR pending claim lands
+    durably before any remote mutation. The CRASH window (claim written,
+    create landed, process died before the link write) stays open by spec
+    decision - this closes only the live concurrent race."""
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            _path, spec_data = reloaded
+            state = derive_link_state(merged_tracker(spec_data))
+            if require_unlinked and state != "unlinked":
+                return TrackerError(
+                    ErrorClass.CONFLICT,
+                    f"spec {spec_id!r} is already linked "
+                    f"(linkState={state!r}); refuse bare create",
+                    subtype="already_linked",
+                )
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"{prior.get('op') or operation} for spec "
+                        f"{spec_id!r} is already in flight "
+                        "in another process; retry after it finishes",
+                        subtype=("create_in_flight"
+                                 if operation == "create"
+                                 else "spec_operation_in_flight"),
+                        details={"specId": spec_id,
+                                 "claim": {"pid": prior.get("pid"),
+                                           "host": prior.get("host"),
+                                           "claimedAt": prior.get("claimedAt")}},
+                        auto_retryable=True)
+                # A STALE pending claim (crashed run) is reclaimed by
+                # overwriting it with OUR claim below - same rule as
+                # create_first.
+            claim = {"specId": spec_id, "status": "pending",
+                     "op": operation,
+                     "pid": os.getpid(), "host": socket.gethostname(),
+                     "claimedAt": time.time(), "title": title,
+                     "transport": provider}
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+    return None
+
+
+def _claim_spec_create(flow_dir: Path, spec_id: str, rec_path: Path,
+                       provider: str, title: str) -> Optional[TrackerError]:
+    return _claim_spec_operation(
+        flow_dir, spec_id, rec_path, provider,
+        operation="create", require_unlinked=True, title=title)
+
+
+def _create_transaction(flow_dir, spec_id: str, *, title: str, body: str,
+                        flow_body: Optional[str] = None,
+                        event: Optional[str] = None,
+                        execute: Execute = default_execute,
+                        write_receipt: bool = True) -> Result:
+    """Create, link, fresh-read, seed the paired base, then write one receipt."""
+    flow_dir = Path(flow_dir)
+    config = read_config(flow_dir)
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    loaded = load_spec(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    path, spec_data = loaded
+    tracker = merged_tracker(spec_data)
+    if derive_link_state(tracker) != "unlinked":
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"spec {spec_id!r} is already linked "
+            f"(linkState={derive_link_state(tracker)!r}); refuse bare create",
+            subtype="already_linked",
+        )
+    rec_path = flow_dir / "create-first" / f"spec-{spec_id}.json"
+    claimed = _claim_spec_create(flow_dir, spec_id, rec_path, provider, title)
+    if claimed is not None:
+        return claimed
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+    created = provider_create(config, ex, title=title, body=body)
+    if isinstance(created, TrackerError):
+        _release_claim(rec_path)
+        return created
+    link_fields = {
+        "id": created["id"],
+        "identifier": created["identifier"],
+        "url": created.get("url"),
+        "linkState": "linked",
+    }
+
+    def _link(t: dict):
+        # An identity that appeared concurrently (e.g. persist-external, which
+        # takes no create claim) must never be clobbered - replacing it is
+        # exactly the orphan-duplicate the claim exists to prevent. The
+        # created identity rides out via the completed-steps decoration below.
+        state = derive_link_state(t)
+        if state != "unlinked" and str(t.get("id") or "") != str(created["id"]):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                f"spec {spec_id!r} became {state} to "
+                f"{t.get('identifier')!r} while the provider create was in "
+                "flight; refusing to overwrite the existing link",
+                subtype="already_linked",
+                details={"linkState": state,
+                         "identifier": t.get("identifier")})
+        return {**t, **link_fields}
+
+    # Persist ONLY the link-owned fields onto a spec RELOADED under the shared
+    # writer lock - the pre-create snapshot must never be replayed wholesale
+    # (a concurrent flowctl update to the same spec landed while the provider
+    # request was in flight would be silently erased; status/relate/sync-body
+    # follow the same reload-merge rule). The durable-collision scan runs
+    # inside the same critical section (check-then-lock was a race).
+    err = _locked_tracker_write(
+        flow_dir, spec_id, _link, collision_id=created["id"])
+    if isinstance(err, TrackerError):
+        # The issue exists but the spec is still unlinked - a bare failure
+        # here reads as "nothing happened" and a retry would create a
+        # duplicate (the crash window itself stays open by spec decision;
+        # this is the OBSERVED-failure path, so the created identity is in
+        # hand). TrackerError is frozen: rebuild with the completed-steps
+        # detail so the caller can link the existing issue instead.
+        import dataclasses  # noqa: PLC0415
+        details = {
+            **(err.details or {}),
+            "completed_steps": ["create"],
+            "id": created["id"],
+            "identifier": created["identifier"],
+            "url": created.get("url"),
+        }
+        if created.get("degraded") is not None:
+            details["degraded"] = created["degraded"]
+        failed = dataclasses.replace(err, details=details)
+        _release_claim(rec_path)
+        return failed
+
+    # A durable link is not a completed create lifecycle until both base forms
+    # reflect one real sync point. Import locally to avoid the intentional
+    # lifecycle.verbs <-> syncbody module dependency at import time.
+    from ..syncbody import sync_body  # noqa: PLC0415
+    seed_flow_body = (
+        created.get("seedFlowBody")
+        if "seedFlowBody" in created
+        else (body if flow_body is None else flow_body)
+    )
+    seeded = sync_body(
+        flow_dir, spec_id,
+        flow_file_body=seed_flow_body,
+        expected_tracker_body=created.get("bodyWritten"),
+        direction="pull", event=event, execute=execute, write_receipt=False,
+    )
+    if isinstance(seeded, TrackerError):
+        import dataclasses  # noqa: PLC0415
+        details = {
+            **(seeded.details or {}),
+            "completed_steps": ["create", "link"],
+            "id": created["id"],
+            "identifier": created["identifier"],
+            "url": created.get("url"),
+        }
+        if created.get("degraded") is not None:
+            details["degraded"] = created["degraded"]
+        failed = dataclasses.replace(seeded, details=details)
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="errored",
+                tracker_id=created["id"], event=event, transport=provider,
+                note="create linked; paired-base seed failed",
+                degraded=created.get("degraded"),
+                details=details,
+            )
+            if rerr is not None:
+                details["receipt_status"] = "unwritten"
+                details["receipt_write_failed"] = {
+                    "class": rerr.cls.value,
+                    "subtype": rerr.subtype,
+                    "message": rerr.message,
+                }
+                failed = dataclasses.replace(failed, details=details)
+        _release_claim(rec_path)
+        return failed
+
+    if write_receipt:
+        err = write_sync_receipt(
+            flow_dir, spec_id=spec_id, status="pushed",
+            tracker_id=created["id"], event=event, transport=provider,
+            degraded=created.get("degraded"),
+        )
+        if err:
+            # The issue exists and the link IS persisted - a bare failure here
+            # would read as "nothing happened" and invite a duplicating retry.
+            # TrackerError is frozen: rebuild with the completed-steps detail.
+            import dataclasses  # noqa: PLC0415
+            details = {
+                **(err.details or {}),
+                "completed_steps": ["create", "link", "paired-base"],
+                "id": created["id"],
+                "identifier": created["identifier"],
+            }
+            if created.get("degraded") is not None:
+                details["degraded"] = created["degraded"]
+            failed = dataclasses.replace(err, details=details)
+            _release_claim(rec_path)
+            return failed
+    result = {"id": created["id"], "identifier": created["identifier"],
+              "url": created.get("url"), "linkState": "linked",
+              "paired_base": seeded}
+    if created.get("degraded") is not None:
+        result["degraded"] = created["degraded"]
+    _release_claim(rec_path)
+    return result
+
+
+def create(flow_dir, spec_id: str, *, title: str, body: str,
+           flow_body: Optional[str] = None,
+           event: Optional[str] = None,
+           execute: Execute = default_execute,
+           write_receipt: bool = True) -> Result:
+    """Create transaction with exception-safe release of its spec claim."""
+    flow_dir = Path(flow_dir)
+    rec_path = flow_dir / "create-first" / f"spec-{spec_id}.json"
+    completed = False
+    try:
+        result = _create_transaction(
+            flow_dir, spec_id, title=title, body=body, flow_body=flow_body,
+            event=event, execute=execute, write_receipt=write_receipt)
+        completed = True
+        return result
+    finally:
+        # Normal branches release themselves. Only an unexpected raise can
+        # strand OUR claim; a normal create_in_flight result may describe a
+        # same-process nested contender and must not delete the winner's claim.
+        if not completed:
+            _release_claim(rec_path)
+
+
+def compute_create_first_key(tracker_type_name: str, title: str, body: str) -> str:
+    """Identical semantics to flowctl.compute_create_first_key (fn-134)."""
+    normalized = (tracker_type_name or "").strip().lower()
+    payload = "\0".join([normalized, title or "", body or ""])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _create_first_rule_active(gitignore_text: str) -> bool:
+    """Real gitignore semantics, not a substring: `# create-first/` is a
+    comment (reproduced committable), and a later `!create-first/` negates an
+    earlier rule. Last matching line wins, exactly like git."""
+    active = False
+    for raw in gitignore_text.splitlines():
+        line = raw.strip()
+        if line in ("create-first/", "/create-first/", "create-first"):
+            active = True
+        elif line in ("!create-first/", "!/create-first/", "!create-first"):
+            active = False
+    return active
+
+
+def _ensure_create_first_ignored(flow_dir: Path):
+    """fn-134 cross-checkout safety: a COMMITTED recovery record makes another
+    checkout resume onto someone else's issue. Repos initialized before the
+    managed `create-first/` ignore pattern existed can commit it silently, so
+    the verb secures storage BEFORE any remote mutation - and aborts when it
+    cannot (a symlinked .gitignore is never written through).
+    """
+    gi = flow_dir / ".gitignore"
+    unsafe = leaf_is_safe(flow_dir, gi)
+    if unsafe:
+        return unsafe
+    try:
+        existing = gi.read_text(encoding="utf-8") if gi.is_file() else ""
+    except OSError as exc:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"cannot read .flow/.gitignore: {exc}",
+                            subtype="gitignore")
+    if _create_first_rule_active(existing):
+        return None
+    try:
+        # Appended BELOW flowctl's managed block: init's reconciliation
+        # preserves user patterns after the footer, so this survives upgrades.
+        with open(gi, "a", encoding="utf-8") as f:
+            if existing and not existing.endswith("\n"):
+                f.write("\n")
+            f.write("create-first/\n")
+    except OSError as exc:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"cannot secure .flow/.gitignore: {exc}; refusing "
+                            "to create before storage is safe",
+                            subtype="gitignore")
+    return None
+
+
+def _claim_is_stale(claim: dict, rec_path: Path) -> bool:
+    """config_lock's owner rules applied to a pending create-first claim: a
+    claim older than STALE_OWNER_S whose pid is dead ON THIS HOST is a crashed
+    run's leftover and reclaimable. Another host's pid space is unknowable
+    (shared/network checkout) - fail closed, exactly like the config lock."""
+    from ..config_lock import STALE_OWNER_S, _pid_alive  # noqa: PLC0415
+    now = time.time()
+    try:
+        claimed_at = float(claim["claimedAt"])
+        pid = int(claim["pid"])
+        host = str(claim["host"])
+    except (KeyError, TypeError, ValueError):
+        # Truncated/corrupt claim: fall back to file age (mirror config_lock's
+        # ownerless-directory rule) - refusing forever would wedge the key.
+        try:
+            return (now - rec_path.stat().st_mtime) > STALE_OWNER_S
+        except OSError:
+            return False
+    if (now - claimed_at) <= STALE_OWNER_S:
+        return False
+    if host != socket.gethostname():
+        return False
+    return not _pid_alive(pid)
+
+
+def _claim_body_mutation(flow_dir: Path, provider: str, locator: dict, *,
+                         operation: str,
+                         spec_id: Optional[str] = None) -> Path | TrackerError:
+    """Serialize whole issue-body read/replace transactions per remote issue.
+
+    ``sync-body``, direct wire body updates, and GitLab ``relate`` can all read
+    the current body and later replace it wholesale. Their operation/identity
+    claims have different purposes and deliberately do not exclude one another,
+    so none protects this shared remote resource. Key by provider + durable id,
+    not spec id: two force-aliased specs targeting one issue must serialize,
+    while unrelated issues remain concurrent.
+
+    The claim is additive: spec-aware callers retain their existing claims,
+    then take this one before the first relevant remote read and hold it through
+    readback/finalization. It is fail-fast (never waits while holding another
+    claim) and uses the same stale-owner rules as every create-first claim.
+    """
+    durable = locator.get("durable") if isinstance(locator, dict) else None
+    display = locator.get("display") if isinstance(locator, dict) else None
+    if not isinstance(durable, str) or not durable.strip():
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "body mutation claim requires locator.durable",
+            subtype="locator",
+        )
+    durable = durable.strip()
+    resource_hash = hashlib.sha256(
+        f"{provider}\0{durable}".encode("utf-8")).hexdigest()
+    rec_path = flow_dir / "create-first" / f"body-{resource_hash}.json"
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"{provider} body mutation for issue "
+                        f"{(display or durable)!r} is already in flight; retry "
+                        "after it finishes",
+                        subtype="body_mutation_in_flight",
+                        details={
+                            "specId": spec_id,
+                            "resource": {
+                                "provider": provider,
+                                "durable": durable,
+                                "display": display,
+                            },
+                            "claim": {
+                                "operation": prior.get("operation"),
+                                "pid": prior.get("pid"),
+                                "host": prior.get("host"),
+                                "claimedAt": prior.get("claimedAt"),
+                            },
+                        },
+                        auto_retryable=True,
+                    )
+            claim = {
+                "specId": spec_id,
+                "status": "pending",
+                "op": "body-mutation",
+                "operation": operation,
+                "resource": {
+                    "provider": provider,
+                    "durable": durable,
+                    "display": display,
+                },
+                "pid": os.getpid(),
+                "host": socket.gethostname(),
+                "claimedAt": time.time(),
+                "transport": provider,
+            }
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    return rec_path
+
+
+def _release_claim(rec_path: Path) -> None:
+    """Best-effort removal of OUR pending claim after an OBSERVED create
+    failure, restoring the record-absent state so a retry may create again.
+    Safe without the lock: while a live claim exists, every other process
+    refuses (create_in_flight) rather than touch the record path."""
+    try:
+        cur = json.loads(rec_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if (isinstance(cur, dict) and cur.get("status") == "pending"
+            and cur.get("pid") == os.getpid()
+            and cur.get("host") == socket.gethostname()):
+        try:
+            rec_path.unlink()
+        except OSError:
+            pass
+
+
+def _create_first_transaction(flow_dir, *, title: str, body: str,
+                              retry_key: str,
+                              execute: Execute = default_execute) -> Result:
+    """NO spec, NO receipt. Recovery record is the retry-dedupe guarantee."""
+    flow_dir = Path(flow_dir)
+    if not CREATE_FIRST_KEY_RE.fullmatch(retry_key or ""):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"invalid --retry-key {retry_key!r}: expected 16 hex",
+                            subtype="retry_key")
+    config = read_config(flow_dir)
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    rec_path = flow_dir / "create-first" / f"{retry_key}.json"
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    # Two concurrent create-first calls with the same retry key could both
+    # observe the record absent and both run provider_create - two remote
+    # issues, the last record write hiding the first. The retry key is CLAIMED
+    # under the shared writer lock BEFORE the remote create (relate's
+    # two-phase ledger pattern: intent lands durably first, the network call
+    # runs OUTSIDE the lock). While OUR live claim exists no other process
+    # writes the record path, so the finalize/release below need no lock.
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if isinstance(prior, dict) and prior.get("id"):
+                    out = {"id": prior["id"],
+                           "identifier": prior.get("identifier"),
+                           "url": prior.get("url"), "retried": True}
+                    if prior.get("degraded") is not None:
+                        out["degraded"] = prior["degraded"]
+                    return out
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"create-first for retry key {retry_key!r} is already "
+                        "in flight in another process; retry after it "
+                        "finishes to reuse its recorded issue",
+                        subtype="create_in_flight",
+                        details={"retryKey": retry_key,
+                                 "claim": {"pid": prior.get("pid"),
+                                           "host": prior.get("host"),
+                                           "claimedAt": prior.get("claimedAt")}},
+                        auto_retryable=True)
+                # A STALE pending claim (crashed run) is reclaimed by
+                # overwriting it with OUR claim below. The duplicate window
+                # this reopens (crash after the remote create landed but
+                # before the record write) is exactly the pre-record window
+                # that existed before claims - no new exposure.
+            claim = {"retryKey": retry_key, "status": "pending",
+                     "pid": os.getpid(), "host": socket.gethostname(),
+                     "claimedAt": time.time(), "title": title,
+                     "transport": provider}
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+    created = provider_create(config, ex, title=title, body=body)
+    if isinstance(created, TrackerError):
+        _release_claim(rec_path)
+        return created
+    record = {
+        "retryKey": retry_key,
+        "id": created["id"],
+        "identifier": created["identifier"],
+        "url": created.get("url"),
+        "title": title,
+        "createdAt": now_iso(),
+        "transport": provider,
+    }
+    if created.get("degraded") is not None:
+        record["degraded"] = created["degraded"]
+    err = atomic_write_json(rec_path, record)
+    if err:
+        # The issue exists but the claim is still pending - a bare failure
+        # would leave retries refusing (create_in_flight) until the claim
+        # goes stale, with the created identity lost. TrackerError is frozen:
+        # rebuild with the completed-steps detail so the caller can link the
+        # existing issue instead of waiting out the stale window.
+        import dataclasses  # noqa: PLC0415
+        details = {
+            **(err.details or {}),
+            "completed_steps": ["create"],
+            "id": created["id"],
+            "identifier": created["identifier"],
+            "url": created.get("url"),
+            "retryKey": retry_key,
+        }
+        if created.get("degraded") is not None:
+            details["degraded"] = created["degraded"]
+        return dataclasses.replace(err, details=details)
+    out = {"id": created["id"], "identifier": created["identifier"],
+           "url": created.get("url"), "retried": False}
+    if created.get("degraded") is not None:
+        out["degraded"] = created["degraded"]
+    return out
+
+
+def create_first(flow_dir, *, title: str, body: str, retry_key: str,
+                 execute: Execute = default_execute) -> Result:
+    """Create-first with cleanup only when an exception aborts finalization."""
+    flow_dir = Path(flow_dir)
+    rec_path = flow_dir / "create-first" / f"{retry_key}.json"
+    completed = False
+    try:
+        result = _create_first_transaction(
+            flow_dir, title=title, body=body, retry_key=retry_key,
+            execute=execute)
+        completed = True
+        return result
+    finally:
+        # A normal success replaces the pending claim with the durable retry
+        # record and must retain it. Normal error paths release themselves.
+        # Only an unexpected raise needs this final escape-hatch cleanup.
+        if not completed:
+            _release_claim(rec_path)
+
+
+def persist_external(flow_dir, spec_id: str, *, identifier: str,
+                     durable_id: Optional[str] = None, url: Optional[str] = None,
+                     source: str,
+                     execute: Execute = default_execute,
+                     event: Optional[str] = None) -> Result:
+    """Record an MCP create while holding the spec identity through receipt."""
+    flow_dir = Path(flow_dir)
+    if source != "mcp":
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"--source must be 'mcp', got {source!r}",
+                            subtype="source")
+    if not isinstance(identifier, str) or not identifier.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "--identifier is required", subtype="identifier")
+    identifier = identifier.strip()
+    config = read_config(flow_dir)
+    if tracker_type(config) != "linear":
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "persist-external requires tracker.type=linear",
+                            subtype="provider")
+    rec_path = flow_dir / "create-first" / f"spec-{spec_id}.json"
+    claimed = _claim_spec_operation(
+        flow_dir, spec_id, rec_path, "linear",
+        operation="persist-external", require_unlinked=False)
+    if claimed is not None:
+        return claimed
+    try:
+        return _persist_external_claimed(
+            flow_dir, spec_id, identifier=identifier,
+            durable_id=durable_id, url=url, execute=execute, event=event)
+    finally:
+        _release_claim(rec_path)
+
+
+def _persist_external_claimed(flow_dir: Path, spec_id: str, *,
+                              identifier: str,
+                              durable_id: Optional[str],
+                              url: Optional[str],
+                              execute: Execute,
+                              event: Optional[str]) -> Result:
+    """Claimed persist transaction; caller owns the spec claim."""
+    config = read_config(flow_dir)
+    loaded = load_spec(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    path, spec_data = loaded
+    tracker = merged_tracker(spec_data)
+
+    # Existing-link guard: persist-external may (a) link an UNLINKED spec,
+    # (b) idempotently complete/confirm the SAME identifier, and nothing else.
+    # A retry against a linked spec must never repoint it, and a resolution
+    # failure must never erase a durable id (reproduced by review: linked/old
+    # silently became identifier_only/NEW).
+    state = derive_link_state(tracker)
+    if state != "unlinked" and tracker.get("identifier") != identifier:
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"spec {spec_id!r} is already {state} to "
+            f"{tracker.get('identifier')!r}; refusing to repoint to "
+            f"{identifier!r}",
+            subtype="already_linked",
+            details={"linkState": state,
+                     "identifier": tracker.get("identifier")})
+    if state == "linked":
+        # Same identifier, durable already present: idempotent no-op success
+        # (unless the caller asserts a DIFFERENT durable - that is a conflict).
+        if durable_id and str(durable_id).strip() != str(tracker.get("id")):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                f"--id {durable_id!r} does not match the linked durable "
+                f"{tracker.get('id')!r} for {identifier!r}",
+                subtype="durable_mismatch")
+        rerr = write_sync_receipt(
+            flow_dir, spec_id=spec_id, status="pushed",
+            tracker_id=tracker.get("id"), event=event, transport="mcp",
+        )
+        if rerr:
+            return rerr
+        return {"id": tracker.get("id"), "identifier": tracker.get("identifier"),
+                "url": tracker.get("url"), "linkState": "linked",
+                "idempotent": True}
+
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+
+    resolved_id = (durable_id.strip()
+                   if isinstance(durable_id, str) and durable_id.strip() else None)
+    resolved_url = url
+    degraded = None
+    if resolved_id is None:
+        resolved = resolve_linear_uuid(ex, identifier)
+        if isinstance(resolved, TrackerError):
+            # Degrade ONLY on reachability failures. A semantic answer -
+            # not-found, auth, invalid input, conflict - is a real verdict
+            # about this identifier and must propagate unchanged, never be
+            # dressed up as "GraphQL unreachable".
+            if resolved.cls not in (ErrorClass.TRANSPORT, ErrorClass.RATE_LIMITED):
+                return resolved
+            degraded = {"kind": "identifier_only",
+                        "reason": resolved.cls.value,
+                        "identifier": identifier, "url": url}
+            tracker.update({
+                "id": None, "identifier": identifier, "url": url,
+                "linkState": "identifier_only", "lastSyncedAt": now_iso(),
+            })
+        else:
+            resolved_id = resolved["id"]
+            identifier = resolved["identifier"]
+            resolved_url = resolved.get("url") or url
+            tracker.update({
+                "id": resolved_id, "identifier": identifier, "url": resolved_url,
+                "linkState": "linked", "lastSyncedAt": now_iso(),
+            })
+    else:
+        # A caller-supplied durable is VERIFIED against GraphQL when reachable:
+        # persisting an unchecked id is how a typo becomes a wrong link. On
+        # mismatch -> conflict; GraphQL unreachable -> trust the explicit id
+        # (the caller asserted it; identifier_only would discard information).
+        check = resolve_linear_uuid(ex, identifier)
+        if isinstance(check, dict) and str(check["id"]) != str(resolved_id):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                f"--id {resolved_id!r} does not match the id GraphQL resolves "
+                f"for {identifier!r} ({check['id']!r})",
+                subtype="durable_mismatch",
+                details={"normalized": "durable", "candidates": [
+                    {"durable": resolved_id, "role": "caller"},
+                    {"durable": check["id"], "role": "graphql"},
+                ]})
+        if isinstance(check, TrackerError) and check.cls not in (
+                ErrorClass.TRANSPORT, ErrorClass.RATE_LIMITED):
+            return check
+        if isinstance(check, dict):
+            resolved_url = check.get("url") or resolved_url
+        tracker.update({
+            "id": resolved_id, "identifier": identifier, "url": resolved_url,
+            "linkState": "linked", "lastSyncedAt": now_iso(),
+        })
+
+    # Persist ONLY the link-owned fields onto a spec RELOADED under the shared
+    # writer lock - the snapshot loaded before the UUID resolve/verify request
+    # must never be replayed wholesale (a concurrent flowctl update to the
+    # same spec landed while GraphQL was in flight would be silently erased;
+    # status/relate/sync-body follow the same reload-merge rule). The
+    # durable-collision scan runs INSIDE the same critical section via
+    # collision_id: an unlocked pre-scan is a check-then-lock race - two
+    # specs persisting the same durable id could both pass it, then both
+    # serialized writes succeed.
+    owned = {key: tracker.get(key)
+             for key in ("id", "identifier", "url", "linkState", "lastSyncedAt")}
+
+    def _persist(t: dict):
+        # A link that appeared on THIS spec while GraphQL was in flight is
+        # never repointed and never downgraded: overwriting it repeats the
+        # existing-link-guard regression (linked/old silently became a new
+        # identity), and a degraded identifier_only write would erase a
+        # durable id.
+        state = derive_link_state(t)
+        if state != "unlinked" and (
+                t.get("identifier") != owned.get("identifier")
+                or (t.get("id") is not None
+                    and str(t.get("id")) != str(owned.get("id")))):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                f"spec {spec_id!r} became {state} to "
+                f"{t.get('identifier')!r} while persist-external was in "
+                "flight; refusing to overwrite the existing link",
+                subtype="already_linked",
+                details={"linkState": state,
+                         "identifier": t.get("identifier"),
+                         "id": t.get("id")})
+        return {**t, **owned}
+
+    persisted = _locked_tracker_write(
+        flow_dir, spec_id, _persist, collision_id=resolved_id)
+    if isinstance(persisted, TrackerError):
+        return persisted
+
+    # Degradation context lives EXCLUSIVELY in the structured `degraded`
+    # field (epic contract: never a sentence in `note`).
+    status = "pushed" if degraded is None else "updated"
+    err = write_sync_receipt(
+        flow_dir, spec_id=spec_id, status=status,
+        tracker_id=resolved_id, event=event, transport="mcp",
+        degraded=degraded,
+    )
+    if err:
+        # The link IS persisted - a bare failure here reads as "nothing
+        # happened", and a retry takes the state == linked idempotent return
+        # above without ever reporting the partial success. TrackerError is
+        # frozen: rebuild with the completed-steps detail so the caller holds
+        # the linked identity (mirrors the create() receipt-failure branch).
+        import dataclasses  # noqa: PLC0415
+        return dataclasses.replace(err, details={
+            **(err.details or {}),
+            "completed_steps": ["link"],
+            "id": tracker.get("id"),
+            "identifier": tracker.get("identifier"),
+            "linkState": tracker["linkState"]})
+    return {"id": tracker.get("id"), "identifier": tracker.get("identifier"),
+            "url": tracker.get("url"), "linkState": tracker["linkState"],
+            "degraded": degraded}

--- a/.flow/bin/flowctl_tracker/providers/__init__.py
+++ b/.flow/bin/flowctl_tracker/providers/__init__.py
@@ -1,0 +1,25 @@
+"""Per-provider resolution adapters (fn-139.4/.6).
+
+`resolver_for(provider)` is the dispatch the resolve verb builds on: each
+provider module exposes `resolve_destination(config, execute)` and
+`resolve_capabilities(config, execute)`; Linear/Jira additionally expose their
+ids-scope resolvers (`resolve_state_ids` / `resolve_status_ids`) and the live
+fetchers `--select` validates against. `resolver_for` on an unknown provider
+raises KeyError so a caller cannot silently half-resolve.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+__all__ = ["resolver_for"]
+
+_PROVIDERS = {"github", "gitlab", "linear", "jira"}
+
+
+def resolver_for(provider: str) -> ModuleType:
+    if provider not in _PROVIDERS:
+        raise KeyError(f"no resolver for provider {provider!r}; "
+                       f"available: {sorted(_PROVIDERS)}")
+    return import_module(f".{provider}", __name__)

--- a/.flow/bin/flowctl_tracker/providers/github.py
+++ b/.flow/bin/flowctl_tracker/providers/github.py
@@ -1,0 +1,64 @@
+"""GitHub resolution (fn-139.4).
+
+Destination is `owner` + `repo` - stable, resolved once from `gh repo view`
+(the CLI route already carries host + auth resolution this repo depends on).
+
+Capabilities are STATIC and never re-probed: GitHub has no attachment API
+(measured: `/issues/:n/uploads` -> 404), no issue-level blocked-by, a real
+`sub_issues` hierarchy API, and no issue delete (close `not_planned` only).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Union
+
+from ..types import ErrorClass, Request, Response, TrackerError
+
+#: The truth-table row, verbatim from the spec. Static: resolving capabilities
+#: is a table copy, not a network call, and there is no TTL re-probe.
+CAPABILITIES = {"attachments": False, "blockedBy": False,
+                "subIssues": True, "deleteIssue": False}
+
+
+def _json_body(resp: Response) -> Union[dict, TrackerError]:
+    try:
+        data = json.loads(resp.body or b"{}")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"malformed gh output: {exc}",
+                            subtype="malformed_body")
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gh output is not an object",
+                            subtype="malformed_body")
+    return data
+
+
+def resolve_destination(config: dict, execute: Callable) -> Union[dict, TrackerError]:
+    """`gh repo view` on the current repo -> {owner, repo}."""
+    result = execute(Request(
+        provider="github", op="resolve-destination", method="GET",
+        url_or_argv=["gh", "repo", "view", "--json", "owner,name"],
+        idempotent=True,
+    ))
+    if isinstance(result, TrackerError):
+        return result
+    data = _json_body(result)
+    if isinstance(data, TrackerError):
+        return data
+    owner_obj = data.get("owner")
+    owner = owner_obj.get("login") if isinstance(owner_obj, dict) else None
+    owner = owner if isinstance(owner, str) else None
+    repo = data.get("name")
+    repo = repo if isinstance(repo, str) else None
+    if not owner or not repo:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "gh repo view returned no owner/name; is this a "
+                            "GitHub repo with gh authenticated?",
+                            subtype="destination")
+    return {"owner": owner, "repo": repo}
+
+
+def resolve_capabilities(config: dict, execute: Callable) -> dict:
+    """Static table copy - deliberately NO network and NO `execute` use, which
+    is itself the tested contract (GitHub is never probed)."""
+    return dict(CAPABILITIES)

--- a/.flow/bin/flowctl_tracker/providers/gitlab.py
+++ b/.flow/bin/flowctl_tracker/providers/gitlab.py
@@ -1,0 +1,195 @@
+"""GitLab resolution + the tier probe (fn-139.4).
+
+Destination pins the **numeric** `projectId` (API paths take the id and the
+path changes on rename), `projectPath`, `host`, and **`namespaceId`** - the
+tier probe is `GET /namespaces/:id`, so pinning the namespace id keeps the TTL
+re-probe at exactly ONE request instead of paying a project lookup first.
+
+`blockedBy` is plan-dependent and **trials are GROUP-scoped** (measured both
+ways): a personal-namespace project stays Free even while the same user's
+group is on Ultimate, which is exactly the misleading case that produced the
+earlier "blocked issues unavailable" misdiagnosis.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Optional, Union
+from urllib.parse import quote, urlparse
+
+from ..resolved_cache import STATIC_CAPABILITIES, apply_capability_probe
+from ..types import (ErrorClass, Request, Response, TrackerError,
+                     gitlab_cli_hostname)
+
+#: Plans that unlock `is_blocked_by` (Free degrades to `relates_to` in B).
+BLOCKEDBY_PLANS = frozenset({
+    "premium", "premium_trial", "ultimate", "ultimate_trial", "gold", "silver",
+})
+
+#: Every plan value we treat as EVIDENCE. Anything else - absent, non-string,
+#: or unknown - is a failed probe, not a `blockedBy: false`: subgroup and
+#: non-owner namespace responses can simply omit this conditional billing
+#: field, and missing evidence must never read as a capability answer.
+KNOWN_PLANS = BLOCKEDBY_PLANS | frozenset({
+    "free", "bronze", "default", "opensource", "early_adopter",
+})
+
+
+def _json_body(resp: Response) -> Union[dict, TrackerError]:
+    try:
+        data = json.loads(resp.body or b"{}")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"malformed glab output: {exc}",
+                            subtype="malformed_body")
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "glab output is not an object",
+                            subtype="malformed_body")
+    return data
+
+
+def _argv(config: dict, endpoint: str) -> list[str]:
+    host = ((config.get("tracker") or {}).get("perTracker") or {}).get("host")
+    argv = ["glab", "api", endpoint]
+    if host:
+        argv += ["--hostname", gitlab_cli_hostname(str(host))]
+    return argv
+
+
+def resolve_destination(config: dict, execute: Callable) -> Union[dict, TrackerError]:
+    """`GET /projects/:url-encoded-path` -> numeric id, path, host, namespaceId.
+
+    Two rules that came out of review, not preference:
+
+    * The persisted `host` is derived from the RESPONSE (`web_url`), never
+      assumed. With `perTracker.host` unset, `glab` may resolve a self-managed
+      host from the git remote - the query then succeeds against one host while
+      a `gitlab.com` default would cache another.
+    * `namespaceId` is the **top-level (billing) namespace**. Plans live on the
+      root group, and a subgroup's own namespace can omit or misreport the
+      billing plan - pinning the subgroup id would poison every TTL re-probe.
+    """
+    per = (config.get("tracker") or {}).get("perTracker") or {}
+    path = per.get("project")
+    if not path:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "tracker.perTracker.project is not set; run the "
+                            "discovery ceremony first", subtype="destination")
+    result = execute(Request(
+        provider="gitlab", op="resolve-destination", method="GET",
+        url_or_argv=_argv(config, f"projects/{quote(str(path), safe='')}"),
+        idempotent=True,
+    ))
+    if isinstance(result, TrackerError):
+        return result
+    data = _json_body(result)
+    if isinstance(data, TrackerError):
+        return data
+    project_id = data.get("id")
+    namespace = data.get("namespace")
+    namespace = namespace if isinstance(namespace, dict) else {}
+    namespace_id = namespace.get("id")
+    if not isinstance(project_id, int) or not isinstance(namespace_id, int):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "gitlab project lookup returned no numeric "
+                            "id/namespace id", subtype="destination")
+
+    host = per.get("host")
+    if not host:
+        web_url = data.get("web_url")
+        parsed_host = urlparse(web_url).hostname if isinstance(web_url, str) else None
+        if not parsed_host:
+            return TrackerError(
+                ErrorClass.UNRESOLVED,
+                "cannot determine the GitLab host: perTracker.host is unset and "
+                "the project response carries no parseable web_url; set "
+                "tracker.perTracker.host explicitly", subtype="destination")
+        host = parsed_host
+
+    # Subgroup project: the billing namespace is the ROOT group. One extra
+    # lookup at RESOLUTION time keeps the TTL re-probe at one request.
+    full_path = namespace.get("full_path")
+    if isinstance(full_path, str) and "/" in full_path:
+        root = full_path.split("/", 1)[0]
+        root_result = execute(Request(
+            provider="gitlab", op="resolve-billing-namespace", method="GET",
+            url_or_argv=_argv(config, f"namespaces/{quote(root, safe='')}"),
+            idempotent=True,
+        ))
+        if isinstance(root_result, TrackerError):
+            return root_result
+        root_data = _json_body(root_result)
+        if isinstance(root_data, TrackerError):
+            return root_data
+        root_id = root_data.get("id")
+        if not isinstance(root_id, int):
+            return TrackerError(ErrorClass.UNRESOLVED,
+                                f"root namespace lookup for {root!r} returned "
+                                "no numeric id", subtype="destination")
+        namespace_id = root_id
+
+    return {
+        "projectId": project_id,
+        "projectPath": data.get("path_with_namespace") or str(path),
+        "host": host,
+        "namespaceId": namespace_id,
+    }
+
+
+def probe_plan(config: dict, execute: Callable,
+               namespace_id: Optional[int] = None) -> tuple[bool, Optional[str], Optional[str]]:
+    """ONE request: `GET /namespaces/:id` -> plan. Returns (ok, plan, reason).
+
+    The namespace id comes from the PINNED destination unless the caller (a
+    fresh backfill that just resolved it) passes it directly - either way the
+    TTL re-probe never pays a project lookup.
+    """
+    if namespace_id is None:
+        resolved = ((config.get("tracker") or {}).get("resolved") or {})
+        namespace_id = (resolved.get("destination") or {}).get("namespaceId")
+    if not isinstance(namespace_id, int):
+        return False, None, "no pinned namespaceId; resolve destination first"
+    result = execute(Request(
+        provider="gitlab", op="probe-plan", method="GET",
+        url_or_argv=_argv(config, f"namespaces/{namespace_id}"),
+        idempotent=True,
+    ))
+    if isinstance(result, TrackerError):
+        # A transient failure (403 included) is a FAILED PROBE, never a
+        # capability change - the caller reports it via `probe`.
+        return False, None, f"{result.cls.value}: {result.message}"
+    data = _json_body(result)
+    if isinstance(data, TrackerError):
+        return False, None, data.message
+    plan = data.get("plan")
+    if not isinstance(plan, str) or plan.lower() not in KNOWN_PLANS:
+        # A 200 with no recognizable plan is MISSING EVIDENCE, not Free.
+        return False, None, f"namespace response carries no recognized plan (got {plan!r})"
+    return True, plan, None
+
+
+def resolve_capabilities(config: dict, execute: Callable,
+                         namespace_id: Optional[int] = None) -> Union[dict, TrackerError]:
+    """Static rows + the plan-dependent `blockedBy`, from one tier probe.
+
+    Unlike a TTL re-probe (best-effort, prior value kept), a fresh CAPABILITY
+    RESOLUTION has no prior value to keep - a failed probe here is a failed
+    resolve, not a silent `blockedBy: false` (that would be exactly the false
+    `false` the absent-block rule forbids).
+    """
+    ok, plan, reason = probe_plan(config, execute, namespace_id=namespace_id)
+    if not ok:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            f"gitlab tier probe failed: {reason}",
+                            subtype="capabilities")
+    caps = dict(STATIC_CAPABILITIES["gitlab"])
+    caps["blockedBy"] = (plan or "").lower() in BLOCKEDBY_PLANS
+    caps["_source"] = {"gitlabPlan": plan}
+    return caps
+
+
+def ttl_reprobe(config: dict, execute: Callable, *, now: Optional[str] = None) -> dict:
+    """Synchronous, bounded TTL re-probe - one request, then fold the outcome
+    through `apply_capability_probe` (failed probe -> prior capability kept,
+    reported via `probe`, never `degraded`)."""
+    ok, plan, reason = probe_plan(config, execute)
+    return apply_capability_probe(config, ok=ok, plan=plan, reason=reason, now=now)

--- a/.flow/bin/flowctl_tracker/providers/jira.py
+++ b/.flow/bin/flowctl_tracker/providers/jira.py
@@ -1,0 +1,260 @@
+"""Jira resolution (fn-139.6).
+
+Destination pins `baseUrl`, `projectKey`, `projectId`, `issueTypeId`,
+`apiVersion: 2`, `style`; `statusIds` is its own scope and holds **status ids
+ONLY** - transition ids are NEVER cached (`jira.md:738`: valid only FROM the
+current status, verified live: To Do / In Progress / Done each surfaced
+different transition ids). Transition re-fetch is spec B's concern.
+
+`apiVersion` resolves to **2** by decision: v2 round-trips a plain-string body
+byte-exact on Cloud AND DC (measured), while v3 forces ADF.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Callable, Optional, Union
+from urllib.parse import quote
+
+from ..states import Assignment, assign_slots
+from ..types import ErrorClass, Request, TrackerError
+
+#: Truth-table row: everything static (attachments need the XSRF header, Blocks
+#: links work on the free tier, no sub-issues we consume, real delete).
+CAPABILITIES = {"attachments": True, "blockedBy": True,
+                "subIssues": False, "deleteIssue": True}
+
+#: statusCategory.key -> normalized slots it naturally fills. Only 3 buckets
+#: (vs Linear's 6 types), so name hints carry more weight here.
+CATEGORY_TO_SLOTS = {
+    "new": ("todo", "backlog"),
+    "indeterminate": ("in_progress", "in_review"),
+    "done": ("done", "cancelled"),
+}
+
+API_VERSION = 2
+
+#: Legacy `statusMap` normalized vocabulary (status-sync.md: `backlog, planned,
+#: in-progress, in-review, done, verified, deferred, wontfix`) -> fn-139 slots.
+#: `verified` (a second done-category status) has no slot of its own: it fills
+#: `done` only when the legacy map has no `done` entry, else it is dropped with
+#: a warning. `deferred` has no equivalent at all.
+LEGACY_KEY_MAP = {
+    "backlog": "backlog",
+    "planned": "todo",
+    "in-progress": "in_progress",
+    "in-review": "in_review",
+    "done": "done",
+    "wontfix": "cancelled",
+    # new-form keys pass through unchanged
+    "todo": "todo", "in_progress": "in_progress", "in_review": "in_review",
+    "cancelled": "cancelled", "canceled": "cancelled",
+}
+
+
+def base_url(config: dict) -> Optional[str]:
+    """`JIRA_BASE_URL` overrides the persisted value at runtime (fn-70 R8)."""
+    env = os.environ.get("JIRA_BASE_URL")
+    if env:
+        return env.rstrip("/")
+    per = (config.get("tracker") or {}).get("perTracker") or {}
+    persisted = per.get("baseUrl")
+    return str(persisted).rstrip("/") if persisted else None
+
+
+def _get(execute: Callable, op: str, url: str) -> Union[object, TrackerError]:
+    result = execute(Request(provider="jira", op=op, method="GET",
+                             url_or_argv=url, idempotent=True))
+    if isinstance(result, TrackerError):
+        return result
+    try:
+        return json.loads(result.body or b"null")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"malformed jira body: {exc}",
+                            subtype="malformed_body")
+
+
+def _project_inputs(config: dict) -> Union[tuple, TrackerError]:
+    per = (config.get("tracker") or {}).get("perTracker") or {}
+    base = base_url(config)
+    key = per.get("projectKey")
+    if not base or not key:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "tracker.perTracker.baseUrl/projectKey are not set; "
+                            "run the discovery ceremony first", subtype="destination")
+    return base, str(key)
+
+
+def _resolve_issue_type(config: dict, issue_types: list) -> Union[str, TrackerError]:
+    """Precedence, matching the existing prose: configured `perTracker.issueType`
+    -> a type named `Task` -> the project's first non-subtask type. A configured
+    value that does not resolve against the LIVE project is an ERROR, never a
+    silent fallback."""
+    types = [t for t in issue_types if isinstance(t, dict) and t.get("id")]
+    per = (config.get("tracker") or {}).get("perTracker") or {}
+    configured = per.get("issueType")
+    if configured:
+        want = str(configured).lower()
+        for t in types:
+            if str(t.get("id")) == str(configured) or str(t.get("name", "")).lower() == want:
+                return str(t["id"])
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"configured issueType {configured!r} does not resolve against the "
+            f"live project (types: {[t.get('name') for t in types]})",
+            subtype="issue_type")
+    for t in types:
+        if str(t.get("name", "")).lower() == "task" and not t.get("subtask"):
+            return str(t["id"])
+    for t in types:
+        if not t.get("subtask"):
+            return str(t["id"])
+    return TrackerError(ErrorClass.UNRESOLVED,
+                        "project has no non-subtask issue type", subtype="issue_type")
+
+
+def resolve_destination(config: dict, execute: Callable) -> Union[dict, TrackerError]:
+    inputs = _project_inputs(config)
+    if isinstance(inputs, TrackerError):
+        return inputs
+    base, key = inputs
+    data = _get(execute, "resolve-destination",
+                f"{base}/rest/api/2/project/{quote(key, safe='')}")
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict) or not data.get("id"):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            f"jira project {key!r} did not resolve",
+                            subtype="destination")
+    issue_type = _resolve_issue_type(config, data.get("issueTypes") or [])
+    if isinstance(issue_type, TrackerError):
+        return issue_type
+    # Cloud team-managed reports style "next-gen" / simplified true; classic
+    # company-managed differs in workflow/field APIs, so the enum is pinned.
+    style = "next-gen" if (data.get("style") == "next-gen"
+                           or data.get("simplified") is True) else "classic"
+    return {
+        "baseUrl": base,
+        "projectKey": key,
+        "projectId": str(data["id"]),
+        "issueTypeId": issue_type,
+        "apiVersion": API_VERSION,
+        "style": style,
+    }
+
+
+def fetch_statuses(config: dict, execute: Callable) -> Union[tuple, TrackerError]:
+    """Live statuses for the resolved issue type -> (pools, live)."""
+    inputs = _project_inputs(config)
+    if isinstance(inputs, TrackerError):
+        return inputs
+    base, key = inputs
+    data = _get(execute, "resolve-statuses",
+                f"{base}/rest/api/2/project/{quote(key, safe='')}/statuses")
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, list):
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "project statuses response is not a list",
+                            subtype="malformed_body")
+    resolved = ((config.get("tracker") or {}).get("resolved") or {})
+    issue_type_id = (resolved.get("destination") or {}).get("issueTypeId")
+    if not issue_type_id:
+        # NEVER "first entry": without the resolved issue type a Task project
+        # would happily cache the first (e.g. Story) workflow's status ids -
+        # bypassing the configured -> Task -> first-non-subtask precedence.
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "no resolved issueTypeId; resolve destination first "
+                            "(statusIds is scoped to the pinned issue type)",
+                            subtype="statusIds")
+    entry = None
+    for t in data:
+        if isinstance(t, dict) and str(t.get("id")) == str(issue_type_id):
+            entry = t
+            break
+    if entry is None:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            f"no status set for issue type {issue_type_id!r}; "
+                            "resolve destination first", subtype="statusIds")
+    pools: dict = {}
+    live: dict = {}
+    for s in entry.get("statuses") or []:
+        if not isinstance(s, dict) or not s.get("id"):
+            continue
+        sid = str(s["id"])
+        category = str(((s.get("statusCategory") or {}) if
+                        isinstance(s.get("statusCategory"), dict) else {}).get("key", ""))
+        live[sid] = {"id": sid, "name": s.get("name"), "category": category}
+        for slot in CATEGORY_TO_SLOTS.get(category, ()):
+            pools.setdefault(slot, []).append(
+                {"id": sid, "name": s.get("name"), "category": category})
+    return pools, live
+
+
+def _migrated_status_map(config: dict, live: dict) -> tuple[dict, list]:
+    """Existing `perTracker.statusMap` entries ({name}/{id}) migrate into
+    `statusIds` where they resolve to a LIVE status; dead entries are dropped
+    WITH A WARNING, never carried forward silently."""
+    per = (config.get("tracker") or {}).get("perTracker") or {}
+    status_map = per.get("statusMap")
+    if not isinstance(status_map, dict):
+        return {}, ([f"perTracker.statusMap is malformed ({type(status_map).__name__}); ignored"]
+                    if status_map not in (None, {}) else [])
+    by_name = {str(v.get("name", "")).lower(): k for k, v in live.items()
+               for v in [live[k]]}
+    migrated: dict = {}
+    warnings: list = []
+    for legacy_key, spec in status_map.items():
+        # Legacy keys use the OLD normalized vocabulary (`planned`,
+        # `in-progress`, `verified`, ...) - copying them verbatim silently
+        # ignored every real existing mapping.
+        slot = LEGACY_KEY_MAP.get(str(legacy_key))
+        if slot is None and str(legacy_key) == "verified":
+            if "done" in status_map:
+                warnings.append(
+                    "dropped statusMap entry 'verified': the fn-139 vocabulary "
+                    "has no verified slot and 'done' is already mapped")
+                continue
+            slot = "done"
+        if slot is None:
+            warnings.append(
+                f"dropped statusMap entry {legacy_key!r}: no equivalent slot in "
+                f"the fn-139 vocabulary")
+            continue
+        if not isinstance(spec, dict):
+            warnings.append(f"statusMap[{legacy_key!r}] is malformed; dropped")
+            continue
+        sid = spec.get("id")
+        if sid is not None and str(sid) in live:
+            migrated[slot] = str(sid)
+            continue
+        name = str(spec.get("name", "")).lower()
+        if name and name in by_name:
+            migrated[slot] = by_name[name]
+            continue
+        warnings.append(
+            f"dropped statusMap entry {legacy_key!r}: {spec!r} no longer "
+            "resolves to a live status")
+    return migrated, warnings
+
+
+def resolve_status_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
+    fetched = fetch_statuses(config, execute)
+    if isinstance(fetched, TrackerError):
+        return fetched
+    pools, live = fetched
+    resolved = ((config.get("tracker") or {}).get("resolved") or {})
+    existing = (resolved.get("destination") or {}).get("statusIds") or {}
+    migrated, warnings = _migrated_status_map(config, live)
+    # Prior cache entries win over the legacy statusMap (they are newer intent);
+    # both are validated against live by assign_slots.
+    seed = {**migrated, **(existing if isinstance(existing, dict) else {})}
+    assignment = assign_slots(pools, live, seed)
+    assignment.warnings = warnings + assignment.warnings
+    return assignment
+
+
+def resolve_capabilities(config: dict, execute: Callable) -> dict:
+    """Static table copy - no network, no probe, never TTL-reprobed."""
+    return dict(CAPABILITIES)

--- a/.flow/bin/flowctl_tracker/providers/linear.py
+++ b/.flow/bin/flowctl_tracker/providers/linear.py
@@ -1,0 +1,179 @@
+"""Linear resolution (fn-139.6).
+
+Destination pins `teamId`, `teamKey` and `labelIds` (label NAME, lowercased ->
+id); `stateIds` is its own scope (`destination.stateIds`) because status
+writes need a `stateId` and `type: started` maps to TWO states (In Progress,
+In Review) - a human decides that tiebreak once, via `--select`.
+
+Everything GraphQL is PAGINATED and fully drained (`pageInfo.hasNextPage`) -
+first-page-only silently loses labels/states on real workspaces.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Optional, Union
+
+from ..states import Assignment, assign_slots
+from ..types import ErrorClass, Request, TrackerError
+
+GRAPHQL_URL = "https://api.linear.app/graphql"
+
+#: Truth-table row: everything static (uploads are presigned two-step, blockedBy
+#: native, no sub-issues concept we consume, real delete). Never TTL-reprobed.
+CAPABILITIES = {"attachments": True, "blockedBy": True,
+                "subIssues": False, "deleteIssue": True}
+
+#: Linear `state.type` -> normalized slots it naturally fills. `started` is the
+#: measured one-to-many (In Progress AND In Review).
+TYPE_TO_SLOTS = {
+    "backlog": ("backlog",),
+    "unstarted": ("todo",),
+    "started": ("in_progress", "in_review"),
+    "completed": ("done",),
+    "canceled": ("cancelled",),
+}
+
+_PAGE = 100
+_MAX_PAGES = 50  # 5000 items; a generous ceiling, not a tunable
+
+
+def _gql(execute: Callable, op: str, query: str,
+         variables: dict) -> Union[dict, TrackerError]:
+    result = execute(Request(
+        provider="linear", op=op, method="POST", url_or_argv=GRAPHQL_URL,
+        headers={"Content-Type": "application/json"},
+        body=json.dumps({"query": query, "variables": variables}).encode(),
+        idempotent=True,
+    ))
+    if isinstance(result, TrackerError):
+        return result
+    try:
+        payload = json.loads(result.body or b"{}")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT, f"malformed GraphQL body: {exc}",
+                            subtype="malformed_body")
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "GraphQL response carries no data",
+                            subtype="malformed_body")
+    return data
+
+
+def _drain(execute: Callable, op: str, query: str, team_id: str,
+           connection: str) -> Union[list, TrackerError]:
+    """Fully drain one paginated team connection - never first-page-only."""
+    nodes: list = []
+    cursor: Optional[str] = None
+    seen_cursors: set = set()
+    pages = 0
+    while True:
+        pages += 1
+        if pages > _MAX_PAGES:
+            return TrackerError(ErrorClass.TRANSPORT,
+                                f"{connection} pagination exceeded {_MAX_PAGES} pages",
+                                subtype="malformed_body")
+        data = _gql(execute, op, query, {"teamId": team_id, "after": cursor})
+        if isinstance(data, TrackerError):
+            return data
+        team = data.get("team")
+        conn = (team or {}).get(connection) if isinstance(team, dict) else None
+        if not isinstance(conn, dict) or not isinstance(conn.get("nodes"), list):
+            return TrackerError(ErrorClass.TRANSPORT,
+                                f"GraphQL {connection} connection is malformed",
+                                subtype="malformed_body")
+        nodes.extend(n for n in conn["nodes"] if isinstance(n, dict))
+        page = conn.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            return nodes
+        cursor = page.get("endCursor")
+        if not cursor:
+            return TrackerError(ErrorClass.TRANSPORT,
+                                "hasNextPage without an endCursor",
+                                subtype="malformed_body")
+        if cursor in seen_cursors:
+            # A provider looping the same cursor would otherwise drive an
+            # unbounded request loop with growing memory - progress or fail.
+            return TrackerError(ErrorClass.TRANSPORT,
+                                f"pagination repeated cursor {cursor!r}",
+                                subtype="malformed_body")
+        seen_cursors.add(cursor)
+
+
+_TEAM_QUERY = "query($teamId: String!) { team(id: $teamId) { id key } }"
+_STATES_QUERY = (
+    "query($teamId: String!, $after: String) { team(id: $teamId) { "
+    f"states(first: {_PAGE}, after: $after) "
+    "{ nodes { id name type } pageInfo { hasNextPage endCursor } } } }"
+)
+_LABELS_QUERY = (
+    "query($teamId: String!, $after: String) { team(id: $teamId) { "
+    f"labels(first: {_PAGE}, after: $after) "
+    "{ nodes { id name } pageInfo { hasNextPage endCursor } } } }"
+)
+
+
+def _team_id(config: dict) -> Optional[str]:
+    per = (config.get("tracker") or {}).get("perTracker") or {}
+    return per.get("teamId")
+
+
+def resolve_destination(config: dict, execute: Callable) -> Union[dict, TrackerError]:
+    team_id = _team_id(config)
+    if not team_id:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "tracker.perTracker.teamId is not set; run the "
+                            "discovery ceremony first", subtype="destination")
+    data = _gql(execute, "resolve-destination", _TEAM_QUERY, {"teamId": team_id})
+    if isinstance(data, TrackerError):
+        return data
+    team = data.get("team")
+    if not isinstance(team, dict) or not team.get("id") or not team.get("key"):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            f"linear team {team_id!r} did not resolve",
+                            subtype="destination")
+    labels = _drain(execute, "resolve-labels", _LABELS_QUERY, team_id, "labels")
+    if isinstance(labels, TrackerError):
+        return labels
+    label_ids = {str(lbl["name"]).lower(): lbl["id"]
+                 for lbl in labels if lbl.get("name") and lbl.get("id")}
+    return {"teamId": team["id"], "teamKey": team["key"], "labelIds": label_ids}
+
+
+def fetch_states(config: dict, execute: Callable) -> Union[tuple, TrackerError]:
+    """Live states -> (pools, live). Shared by resolve and `--select` so a
+    selection is always validated against CURRENT candidates."""
+    team_id = _team_id(config)
+    if not team_id:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "tracker.perTracker.teamId is not set",
+                            subtype="stateIds")
+    states = _drain(execute, "resolve-states", _STATES_QUERY, team_id, "states")
+    if isinstance(states, TrackerError):
+        return states
+    pools: dict = {}
+    live: dict = {}
+    for s in states:
+        sid, name, stype = s.get("id"), s.get("name"), s.get("type")
+        if not sid:
+            continue
+        live[sid] = {"id": sid, "name": name, "type": stype}
+        for slot in TYPE_TO_SLOTS.get(str(stype), ()):
+            pools.setdefault(slot, []).append({"id": sid, "name": name, "type": stype})
+    return pools, live
+
+
+def resolve_state_ids(config: dict, execute: Callable) -> Union[Assignment, TrackerError]:
+    fetched = fetch_states(config, execute)
+    if isinstance(fetched, TrackerError):
+        return fetched
+    pools, live = fetched
+    existing = (((config.get("tracker") or {}).get("resolved") or {})
+                .get("destination") or {}).get("stateIds") or {}
+    return assign_slots(pools, live, existing if isinstance(existing, dict) else {},
+                        policy="linear")
+
+
+def resolve_capabilities(config: dict, execute: Callable) -> dict:
+    """Static table copy - no network, no probe, never TTL-reprobed."""
+    return dict(CAPABILITIES)

--- a/.flow/bin/flowctl_tracker/question_claim.py
+++ b/.flow/bin/flowctl_tracker/question_claim.py
@@ -1,0 +1,90 @@
+"""Transient claim for concurrency-safe stable tracker questions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from typing import Optional
+
+from .lifecycle.helpers import atomic_write_json, leaf_is_safe
+from .lifecycle.verbs import (
+    _claim_is_stale,
+    _ensure_create_first_ignored,
+    _release_claim,
+)
+from .types import ErrorClass, TrackerError
+
+
+def question_claim_path(flow_dir: Path, *, provider: str,
+                        durable: str, question_id: str) -> Path:
+    """Return the stable claim path for one provider issue + question key."""
+    payload = "\0".join([provider, durable, question_id])
+    key = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return Path(flow_dir) / "create-first" / f"question-{key}.json"
+
+
+def claim_question(flow_dir: Path, rec_path: Path, *, provider: str,
+                   durable: str, question_id: str,
+                   subject_id: str) -> Optional[TrackerError]:
+    """Serialize question list -> optional add before any remote read."""
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from .config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        "this stable tracker question is already in flight; "
+                        "retry after it finishes so the dedup scan sees the "
+                        "winner's marker",
+                        subtype="question_in_flight",
+                        details={
+                            "question_id": question_id,
+                            "durable": durable,
+                            "claim": {
+                                "pid": prior.get("pid"),
+                                "host": prior.get("host"),
+                                "claimedAt": prior.get("claimedAt"),
+                            },
+                        },
+                        auto_retryable=True,
+                    )
+            claim = {
+                "status": "pending",
+                "op": "question",
+                "provider": provider,
+                "durable": durable,
+                "question_id": question_id,
+                "subject_id": subject_id,
+                "pid": os.getpid(),
+                "host": socket.gethostname(),
+                "claimedAt": time.time(),
+            }
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(
+            ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+    return None
+
+
+def release_question_claim(rec_path: Path) -> None:
+    """Release the transient claim; the remote marker is durable evidence."""
+    _release_claim(rec_path)

--- a/.flow/bin/flowctl_tracker/relate/__init__.py
+++ b/.flow/bin/flowctl_tracker/relate/__init__.py
@@ -1,0 +1,995 @@
+"""Spec-aware `tracker relate` verb (fn-140.4).
+
+Reproduces fn-64's contract: depRelations ledger (same edge-key semantics as
+flowctl), additive-only, never-clobber-on-collision (queued + receipt, never
+overwrite). Completed blockers are PROJECTED - the relation stays visible on
+the tracker as the historical ordering (docs/tracker-sync.md fn-64 rule);
+only readiness gating excludes done deps, and that lives in flowctl's ready
+computation, not here. The 4-way ledger x remote classification runs BEFORE
+any mutation: ledger+remote noop, ledger+missing = human removal collision
+(queued, default NOT re-created), unledgered+remote = foreign-edge collision
+(queued), neither = create.
+
+GitLab writes the <!-- flow:deps --> direction/provenance twin with every
+native or degraded link and repairs it before finalizing an interrupted
+create. Its whole-description read/replace is serialized with GitLab
+sync-body and direct wire pushes by their shared remote-resource claim. Hash
+exclusion remains sync-body's concern.
+
+GitHub: native sub_issues is a HIERARCHY PROXY reported only in the structured
+degraded field - never presented as a blocked-by relation; body-block
+projection is .5's body machinery.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import (ACTIVE, Execute, Result, dict_, load_spec,
+                                 merged_tracker, read_config, tracker_type,
+                                 write_sync_receipt, write_tracker_block,
+                                 atomic_write_json, leaf_is_safe)
+from ..lifecycle.verbs import (_claim_body_mutation,
+                               _ensure_create_first_ignored, _release_claim)
+from ..types import ErrorClass, TrackerError
+from . import providers as P
+from .ledger import (blocker_completed, caps_of, claim_owner,
+                     dep_relation_key, ledger_append, ledger_entry,
+                     ledger_finalize, ledger_release, ledger_stamp_claim,
+                     require_linked_pair)
+
+__all__ = [
+    "FLOW_DEPS_CLOSE",
+    "FLOW_DEPS_OPEN",
+    "dep_relation_key",
+    "relate",
+    "run",
+]
+
+# Re-export marker constants for .5 consumers.
+from .ledger import FLOW_DEPS_CLOSE, FLOW_DEPS_OPEN  # noqa: E402, F401
+
+
+def _queue_conflict(flow_dir: Path, spec_id: str, *, summary: str,
+                    reason: str) -> Optional[TrackerError]:
+    """Append to the canonical deferred-decisions sink
+    (.flow/review-deferred/<slug>.md) - the same queue `flowctl sync defer`
+    uses, so relate collisions land where humans already look."""
+    from datetime import datetime, timezone  # noqa: PLC0415
+    sink_dir = Path(flow_dir) / "review-deferred"
+    try:
+        sink_dir.mkdir(parents=True, exist_ok=True)
+        sink = sink_dir / "tracker-relate.md"
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+        lines = []
+        if not sink.exists():
+            lines.append("# Deferred review findings - tracker-relate\n")
+        lines.append(f"\n## {ts} - tracker-sync conflict {spec_id}\n")
+        lines.append(f"- **{summary}**\n  - reason: {reason}\n"
+                     f"  - file: specs/{spec_id}.md\n")
+        with open(sink, "a", encoding="utf-8") as f:
+            f.write("".join(lines))
+    except OSError as exc:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"cannot queue conflict: {exc}", subtype="queue")
+    return None
+
+
+def _ledger_write(flow_dir: Path, spec_id: str, mutate) -> Result:
+    """Reload + mutate + persist the tracker block, SERIALIZED under the shared
+    .flow writer lock (reload alone narrowed but did not close the lost-update
+    window: two relates could reload the same pre-write state and the second
+    atomic replace dropped the first edge). Returns the persisted tracker
+    block, or a TrackerError - never raises."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            path, spec = reloaded
+            tracker = merged_tracker(spec)
+            tracker = mutate(tracker)
+            werr = write_tracker_block(path, spec, tracker)
+            if werr:
+                return werr
+            return tracker
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+#: TRANSPORT subtypes where the failed provider create is still KNOWN not to
+#: have landed: the CLI process never spawned, or the server responded and
+#: the parsed payload reported the mutation rejected (linear success!=true).
+_TRANSPORT_NOT_LANDED = frozenset({"spawn", "mutation_failed"})
+
+
+def _create_failure_not_landed(err: TrackerError) -> bool:
+    """Did the failed provider create DEFINITELY not land?
+
+    Non-TRANSPORT classes are parsed server rejections (auth, 4xx, rate
+    limit, capability, not-found, conflict) or local pre-flight refusals -
+    nothing was applied, so the pending claim may be released for an
+    immediate retry. TRANSPORT is AMBIGUOUS (timeout / read / 5xx /
+    malformed body: the request may have reached the server and the edge
+    may exist) except the subtypes above - ambiguous failures must keep the
+    pending entry so the repair path can finalize against the remote probe
+    on retry instead of duplicating the create."""
+    if "relate-create" in ((err.details or {}).get("completed_steps") or []):
+        return False
+    if err.cls is not ErrorClass.TRANSPORT:
+        return True
+    return err.subtype in _TRANSPORT_NOT_LANDED
+
+
+def _ledger_release(flow_dir: Path, spec_id: str, *, key: str) -> None:
+    """Best-effort removal of OUR pending claim after an OBSERVED provider
+    create failure known not to have landed (mirrors lifecycle's
+    _release_claim on the create-first record). Without this, the dead prior
+    pid looked live for the full STALE_OWNER_S window and ordinary immediate
+    retries failed as concurrent_claim. Never raises; on any failure the
+    pending entry simply remains and the staleness rules recover as before."""
+    out = _ledger_write(flow_dir, spec_id,
+                        lambda t: ledger_release(t, key=key))
+    # Best-effort by design: a TrackerError here is swallowed - the caller
+    # is already returning the (more informative) create failure.
+    del out
+
+
+def _pending_claim_live(entry: dict) -> bool:
+    """Is this pending entry owned by a LIVE concurrent invocation?
+
+    The owner triple ({pid, host, claimedAt}) mirrors lifecycle create-first
+    claims, judged by config_lock's owner rules: within STALE_OWNER_S the
+    claim is live; past it, a dead pid ON THIS HOST is a crashed run's
+    leftover (stale, reclaimable); another host's pid space is unknowable
+    (shared/network checkout) so we fail closed (live). Our OWN pid+host is
+    never a concurrent owner - it is this process's earlier failed attempt,
+    free to retry. Entries without the triple (wave-1 shape, or written by an
+    older version) fall back to updatedAt age: recent means possibly live,
+    old or unparsable means stale (preserving the wave-1 interrupted-run
+    retry semantics)."""
+    import os  # noqa: PLC0415
+    import socket  # noqa: PLC0415
+    import time  # noqa: PLC0415
+    from ..config_lock import STALE_OWNER_S, _pid_alive  # noqa: PLC0415
+    now = time.time()
+    try:
+        claimed_at = float(entry["claimedAt"])
+        pid = int(entry["pid"])
+        host = str(entry["host"])
+    except (KeyError, TypeError, ValueError):
+        from datetime import datetime, timezone  # noqa: PLC0415
+        raw = entry.get("updatedAt")
+        try:
+            dt = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return False
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return (now - dt.timestamp()) <= STALE_OWNER_S
+    if host == socket.gethostname() and pid == os.getpid():
+        return False
+    if (now - claimed_at) <= STALE_OWNER_S:
+        return True
+    if host != socket.gethostname():
+        return True
+    return _pid_alive(pid)
+
+
+def _concurrent_claim_error(dep_spec: str, key: str) -> TrackerError:
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"a concurrent relate invocation claimed the blocked-by "
+        f"edge to {dep_spec} first; no mutation performed by this "
+        "invocation - re-run relate after it completes to verify "
+        "or heal the ledger",
+        subtype="concurrent_claim",
+        details={"recoverable": True, "key": key})
+
+
+def _relinked_error(spec_id: str, dep_spec: str, *, expected_from: str,
+                    expected_to: str, current_from, current_to) -> TrackerError:
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"tracker link for {spec_id} or {dep_spec} changed while this relate "
+        "invocation was in flight (a spec was relinked to a different "
+        "issue); refusing to claim under the stale identity - nothing "
+        "written, no mutation performed by this invocation; re-run relate "
+        "against the current link state",
+        subtype="relinked",
+        details={"recoverable": True,
+                 "expected": {"from": expected_from, "to": expected_to},
+                 "current": {"from": current_from, "to": current_to}})
+
+
+def _claim_identity_drift(flow_dir: Path, spec_id: str, dep_spec: str, *,
+                          tracker: dict, from_id: str, to_id: str
+                          ) -> Optional[TrackerError]:
+    """Revalidate BOTH linked identities INSIDE the claim's critical section
+    (the wave-10 complete_identifier_only pattern: re-check state under the
+    lock, refuse and persist nothing on drift). The pair snapshot this
+    invocation classified against was taken BEFORE the probe and guard ran;
+    if either spec was relinked in that window, the key/from/to computed from
+    the snapshot belong to the OLD issues - claiming would attach an old-ID
+    ledger entry to the newly linked spec and then create the remote edge
+    between the old issues (orphaned relation, ledger on the wrong identity).
+    `tracker` is the caller's RELOADED tracker block for `spec_id` (already
+    loaded under the same lock); the dep spec is reloaded here. Returns a
+    CONFLICT/relinked TrackerError on drift, None when both durable ids still
+    match - never raises."""
+    current_from = tracker.get("id")
+    reloaded_dep = load_spec(flow_dir, dep_spec)
+    if isinstance(reloaded_dep, TrackerError):
+        return reloaded_dep
+    _dep_path, dep = reloaded_dep
+    current_to = merged_tracker(dep).get("id")
+    if (isinstance(current_from, str) and current_from.strip() == from_id
+            and isinstance(current_to, str)
+            and current_to.strip() == to_id):
+        return None
+    return _relinked_error(spec_id, dep_spec,
+                           expected_from=from_id, expected_to=to_id,
+                           current_from=current_from, current_to=current_to)
+
+
+def _post_probe_identity_drift(flow_dir: Path, spec_id: str, dep_spec: str, *,
+                               from_id: str, to_id: str
+                               ) -> Optional[TrackerError]:
+    """Revalidate both durable identities after the remote relation probe.
+
+    Collision branches do not take a ledger claim, yet they emit durable
+    local side effects (a deferred-review entry and a receipt). A relink can
+    land while the probe is in flight, making its result and the pre-probe
+    ledger snapshot belong to the old tracker IDs. Recheck under the shared
+    writer lock before classification can emit those side effects.
+    """
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            _path, spec = reloaded
+            return _claim_identity_drift(
+                flow_dir, spec_id, dep_spec, tracker=merged_tracker(spec),
+                from_id=from_id, to_id=to_id)
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+
+
+def _ledger_reclaim(flow_dir: Path, spec_id: str, *, key: str,
+                    dep_spec: str, from_id: str, to_id: str) -> Result:
+    """RECLAIM a stale pending entry (crashed run's leftover) by stamping OUR
+    owner triple onto it under the shared writer lock. Re-checks liveness on
+    the RELOADED entry inside the lock: if another invocation reclaimed (or
+    finalized) it since our snapshot, this invocation backs off instead of
+    issuing a duplicate create. Both linked identities are revalidated
+    against from/to first - a relink since the pair load aborts
+    (CONFLICT/relinked) rather than reclaiming a stale-identity entry.
+    Returns the persisted tracker block, or a TrackerError - never raises."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            path, spec = reloaded
+            tracker = merged_tracker(spec)
+            derr = _claim_identity_drift(flow_dir, spec_id, dep_spec,
+                                         tracker=tracker,
+                                         from_id=from_id, to_id=to_id)
+            if derr:
+                return derr
+            entry = ledger_entry(tracker, key)
+            if (entry is None or entry.get("status") != "pending"
+                    or _pending_claim_live(entry)):
+                return _concurrent_claim_error(dep_spec, key)
+            tracker = ledger_stamp_claim(tracker, key=key)
+            werr = write_tracker_block(path, spec, tracker)
+            if werr:
+                return werr
+            return tracker
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+def _ledger_finalize_guarded(flow_dir: Path, spec_id: str, dep_spec: str, *,
+                             key: str, from_id: str, to_id: str,
+                             form=None, repair: bool = False) -> Result:
+    """FINALIZE the pending entry under the shared writer lock, revalidating
+    both linked identities against the from/to this invocation claimed with
+    (the wave-11 recheck, one step later: locks never span the provider
+    mutation, so a relink can land between the claim's release and this
+    finalize - without the recheck the old-ID entry would be finalized onto
+    the newly linked spec). On drift the pending claim is REMOVED, never
+    finalized, and the returned CONFLICT/relinked carries honest evidence:
+    on the create path (repair=False) the landed remote mutation
+    (details.completed_steps + edge identity, wave-8 decoration) - the
+    create against the OLD issues cannot be un-sent, so the orphan edge is
+    surfaced for a human instead of silently recorded under the wrong
+    identity. On the REPAIR path (repair=True: a pending entry from an
+    interrupted earlier run whose edge the probe found already on the
+    tracker) THIS invocation performed no provider mutation, so the refusal
+    carries the edge identity but NO completed_steps - the remote edge
+    predates this run. Returns the persisted tracker block, or a
+    TrackerError - never raises."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            path, spec = reloaded
+            tracker = merged_tracker(spec)
+            derr = _claim_identity_drift(flow_dir, spec_id, dep_spec,
+                                         tracker=tracker,
+                                         from_id=from_id, to_id=to_id)
+            if derr is None:
+                tracker = ledger_finalize(tracker, key=key)
+                werr = write_tracker_block(path, spec, tracker)
+                if werr:
+                    return werr
+                return tracker
+            if derr.subtype != "relinked":
+                # Dep spec unreadable etc. - keep the pending entry so the
+                # repair path can finalize on retry; the caller wraps this
+                # as the recoverable ledger_finalize partial success.
+                return derr
+            # Drift: drop the pending claim (keyed by the OLD ids, so no
+            # future run of the new pair would ever match it). force=True:
+            # on the repair path the entry was claimed by an earlier
+            # interrupted run (different owner triple), and after the relink
+            # it can never be validly finalized by anyone. Best-effort -
+            # the drift evidence below is the primary outcome either way,
+            # but the cleanup result is reported honestly: a failed
+            # tracker-block write leaves the old-ID pending claim attached
+            # to the relinked spec, and claiming it was removed would send
+            # the operator hunting a ghost (mirrors the receipt_write_failed
+            # decoration: the failure rides alongside, structured, never
+            # masking the relink conflict).
+            released = ledger_release(tracker, key=key, force=True)
+            werr = write_tracker_block(path, spec, released)
+            import dataclasses  # noqa: PLC0415
+            extra: dict = {"recoverable": False, "key": key,
+                           "from": spec_id, "to": dep_spec}
+            if werr is None:
+                claim_note = "pending claim removed"
+                extra["cleanup"] = {"released": True}
+            else:
+                claim_note = (
+                    "removing the pending claim FAILED - the stale old-ID "
+                    "entry is still attached to the relinked spec")
+                extra["cleanup"] = {
+                    "released": False,
+                    "error_class": werr.cls.value,
+                    "subtype": werr.subtype,
+                    "message": werr.message,
+                }
+            if repair:
+                # No mutation was performed by THIS invocation: the remote
+                # edge predates this run (interrupted earlier create). No
+                # completed_steps - false mutation evidence would misattribute
+                # the edge to this run.
+                message = (
+                    f"tracker link for {spec_id} or {dep_spec} changed while "
+                    "the remote edge was being probed; the remote blocked-by "
+                    "edge predates this run (no provider mutation was "
+                    "performed) - the ledger was NOT finalized onto the "
+                    f"relinked spec ({claim_note}); review the stale "
+                    "edge between the OLD issues on the tracker")
+            else:
+                message = (
+                    f"tracker link for {spec_id} or {dep_spec} changed "
+                    "while the provider mutation was in flight; the "
+                    "remote blocked-by edge WAS created between the OLD "
+                    "issues and cannot be un-sent - the ledger was NOT "
+                    "finalized onto the relinked spec "
+                    f"({claim_note}); review the orphan edge on the tracker")
+                extra["completed_steps"] = ["relate-create"]
+                extra["form"] = form
+            return dataclasses.replace(
+                derr, message=message,
+                details={**(derr.details or {}), **extra})
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+def _ledger_claim(flow_dir: Path, spec_id: str, *, key: str, dep_spec: str,
+                  from_id: str, to_id: str) -> Result:
+    """CLAIM the edge by inserting the pending entry under the shared .flow
+    writer lock. Re-checks the RELOADED ledger inside the lock: an entry that
+    appeared since the pre-classification snapshot belongs to a live
+    concurrent relate invocation, so THIS invocation must not proceed to the
+    provider mutation (only the inserter mutates - otherwise both workers
+    probe the edge as absent and both create). Stale interrupted-run pending
+    entries never reach this path: they existed at snapshot time and take the
+    repair/retry classification branches instead. Also revalidates BOTH
+    linked identities against the from/to ids this invocation loaded at
+    start: a spec relinked after the pair load aborts (CONFLICT/relinked)
+    instead of claiming under the stale identity. Returns the persisted
+    tracker block on a successful claim, or a TrackerError - never raises."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            path, spec = reloaded
+            tracker = merged_tracker(spec)
+            derr = _claim_identity_drift(flow_dir, spec_id, dep_spec,
+                                         tracker=tracker,
+                                         from_id=from_id, to_id=to_id)
+            if derr:
+                return derr
+            if ledger_entry(tracker, key) is not None:
+                return _concurrent_claim_error(dep_spec, key)
+            tracker = ledger_append(
+                tracker, key=key, dep_spec=dep_spec,
+                from_tracker_id=from_id, to_tracker_id=to_id,
+                status="pending", claim=claim_owner())
+            werr = write_tracker_block(path, spec, tracker)
+            if werr:
+                return werr
+            return tracker
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+def _locator(tracker: dict) -> Result:
+    durable = tracker.get("id")
+    display = tracker.get("identifier")
+    if not isinstance(durable, str) or not durable.strip():
+        return TrackerError(ErrorClass.UNRESOLVED, "tracker.id missing",
+                            subtype="durable")
+    if not isinstance(display, str) or not display.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "tracker.identifier (display) required for relate",
+                            subtype="locator")
+    return {"durable": durable.strip(), "display": display.strip()}
+
+
+def _claim_relate_pair(flow_dir: Path, spec_id: str, blocked_by: str,
+                       provider: str) -> Result:
+    """Claim both linked specs for the complete relate transaction."""
+    token = uuid.uuid4().hex
+    claim_paths = [
+        flow_dir / "create-first" / f"relate-{sid}-{token}.json"
+        for sid in sorted((spec_id, blocked_by))
+    ]
+    for rec_path in claim_paths:
+        unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+        if unsafe:
+            return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            owner = {
+                "status": "pending",
+                "op": "relate",
+                "pid": os.getpid(),
+                "host": socket.gethostname(),
+                "claimedAt": time.time(),
+                "transport": provider,
+                "specId": spec_id,
+                "blockedBy": blocked_by,
+            }
+            written = []
+            for rec_path in claim_paths:
+                cerr = atomic_write_json(rec_path, owner)
+                if cerr:
+                    for prior_path in written:
+                        _release_claim(prior_path)
+                    return cerr
+                written.append(rec_path)
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    return claim_paths
+
+
+def _write_relate_receipt(enabled: bool, flow_dir: Path, **kwargs
+                          ) -> Optional[TrackerError]:
+    """Let facade composition suppress granular receipts."""
+    if not enabled:
+        return None
+    return write_sync_receipt(flow_dir, **kwargs)
+
+
+def relate(flow_dir, spec_id: str, *, blocked_by: str,
+           event: Optional[str] = None,
+           execute: Execute = default_execute,
+           write_receipt: bool = True) -> Result:
+    """Project A is-blocked-by B. Never raises across the boundary."""
+    flow_dir = Path(flow_dir)
+    if not spec_id or not blocked_by:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "relate requires <spec-id> --blocked-by <other-spec-id>",
+                            subtype="args")
+    if spec_id == blocked_by:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "a spec cannot be blocked by itself",
+                            subtype="self_edge")
+
+    config = read_config(flow_dir)
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    claimed = _claim_relate_pair(flow_dir, spec_id, blocked_by, provider)
+    if isinstance(claimed, TrackerError):
+        return claimed
+    body_claim = None
+    if provider == "gitlab":
+        claimed_spec = load_spec(flow_dir, spec_id)
+        if isinstance(claimed_spec, TrackerError):
+            for rec_path in claimed:
+                _release_claim(rec_path)
+            return claimed_spec
+        _claimed_path, claimed_data = claimed_spec
+        claimed_locator = _locator(merged_tracker(claimed_data))
+        if isinstance(claimed_locator, TrackerError):
+            for rec_path in claimed:
+                _release_claim(rec_path)
+            return claimed_locator
+        body_claim = _claim_body_mutation(
+            flow_dir, provider, claimed_locator, operation="relate",
+            spec_id=spec_id)
+        if isinstance(body_claim, TrackerError):
+            for rec_path in claimed:
+                _release_claim(rec_path)
+            return body_claim
+    try:
+        return _relate_txn(
+            flow_dir, spec_id, blocked_by=blocked_by, event=event,
+            execute=execute, write_receipt=write_receipt)
+    finally:
+        if body_claim is not None:
+            _release_claim(body_claim)
+        for rec_path in claimed:
+            _release_claim(rec_path)
+
+
+def _relate_txn(flow_dir: Path, spec_id: str, *, blocked_by: str,
+                event: Optional[str], execute: Execute,
+                write_receipt: bool) -> Result:
+    """Run probe, mutation, and finalize while both spec claims are live."""
+    config = read_config(flow_dir)
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    loaded_a = load_spec(flow_dir, spec_id)
+    if isinstance(loaded_a, TrackerError):
+        return loaded_a
+    path_a, spec_a = loaded_a
+    loaded_b = load_spec(flow_dir, blocked_by)
+    if isinstance(loaded_b, TrackerError):
+        return loaded_b
+    _path_b, spec_b = loaded_b
+
+    tracker_a = merged_tracker(spec_a)
+    tracker_b = merged_tracker(spec_b)
+
+    pair_err = require_linked_pair(tracker_a, tracker_b,
+                                   self_id=spec_id, other_id=blocked_by)
+    if pair_err:
+        return pair_err
+
+    from_id = str(tracker_a["id"])
+    to_id = str(tracker_b["id"])
+    key = dep_relation_key(from_id, to_id)
+
+    completed_blocker = blocker_completed(spec_b.get("status"))
+
+    loc_a = _locator(tracker_a)
+    if isinstance(loc_a, TrackerError):
+        return loc_a
+    loc_b = _locator(tracker_b)
+    if isinstance(loc_b, TrackerError):
+        return loc_b
+
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+
+    # Resolve Jira's configurable blocking type once and share it between the
+    # probe and mutation via the in-memory config. No blocks-semantics type is
+    # a deferred capability decision, not permission to force stock "Blocks".
+    if provider == "jira":
+        blocks_type = P.jira_blocks_type(config, ex)
+        if isinstance(blocks_type, TrackerError):
+            if blocks_type.subtype != "blocks_link_type":
+                return blocks_type
+            qerr = _queue_conflict(
+                flow_dir, spec_id,
+                summary="Jira has no resolved blocks-semantics issue link type",
+                reason="set tracker.perTracker.blocksLinkType, then retry")
+            if qerr:
+                return qerr
+            rerr = _write_relate_receipt(
+                write_receipt,
+                flow_dir, spec_id=spec_id, status="queued",
+                tracker_id=from_id, event=event, transport=provider,
+                note="no Jira blocks link type; relation deferred")
+            if rerr:
+                return rerr
+            return {
+                "kind": "queued",
+                "reason": "no_blocks_link_type",
+                "from": spec_id,
+                "to": blocked_by,
+                "key": key,
+                "lastSyncedAt": tracker_a.get("lastSyncedAt"),
+            }
+
+    caps = caps_of(config)
+    fn = P.PROVIDERS.get(provider)
+    probe = P.PROBES.get(provider)
+    if fn is None or probe is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    kwargs: dict = {
+        "from_id": from_id, "to_id": to_id,
+        "from_display": loc_a["display"], "to_display": loc_b["display"],
+    }
+
+    # GitHub/GitLab relation paths address issues by display (number/IID):
+    # validate display -> durable for BOTH ends BEFORE any probe or mutation
+    # (wire write-verb parity), so a moved, repointed, or stale identifier
+    # aborts instead of inspecting or relating unrelated issues.
+    verr = P.display_durable_guard(
+        provider, config, ex, locators=(loc_a, loc_b))
+    if verr:
+        return verr
+
+    # 4-way ledger x remote classification BEFORE any mutation (fn-64).
+    # A `pending` entry is recorded ownership INTENT from an earlier run whose
+    # create/finalize was interrupted - it is OURS to complete, never a
+    # collision (two-phase write: intent lands durably BEFORE the provider
+    # mutation, so a ledger failure can no longer orphan ownership).
+    remote = probe(config, ex, **kwargs)
+    if isinstance(remote, TrackerError):
+        return remote
+    entry = ledger_entry(tracker_a, key)
+    pending = entry is not None and entry.get("status") == "pending"
+    in_ledger = entry is not None and not pending
+
+    if in_ledger and remote:
+        if provider == "gitlab":
+            body_out = P.gitlab_ensure_deps_block(
+                config, ex, from_id=from_id,
+                from_display=loc_a["display"], to_display=loc_b["display"])
+            if isinstance(body_out, TrackerError):
+                return body_out
+            if body_out.get("written"):
+                rerr = _write_relate_receipt(
+                    write_receipt,
+                    flow_dir, spec_id=spec_id, status="pushed",
+                    tracker_id=from_id, event=event, transport=provider,
+                    note=f"repaired dependency body block for {blocked_by}")
+                if rerr:
+                    import dataclasses  # noqa: PLC0415
+                    return dataclasses.replace(rerr, details={
+                        **(rerr.details or {}),
+                        "completed_steps": ["relate-body-write"],
+                        "key": key,
+                        "from": spec_id,
+                        "to": blocked_by})
+                return {
+                    "kind": "applied",
+                    "reason": "deps_block_repaired",
+                    "from": spec_id, "to": blocked_by, "key": key,
+                    "form": entry.get("form"),
+                    "completed_blocker": completed_blocker,
+                    "degraded": None,
+                    "depRelations": tracker_a.get("depRelations") or [],
+                }
+        rerr = _write_relate_receipt(
+            write_receipt,
+            flow_dir, spec_id=spec_id, status="noop",
+            tracker_id=from_id, event=event, transport=provider,
+            note=f"blocked-by {blocked_by} already recorded")
+        if rerr:
+            return rerr
+        return {
+            "kind": "noop",
+            "reason": "already_recorded",
+            "from": spec_id, "to": blocked_by, "key": key,
+            "completed_blocker": completed_blocker,
+            "depRelations": tracker_a.get("depRelations") or [],
+        }
+
+    if in_ledger and not remote:
+        drift = _post_probe_identity_drift(
+            flow_dir, spec_id, blocked_by, from_id=from_id, to_id=to_id)
+        if drift:
+            return drift
+        # A human removed OUR tracker-visible edge: a deliberate decision.
+        # Queued, default NOT re-created (adapter-interface.md linkPresent).
+        qerr = _queue_conflict(
+            flow_dir, spec_id,
+            summary=f"flow-created blocked-by edge to {blocked_by} was removed "
+                    "on the tracker",
+            reason="human-removal collision; default NOT re-created")
+        if qerr:
+            return qerr
+        rerr = _write_relate_receipt(
+            write_receipt,
+            flow_dir, spec_id=spec_id, status="queued",
+            tracker_id=from_id, event=event, transport=provider,
+            note="human-removal collision queued; edge not re-created")
+        if rerr:
+            return rerr
+        return {
+            "kind": "queued",
+            "reason": "human_removed_edge",
+            "from": spec_id, "to": blocked_by, "key": key,
+            "lastSyncedAt": tracker_a.get("lastSyncedAt"),
+        }
+
+    if pending and remote:
+        body_repaired = False
+        if provider == "gitlab":
+            body_out = P.gitlab_ensure_deps_block(
+                config, ex, from_id=from_id,
+                from_display=loc_a["display"], to_display=loc_b["display"])
+            if isinstance(body_out, TrackerError):
+                return body_out
+            body_repaired = bool(body_out.get("written"))
+        # OUR interrupted create: the provider mutation succeeded on an earlier
+        # run but the finalize did not land. Repair the ledger - no provider
+        # mutation, no collision queue. Guarded finalize (wave-13, repair
+        # shape): a relink landing after the pair load / during the remote
+        # probe must not finalize the old-ID pending entry onto the newly
+        # linked spec - refuse with CONFLICT/relinked. The remote edge predates
+        # this run; only a body repair performed above is carried as mutation
+        # evidence.
+        finalized = _ledger_finalize_guarded(
+            flow_dir, spec_id, blocked_by, key=key,
+            from_id=from_id, to_id=to_id, repair=True)
+        if isinstance(finalized, TrackerError):
+            if body_repaired:
+                import dataclasses  # noqa: PLC0415
+                return dataclasses.replace(finalized, details={
+                    **(finalized.details or {}),
+                    "completed_steps": ["relate-body-write"],
+                    "key": key,
+                    "from": spec_id,
+                    "to": blocked_by})
+            return finalized
+        tracker_a = finalized
+        rerr = _write_relate_receipt(
+            write_receipt,
+            flow_dir, spec_id=spec_id, status="pushed",
+            tracker_id=from_id, event=event, transport=provider,
+            note=f"ledger finalized for flow-created blocked-by {blocked_by} "
+                 "(interrupted earlier run; edge already on tracker)")
+        if rerr:
+            # Same partial-success shape as the applied path below: the edge
+            # is on the tracker and the ledger is now finalized. Preserve the
+            # completed steps + edge identity on the frozen error; a retry
+            # converges through already_recorded and recreates the receipt.
+            # Nothing is rolled back.
+            import dataclasses  # noqa: PLC0415
+            return dataclasses.replace(rerr, details={
+                **(rerr.details or {}),
+                "completed_steps": (
+                    ["relate-body-write", "ledger-finalize"]
+                    if body_repaired else ["ledger-finalize"]),
+                "key": key,
+                "from": spec_id,
+                "to": blocked_by})
+        return {
+            "kind": "applied",
+            "reason": "ledger_repaired",
+            "from": spec_id, "to": blocked_by, "key": key,
+            "form": None,
+            "completed_blocker": completed_blocker,
+            "degraded": None,
+            "depRelations": tracker_a.get("depRelations") or [],
+        }
+
+    if entry is None and remote:
+        drift = _post_probe_identity_drift(
+            flow_dir, spec_id, blocked_by, from_id=from_id, to_id=to_id)
+        if drift:
+            return drift
+        # Foreign edge - never clobber, never claim ownership.
+        qerr = _queue_conflict(
+            flow_dir, spec_id,
+            summary=f"a blocked-by edge to {blocked_by} exists on the tracker "
+                    "but is not flow's",
+            reason="foreign-edge collision; never clobbered")
+        if qerr:
+            return qerr
+        rerr = _write_relate_receipt(
+            write_receipt,
+            flow_dir, spec_id=spec_id, status="queued",
+            tracker_id=from_id, event=event, transport=provider,
+            note="foreign edge present; never-clobber collision queued")
+        if rerr:
+            return rerr
+        return {
+            "kind": "queued",
+            "reason": "foreign_edge",
+            "from": spec_id, "to": blocked_by, "key": key,
+            "lastSyncedAt": tracker_a.get("lastSyncedAt"),
+        }
+
+    # Pending + remote-absent: the entry is either a LIVE concurrent worker's
+    # claim (its create has not become visible yet - the STAGGERED race: we
+    # started after its pending write but before its create landed) or a
+    # crashed/interrupted run's leftover (the wave-1 retry case). Only the
+    # stale leftover may be reclaimed and retried; a live owner backs off -
+    # otherwise both workers reach the provider create and the relation is
+    # created twice.
+    if pending:
+        if _pending_claim_live(entry):
+            return _concurrent_claim_error(blocked_by, key)
+        reclaimed = _ledger_reclaim(flow_dir, spec_id, key=key,
+                                    dep_spec=blocked_by,
+                                    from_id=from_id, to_id=to_id)
+        if isinstance(reclaimed, TrackerError):
+            return reclaimed
+
+    # Neither ledgered nor remote (or reclaimed stale pending = retry): CREATE.
+    # Completed blockers project too - the relation is the board's historical
+    # ordering; readiness gating alone treats done deps as satisfied
+    # (docs/tracker-sync.md fn-64 rule).
+    #
+    # Two-phase write: record ownership INTENT (a `pending` entry) durably
+    # BEFORE the provider mutation. If the create then fails, the pending
+    # entry makes the next run retry-the-create; if the finalize fails after
+    # a successful create, the pending entry keeps the edge OURS so the next
+    # run repairs the ledger instead of queueing a false foreign collision.
+    # The pending write is a CLAIM: if another live invocation inserted the
+    # entry between our snapshot and the locked write, this invocation backs
+    # off (CONFLICT/concurrent_claim) instead of issuing a duplicate create.
+    if entry is None:
+        claimed = _ledger_claim(
+            flow_dir, spec_id, key=key, dep_spec=blocked_by,
+            from_id=from_id, to_id=to_id)
+        if isinstance(claimed, TrackerError):
+            return claimed
+
+    if provider == "gitlab":
+        source = caps.get("_source") if isinstance(caps.get("_source"), dict) else {}
+        plan = source.get("gitlabPlan")
+        out = fn(config, ex, **kwargs, blocked_by=bool(caps.get("blockedBy")),
+                 plan=plan)
+    else:
+        out = fn(config, ex, **kwargs)
+
+    if isinstance(out, TrackerError):
+        # OBSERVED create failure. When the mutation definitely did NOT land
+        # (parsed rejection / process never spawned), release OUR pending
+        # claim so an immediate retry - a new pid, which the age check would
+        # otherwise treat as live for the full stale window - can claim and
+        # create again. AMBIGUOUS transport failures (timeout / 5xx / read /
+        # malformed) keep the pending entry: the edge may exist remotely and
+        # the repair path finalizes it against the probe on retry.
+        if _create_failure_not_landed(out):
+            _ledger_release(flow_dir, spec_id, key=key)
+        if (out.details or {}).get("completed_steps"):
+            import dataclasses  # noqa: PLC0415
+            out = dataclasses.replace(out, details={
+                **(out.details or {}),
+                "key": key,
+                "from": spec_id,
+                "to": blocked_by,
+            })
+        return out
+
+    degraded = out.get("degraded")
+
+    # Applied: FINALIZE the pending entry (drop the status marker) under the
+    # shared .flow writer lock, rechecking both linked identities first - a
+    # relink during the provider mutation must not finalize the old-ID entry
+    # onto the newly linked spec (CONFLICT/relinked with the landed create as
+    # evidence instead). Other failures here are a RECOVERABLE partial
+    # success: the remote edge exists and the pending entry preserves
+    # ownership, so a retry heals the ledger without a duplicate create.
+    finalized = _ledger_finalize_guarded(
+        flow_dir, spec_id, blocked_by, key=key,
+        from_id=from_id, to_id=to_id, form=out.get("form"))
+    if isinstance(finalized, TrackerError):
+        if finalized.subtype == "relinked":
+            # Already decorated with completed_steps + edge identity; the
+            # pending claim was removed, so this is NOT the recoverable
+            # ledger_finalize shape - a human decides about the orphan edge.
+            return finalized
+        return TrackerError(
+            finalized.cls,
+            f"relation created on tracker but ledger finalize failed: "
+            f"{finalized.message}; re-run relate to heal the ledger "
+            "(ownership is preserved by the pending entry)",
+            subtype="ledger_finalize",
+            details={"recoverable": True,
+                     "completed_steps": ["relate-create"],
+                     "key": key})
+    tracker_a = finalized
+    # GitHub's sub_issues form is a HIERARCHY PROXY, never a blocked-by (R15)
+    # - the note stays a neutral record of WHAT landed; the degradation
+    # context lives exclusively in the structured `degraded` field (epic
+    # contract: never a sentence in `note`).
+    form = out.get("form")
+    if form == "sub_issues":
+        note = f"hierarchy proxy recorded for {blocked_by} via sub_issues"
+    else:
+        note = f"projected blocked-by {blocked_by} via {form}"
+    rerr = _write_relate_receipt(
+        write_receipt,
+        flow_dir, spec_id=spec_id, status="pushed",
+        tracker_id=from_id, event=event, transport=provider,
+        note=note,
+        degraded=degraded,
+    )
+    if rerr:
+        # The remote relation EXISTS and the ledger is finalized - a bare
+        # failure here reads as "nothing happened". A retry takes the
+        # in_ledger+remote no-op path and recreates the receipt, while this
+        # error still carries partial-success evidence. TrackerError is
+        # frozen: rebuild with the completed-steps detail + edge identity
+        # (mirrors lifecycle's create/persist-external receipt-failure
+        # branches). Nothing is rolled back.
+        import dataclasses  # noqa: PLC0415
+        return dataclasses.replace(rerr, details={
+            **(rerr.details or {}),
+            "completed_steps": ["relate-create", "ledger-finalize"],
+            "key": key,
+            "from": spec_id,
+            "to": blocked_by,
+            "form": form})
+    return {
+        "kind": "applied",
+        "from": spec_id,
+        "to": blocked_by,
+        "key": key,
+        "form": form,
+        "completed_blocker": completed_blocker,
+        "degraded": degraded,
+        "depRelations": tracker_a.get("depRelations") or [],
+    }
+
+
+def run(flow_dir, *, spec_id: Optional[str] = None,
+        blocked_by: Optional[str] = None, event: Optional[str] = None,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """Thin envelope shell - never raises across the boundary."""
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        t = dict_(config.get("tracker")).get("type")
+        if t is not None and t not in ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}",
+                subtype="provider"))
+        return envelope.inactive()
+    if not spec_id or not blocked_by:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "relate requires <spec-id> --blocked-by <other-spec-id>",
+            subtype="args"))
+    try:
+        out = relate(flow_dir, spec_id, blocked_by=blocked_by, event=event,
+                     execute=execute)
+    except Exception as exc:  # noqa: BLE001
+        return envelope.failure(TrackerError(
+            ErrorClass.TRANSPORT, f"relate verb raised: {exc}",
+            subtype="unexpected"))
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/relate/ledger.py
+++ b/.flow/bin/flowctl_tracker/relate/ledger.py
@@ -1,0 +1,207 @@
+"""depRelations ledger helpers + flow:deps marker constants (fn-140.4 / fn-64).
+
+Edge-key semantics match flowctl._dep_relation_key: sha256 of the directed
+(from_tracker_id \\x00 to_tracker_id) pair, truncated to 16 hex chars.
+
+The <!-- flow:deps --> marker is importable for .5 body hashing (exclusion is a
+HASHING concern there - this module does not hash bodies).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+import time
+from typing import Any, Optional
+
+from ..lifecycle.helpers import dict_, now_iso
+from ..types import TrackerError
+
+#: Provenance fence for GitHub fenced fallback / GitLab dual-write body block.
+#: Importable by sync-body (.5); do not strip or rewrite here.
+FLOW_DEPS_OPEN = "<!-- flow:deps -->"
+FLOW_DEPS_CLOSE = "<!-- /flow:deps -->"
+
+#: Fields present ONLY on a pending entry (dropped at finalize so applied
+#: entries stay byte-shaped like pre-existing fn-64 entries). The owner triple
+#: mirrors lifecycle create-first claims: it lets a later invocation tell a
+#: LIVE concurrent owner from a crashed run's leftover.
+CLAIM_FIELDS = ("status", "pid", "host", "claimedAt")
+
+
+def claim_owner() -> dict:
+    """Owner triple recorded on a pending claim (create-first claim shape)."""
+    return {"pid": os.getpid(), "host": socket.gethostname(),
+            "claimedAt": time.time()}
+
+
+def dep_relation_key(from_tracker_id: str, to_tracker_id: str) -> str:
+    """Opaque stable edge key - same semantics as flowctl._dep_relation_key."""
+    return hashlib.sha256(
+        f"{from_tracker_id}\x00{to_tracker_id}".encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def ledger_has(tracker: dict, key: str) -> bool:
+    for entry in tracker.get("depRelations") or []:
+        if isinstance(entry, dict) and entry.get("key") == key:
+            return True
+    return False
+
+
+def ledger_entry(tracker: dict, key: str) -> Optional[dict]:
+    """The ledger entry for `key`, or None. An entry WITHOUT a `status` field
+    is applied (the fn-64 schema); `status: "pending"` marks recorded intent
+    whose provider create + finalize has not completed yet (crash-safe
+    two-phase write - ownership is durable before the remote mutation)."""
+    for entry in tracker.get("depRelations") or []:
+        if isinstance(entry, dict) and entry.get("key") == key:
+            return entry
+    return None
+
+
+def ledger_append(tracker: dict, *, key: str, dep_spec: str,
+                  from_tracker_id: str, to_tracker_id: str,
+                  rel_type: str = "blocks", source: str = "flow",
+                  status: Optional[str] = None,
+                  claim: Optional[dict] = None) -> dict:
+    """Idempotent append. Returns the (possibly unchanged) tracker block.
+    `status="pending"` records ownership INTENT before the provider mutation;
+    omitted means applied (field absent, matching existing fn-64 entries).
+    `claim` (the `claim_owner()` triple) stamps ownership onto a pending
+    entry so later invocations can classify it live vs stale."""
+    ledger = list(tracker.get("depRelations") or [])
+    for entry in ledger:
+        if isinstance(entry, dict) and entry.get("key") == key:
+            tracker = dict(tracker)
+            tracker["depRelations"] = ledger
+            return tracker
+    new: dict = {
+        "key": key,
+        "dep_spec": dep_spec,
+        "from_tracker_id": from_tracker_id,
+        "to_tracker_id": to_tracker_id,
+        "type": rel_type,
+        "source": source,
+        "updatedAt": now_iso(),
+    }
+    if status is not None:
+        new["status"] = status
+        if claim:
+            new.update(claim)
+    ledger.append(new)
+    tracker = dict(tracker)
+    tracker["depRelations"] = ledger
+    return tracker
+
+
+def ledger_finalize(tracker: dict, *, key: str) -> dict:
+    """Mark a pending entry applied by DROPPING its status field (and the
+    claim-owner triple), so finalized entries are byte-shaped like
+    pre-existing fn-64 entries. Idempotent."""
+    ledger = []
+    for entry in tracker.get("depRelations") or []:
+        if (isinstance(entry, dict) and entry.get("key") == key
+                and entry.get("status") == "pending"):
+            entry = {k: v for k, v in entry.items() if k not in CLAIM_FIELDS}
+            entry["updatedAt"] = now_iso()
+        ledger.append(entry)
+    tracker = dict(tracker)
+    tracker["depRelations"] = ledger
+    return tracker
+
+
+def ledger_drop(tracker: dict, *, key: str) -> dict:
+    """DROP an APPLIED entry after its native relation has been removed (or
+    proven absent) remotely - the reconcile counterpart of append+finalize.
+    Pending entries are ownership claims and stay untouched (ledger_release
+    owns those). Idempotent on missing keys."""
+    ledger = [
+        entry
+        for entry in tracker.get("depRelations") or []
+        if not (isinstance(entry, dict) and entry.get("key") == key
+                and entry.get("status") != "pending")
+    ]
+    tracker = dict(tracker)
+    tracker["depRelations"] = ledger
+    return tracker
+
+
+def ledger_release(tracker: dict, *, key: str, force: bool = False) -> dict:
+    """DROP a pending entry owned by THIS process (call under the shared
+    writer lock, after an OBSERVED provider create failure that definitely
+    did NOT land). Restores the entry-absent state so an immediate retry -
+    typically a new pid - can claim and create again instead of failing
+    concurrent_claim for the full stale window. Entries that are applied,
+    missing, or owned by another process are left untouched (idempotent).
+
+    force=True drops the pending entry regardless of its owner triple - for
+    the finalize-time identity-drift refusal ONLY (call under the lock,
+    after the drift is established): a pending entry keyed by the OLD
+    tracker ids can never be validly finalized after a relink (no future
+    run of the new pair computes its key), so it must not linger on the
+    relinked spec even when it was claimed by an earlier interrupted run."""
+    me = claim_owner()
+    ledger = []
+    for entry in tracker.get("depRelations") or []:
+        if (isinstance(entry, dict) and entry.get("key") == key
+                and entry.get("status") == "pending"
+                and (force or (entry.get("pid") == me["pid"]
+                               and entry.get("host") == me["host"]))):
+            continue
+        ledger.append(entry)
+    tracker = dict(tracker)
+    tracker["depRelations"] = ledger
+    return tracker
+
+
+def ledger_stamp_claim(tracker: dict, *, key: str) -> dict:
+    """RECLAIM a stale pending entry: overwrite its owner triple with OURS
+    (call under the shared writer lock, after re-checking staleness).
+    Idempotent on non-pending / missing entries."""
+    ledger = []
+    for entry in tracker.get("depRelations") or []:
+        if (isinstance(entry, dict) and entry.get("key") == key
+                and entry.get("status") == "pending"):
+            entry = dict(entry)
+            entry.update(claim_owner())
+            entry["updatedAt"] = now_iso()
+        ledger.append(entry)
+    tracker = dict(tracker)
+    tracker["depRelations"] = ledger
+    return tracker
+
+
+def blocker_completed(status: Any) -> bool:
+    """Completed-blocker rule: local dep-spec status done/closed is NOT projected."""
+    if not isinstance(status, str):
+        return False
+    return status.strip().lower() in {"done", "closed"}
+
+
+def require_linked_pair(self_tracker: dict, other_tracker: dict, *,
+                       self_id: str, other_id: str
+                       ) -> Optional[TrackerError]:
+    """Both sides must be durable-linked; identifier_only/unlinked → unresolved."""
+    from ..lifecycle.linkstate import require_durable  # noqa: PLC0415
+    a = require_durable(self_tracker)
+    if isinstance(a, TrackerError):
+        return TrackerError(
+            a.cls, f"spec {self_id}: {a.message}", subtype=a.subtype,
+            details=a.details)
+    b = require_durable(other_tracker)
+    if isinstance(b, TrackerError):
+        return TrackerError(
+            b.cls, f"spec {other_id}: {b.message}", subtype=b.subtype,
+            details=b.details)
+    return None
+
+
+def caps_of(config: dict) -> dict:
+    caps = dict_(dict_(dict_(config.get("tracker")).get("resolved")).get("capabilities"))
+    if caps:
+        return caps
+    from ..resolved_cache import STATIC_CAPABILITIES  # noqa: PLC0415
+    t = dict_(config.get("tracker")).get("type")
+    return dict(STATIC_CAPABILITIES.get(t) or {})

--- a/.flow/bin/flowctl_tracker/relate/listing.py
+++ b/.flow/bin/flowctl_tracker/relate/listing.py
@@ -1,0 +1,322 @@
+"""Per-provider relation reads for tracker wire."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+from urllib.parse import quote
+
+from ..types import ErrorClass, TrackerError
+from ..wire import (
+    _MAX_PAGES,
+    _PAGE_SIZE,
+    Execute,
+    Result,
+    _check_durable,
+    _destination,
+    _gitlab_iid,
+    _gql,
+    _jira,
+    _jira_base,
+)
+from . import providers
+from .ledger import FLOW_DEPS_CLOSE, FLOW_DEPS_OPEN
+
+
+def _relation(from_display: str, to_display: str, *,
+              source: str = "unknown", link_present: bool = True,
+              degraded: Optional[dict] = None) -> dict:
+    out = {
+        "from": from_display,
+        "to": to_display,
+        "type": "blocks",
+        "source": source,
+        "linkPresent": link_present,
+    }
+    if degraded is not None:
+        out["degraded"] = degraded
+    return out
+
+
+def _dedupe_relations(rows: list) -> list:
+    """Stable directed-pair dedup; provenance-bearing rows win."""
+    by_pair: dict[tuple[str, str], dict] = {}
+    for row in rows:
+        key = (str(row.get("from") or ""), str(row.get("to") or ""))
+        prior = by_pair.get(key)
+        if prior is None or (
+            row.get("source") in {"flow", "block-only"}
+            and prior.get("source") not in {"flow", "block-only"}
+        ):
+            by_pair[key] = row
+    return list(by_pair.values())
+
+
+def _truncated_error(provider: str) -> TrackerError:
+    return TrackerError(
+        ErrorClass.TRANSPORT,
+        f"{provider} relation pages truncated at drain cap; "
+        "dependency graph completeness unproven",
+        subtype="truncated",
+    )
+
+
+def linear_list(config: dict, execute: Execute, *, locator: dict) -> Result:
+    """List every direct blocked-by edge touching one Linear issue."""
+    query = (
+        "query($id: String!, $afterRel: String, $afterInv: String) { "
+        "issue(id: $id) { id identifier "
+        f"relations(first: {_PAGE_SIZE}, after: $afterRel) "
+        "{ nodes { type relatedIssue { id identifier } } "
+        "pageInfo { hasNextPage endCursor } } "
+        f"inverseRelations(first: {_PAGE_SIZE}, after: $afterInv) "
+        "{ nodes { type issue { id identifier } } "
+        "pageInfo { hasNextPage endCursor } } } }"
+    )
+    rel_cursor: Optional[str] = None
+    inv_cursor: Optional[str] = None
+    rows: list = []
+    seen: set = set()
+    for _ in range(_MAX_PAGES):
+        data = _gql(
+            execute, "wire-relation-list", query,
+            {"id": locator["durable"], "afterRel": rel_cursor,
+             "afterInv": inv_cursor},
+            idempotent=True,
+        )
+        if isinstance(data, TrackerError):
+            return data
+        issue = data.get("issue")
+        if issue is None:
+            return TrackerError(
+                ErrorClass.NOT_FOUND, "linear issue not found", subtype="issue")
+        if not isinstance(issue, dict):
+            return TrackerError(
+                ErrorClass.TRANSPORT, "linear relation list malformed",
+                subtype="malformed_body")
+        err = _check_durable("linear", locator, issue)
+        if err:
+            return err
+        current = str(issue.get("identifier") or locator["display"])
+        rel = issue.get("relations") if isinstance(issue.get("relations"), dict) else {}
+        inv = (issue.get("inverseRelations")
+               if isinstance(issue.get("inverseRelations"), dict) else {})
+        for node in rel.get("nodes") or []:
+            if not isinstance(node, dict) or node.get("type") != "blocks":
+                continue
+            related = (node.get("relatedIssue")
+                       if isinstance(node.get("relatedIssue"), dict) else {})
+            display = related.get("identifier")
+            if isinstance(display, str) and display:
+                rows.append(_relation(display, current))
+        for node in inv.get("nodes") or []:
+            if not isinstance(node, dict) or node.get("type") != "blocks":
+                continue
+            blocker = node.get("issue") if isinstance(node.get("issue"), dict) else {}
+            display = blocker.get("identifier")
+            if isinstance(display, str) and display:
+                rows.append(_relation(current, display))
+        rel_info = rel.get("pageInfo") if isinstance(rel.get("pageInfo"), dict) else {}
+        inv_info = inv.get("pageInfo") if isinstance(inv.get("pageInfo"), dict) else {}
+        rel_more = bool(rel_info.get("hasNextPage"))
+        inv_more = bool(inv_info.get("hasNextPage"))
+        if not rel_more and not inv_more:
+            break
+        next_rel = rel_info.get("endCursor") if rel_more else rel_cursor
+        next_inv = inv_info.get("endCursor") if inv_more else inv_cursor
+        step = (next_rel, next_inv)
+        if (rel_more and not next_rel) or (inv_more and not next_inv) or step in seen:
+            return TrackerError(
+                ErrorClass.TRANSPORT, "pagination made no progress",
+                subtype="malformed_body")
+        seen.add(step)
+        rel_cursor, inv_cursor = next_rel, next_inv
+    else:
+        return _truncated_error("linear")
+    return {
+        "relations": _dedupe_relations(rows),
+        "truncated": False,
+        "parent_identity": "validated",
+    }
+
+
+def jira_list(config: dict, execute: Execute, *, locator: dict) -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    blocks_type = providers.jira_blocks_type(config, execute)
+    if isinstance(blocks_type, TrackerError):
+        return blocks_type
+    data = _jira(
+        execute, "wire-relation-list", "GET",
+        f"{base}/rest/api/2/issue/{quote(locator['durable'], safe='')}"
+        "?fields=issuelinks",
+        idempotent=True,
+    )
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(
+            ErrorClass.TRANSPORT, "jira relation list malformed",
+            subtype="malformed_body")
+    err = _check_durable("jira", locator, data)
+    if err:
+        return err
+    current = str(data.get("key") or locator["display"])
+    fields = data.get("fields") if isinstance(data.get("fields"), dict) else {}
+    rows: list = []
+    for link in fields.get("issuelinks") or []:
+        if not isinstance(link, dict):
+            continue
+        typ = link.get("type") if isinstance(link.get("type"), dict) else {}
+        if str(typ.get("name") or "").casefold() != blocks_type.casefold():
+            continue
+        inward = link.get("inwardIssue")
+        if isinstance(inward, dict):
+            blocker = inward.get("key") or inward.get("id")
+            if blocker is not None:
+                rows.append(_relation(current, str(blocker)))
+        outward = link.get("outwardIssue")
+        if isinstance(outward, dict):
+            blocked = outward.get("key") or outward.get("id")
+            if blocked is not None:
+                rows.append(_relation(str(blocked), current))
+    return {
+        "relations": _dedupe_relations(rows),
+        "truncated": False,
+        "parent_identity": "validated",
+    }
+
+
+def _gitlab_link_display(link: dict, current_display: str) -> Optional[str]:
+    refs = link.get("references") if isinstance(link.get("references"), dict) else {}
+    full = refs.get("full")
+    if isinstance(full, str) and full.strip():
+        return full.strip()
+    relative = refs.get("relative")
+    if isinstance(relative, str) and relative.strip():
+        value = relative.strip()
+        if value.startswith("#") and "#" in current_display:
+            return f"{current_display.rsplit('#', 1)[0]}{value}"
+        return value
+    iid = link.get("iid")
+    if isinstance(iid, int) and "#" in current_display:
+        return f"{current_display.rsplit('#', 1)[0]}#{iid}"
+    return None
+
+
+_FLOW_DEPS_RE = re.compile(
+    re.escape(FLOW_DEPS_OPEN) + r".*?" + re.escape(FLOW_DEPS_CLOSE),
+    re.DOTALL,
+)
+_BLOCKED_BY_RE = re.compile(r"(?m)^\*\*Blocked by:\*\*[ \t]*(.*)$")
+
+
+def _gitlab_blocked_refs(description: object) -> list[str]:
+    if not isinstance(description, str):
+        return []
+    match = _FLOW_DEPS_RE.search(description)
+    if match is None:
+        return []
+    blocked = _BLOCKED_BY_RE.search(match.group(0))
+    if blocked is None:
+        return []
+    return [ref.strip() for ref in blocked.group(1).split(",") if ref.strip()]
+
+
+def gitlab_list(config: dict, execute: Execute, *, locator: dict) -> Result:
+    """List native directional links plus flow-owned degraded dependency rows."""
+    from ..wire import gitlab as wire_gitlab  # noqa: PLC0415
+
+    parent = wire_gitlab.parent_read(
+        config, locator, execute, op="wire-relation-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    iid = _gitlab_iid(locator["display"])
+    if isinstance(iid, TrackerError):
+        return iid
+    drained = providers._gitlab_links(config, execute, iid=iid)
+    if isinstance(drained, TrackerError):
+        return drained
+    links, truncated = drained
+    if truncated:
+        return _truncated_error("gitlab")
+    current = locator["display"]
+    rows: list = []
+    visible_blockers: set[str] = set()
+    native_blockers: set[str] = set()
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        target = _gitlab_link_display(link, current)
+        if target is None:
+            continue
+        kind = link.get("link_type")
+        if kind == "is_blocked_by":
+            rows.append(_relation(current, target))
+            visible_blockers.add(target)
+            native_blockers.add(target)
+        elif kind == "blocks":
+            rows.append(_relation(target, current))
+        elif kind == "relates_to":
+            visible_blockers.add(target)
+
+    for blocker in _gitlab_blocked_refs(parent.get("description")):
+        # A native directional row is already the stronger representation.
+        # Do not let the body-owned fallback duplicate win _dedupe_relations()
+        # and relabel a real is_blocked_by link as degraded relates_to.
+        if blocker in native_blockers:
+            continue
+        present = blocker in visible_blockers
+        rows.append(_relation(
+            current,
+            blocker,
+            source="flow" if present else "block-only",
+            link_present=present,
+            degraded={
+                "kind": "relates_to",
+                "capability": "blockedBy",
+                "reason": "direction is carried by the flow:deps block",
+            },
+        ))
+    return {
+        "relations": _dedupe_relations(rows),
+        "truncated": False,
+        "parent_identity": "validated",
+    }
+
+
+def github_list(config: dict, execute: Execute, *, locator: dict) -> Result:
+    """Validate the issue, but never reinterpret hierarchy as dependency."""
+    from ..wire import github as wire_github  # noqa: PLC0415
+
+    parent_issue = wire_github.parent_read(
+        config, locator, execute, op="wire-relation-parent-read")
+    if isinstance(parent_issue, TrackerError):
+        return parent_issue
+    return {
+        "relations": [],
+        "truncated": False,
+        "parent_identity": "validated",
+    }
+
+
+LISTERS = {
+    "linear": linear_list,
+    "jira": jira_list,
+    "gitlab": gitlab_list,
+    "github": github_list,
+}
+
+
+def list_relations(provider: str, config: dict, execute: Execute, *,
+                   locator: dict) -> Result:
+    handler = LISTERS.get(provider)
+    if handler is None:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT, f"unknown tracker provider {provider!r}",
+            subtype="provider")
+    return handler(config, execute, locator=locator)

--- a/.flow/bin/flowctl_tracker/relate/providers.py
+++ b/.flow/bin/flowctl_tracker/relate/providers.py
@@ -1,0 +1,942 @@
+"""Per-provider blocked-by projection (fn-140.4).
+
+GitLab projects both the issue link and flow-owned dependency body block.
+GitHub implements the native sub_issues call + structured degraded hierarchy
+reporting only - never presents sub_issues as blocked-by.
+
+Direction (fn-64): A is-blocked-by B ⇔ from=A to=B type=blocks.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Union
+from urllib.parse import quote
+
+from ..types import ErrorClass, TrackerError
+from ..wire import (
+    _MAX_PAGES,
+    _PAGE_SIZE,
+    Execute,
+    Result,
+    _check_durable,
+    _cli,
+    _destination,
+    _github_number,
+    _gitlab_iid,
+    _gl_project,
+    _gql,
+    _gql_connection_drain,
+    _gh_repo,
+    _rest_drain,
+    _jira,
+    _jira_base,
+)
+from .ledger import FLOW_DEPS_CLOSE, FLOW_DEPS_OPEN
+
+
+# ---------------------------------------------------------------------------
+# Linear
+# ---------------------------------------------------------------------------
+
+def _linear_edge_exists(execute: Execute, from_id: str, to_id: str
+                        ) -> Union[bool, TrackerError]:
+    """Canonicalize relations + inverseRelations (fn-64 read-before-write).
+
+    Drains BOTH connections cursor-by-cursor (one query per round trip, each
+    connection with its own cursor) up to the shared wire page cap. A probe
+    that cannot prove absence must not report absence: hitting the cap with
+    pages still remaining returns a TrackerError, never False.
+    """
+    query = (
+        "query($id: String!, $afterRel: String, $afterInv: String) { "
+        "issue(id: $id) { id "
+        f"relations(first: {_PAGE_SIZE}, after: $afterRel) "
+        "{ nodes { type relatedIssue { id } } "
+        "pageInfo { hasNextPage endCursor } } "
+        f"inverseRelations(first: {_PAGE_SIZE}, after: $afterInv) "
+        "{ nodes { type issue { id } } "
+        "pageInfo { hasNextPage endCursor } } } }"
+    )
+    rel_cursor: Optional[str] = None
+    inv_cursor: Optional[str] = None
+    seen: set = set()
+    for _ in range(_MAX_PAGES):
+        data = _gql(
+            execute, "relate-list", query,
+            {"id": from_id, "afterRel": rel_cursor, "afterInv": inv_cursor},
+            idempotent=True,
+        )
+        if isinstance(data, TrackerError):
+            return data
+        issue = data.get("issue")
+        if not isinstance(issue, dict):
+            return TrackerError(ErrorClass.TRANSPORT, "linear relate list malformed",
+                                subtype="malformed_body")
+        rel = issue.get("relations") if isinstance(issue.get("relations"), dict) else {}
+        inv = (issue.get("inverseRelations")
+               if isinstance(issue.get("inverseRelations"), dict) else {})
+        # relations: this blocks relatedIssue → from=related, to=this
+        # inverseRelations: node.issue blocks this → from=this, to=node.issue
+        for n in (rel.get("nodes") or []):
+            if not isinstance(n, dict) or n.get("type") != "blocks":
+                continue
+            related = n.get("relatedIssue") if isinstance(n.get("relatedIssue"), dict) else {}
+            if related.get("id") == from_id and issue.get("id") == to_id:
+                return True
+        for n in (inv.get("nodes") or []):
+            if not isinstance(n, dict) or n.get("type") != "blocks":
+                continue
+            blocker = n.get("issue") if isinstance(n.get("issue"), dict) else {}
+            if issue.get("id") == from_id and blocker.get("id") == to_id:
+                return True
+        rel_info = rel.get("pageInfo") or {}
+        inv_info = inv.get("pageInfo") or {}
+        rel_more = bool(rel_info.get("hasNextPage"))
+        inv_more = bool(inv_info.get("hasNextPage"))
+        if not rel_more and not inv_more:
+            return False
+        # An exhausted connection keeps its last cursor (yields empty pages).
+        next_rel = rel_info.get("endCursor") if rel_more else rel_cursor
+        next_inv = inv_info.get("endCursor") if inv_more else inv_cursor
+        step = (next_rel, next_inv)
+        if (rel_more and not next_rel) or (inv_more and not next_inv) or step in seen:
+            return TrackerError(ErrorClass.TRANSPORT,
+                                "pagination made no progress",
+                                subtype="malformed_body")
+        seen.add(step)
+        rel_cursor, inv_cursor = next_rel, next_inv
+    return TrackerError(
+        ErrorClass.TRANSPORT,
+        "linear relation pages truncated at drain cap; edge absence unproven",
+        subtype="truncated")
+
+
+def linear_set(config: dict, execute: Execute, *, from_id: str, to_id: str,
+               from_display: str, to_display: str) -> Result:
+    # Presence classification is relate.__init__'s job (4-way probe) -
+    # set() performs the mutation only.
+    data = _gql(
+        execute, "relate-create",
+        "mutation($issueId: String!, $relatedIssueId: String!) { "
+        "issueRelationCreate(input: {issueId: $issueId, "
+        "relatedIssueId: $relatedIssueId, type: blocks}) { "
+        "success issueRelation { id } } }",
+        # issueId=BLOCKER (to), relatedIssueId=BLOCKED (from)
+        {"issueId": to_id, "relatedIssueId": from_id},
+    )
+    if isinstance(data, TrackerError):
+        return data
+    mut = data.get("issueRelationCreate")
+    if not isinstance(mut, dict) or mut.get("success") is not True:
+        return TrackerError(ErrorClass.TRANSPORT, "linear issueRelationCreate failed",
+                            subtype="mutation_failed")
+    return {"projected": True, "already": False, "form": "blocks"}
+
+
+# ---------------------------------------------------------------------------
+# Jira
+# ---------------------------------------------------------------------------
+
+def jira_blocks_type(config: dict, execute: Execute) -> Union[str, TrackerError]:
+    """Resolve the site's blocking link type once per relate invocation.
+
+    A configured name wins. Otherwise discover a type whose outward phrase
+    carries "block" semantics. Cache only on the in-memory config object so the
+    probe and mutation use the exact same resolved name without persisting
+    runtime state behind the discovery transaction.
+    """
+    tracker = config.get("tracker") if isinstance(config.get("tracker"), dict) else {}
+    per = tracker.get("perTracker") if isinstance(tracker.get("perTracker"), dict) else {}
+    configured = per.get("blocksLinkType")
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    cached = dest.get("_runtimeBlocksLinkType")
+    if isinstance(cached, str) and cached:
+        return cached
+    if cached is False:
+        return TrackerError(
+            ErrorClass.CAPABILITY,
+            "no Jira blocks link type; set tracker.perTracker.blocksLinkType",
+            subtype="blocks_link_type",
+        )
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    data = _jira(
+        execute, "relate-link-types", "GET",
+        f"{base}/rest/api/2/issueLinkType", idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    rows = data.get("issueLinkTypes") if isinstance(data, dict) else None
+    if not isinstance(rows, list):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "jira issueLinkType response is malformed",
+            subtype="malformed_body",
+        )
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("name")
+        outward = row.get("outward")
+        if (isinstance(name, str) and name.strip()
+                and isinstance(outward, str)
+                and "block" in outward.lower()):
+            dest["_runtimeBlocksLinkType"] = name.strip()
+            return name.strip()
+    dest["_runtimeBlocksLinkType"] = False
+    return TrackerError(
+        ErrorClass.CAPABILITY,
+        "no Jira blocks link type; set tracker.perTracker.blocksLinkType",
+        subtype="blocks_link_type",
+    )
+
+
+def _jira_edge_exists(config: dict, execute: Execute, *, from_id: str,
+                      to_id: str) -> Union[bool, TrackerError]:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    blocks_type = jira_blocks_type(config, execute)
+    if isinstance(blocks_type, TrackerError):
+        return blocks_type
+    data = _jira(
+        execute, "relate-list", "GET",
+        f"{base}/rest/api/2/issue/{quote(str(from_id), safe='')}"
+        f"?fields=issuelinks",
+        idempotent=True,
+    )
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "jira relate list malformed",
+                            subtype="malformed_body")
+    fields = data.get("fields") if isinstance(data.get("fields"), dict) else {}
+    for link in fields.get("issuelinks") or []:
+        if not isinstance(link, dict):
+            continue
+        typ = link.get("type") if isinstance(link.get("type"), dict) else {}
+        if str(typ.get("name") or "").casefold() != blocks_type.casefold():
+            continue
+        # Querying the blocked issue A: "A is blocked by B" carries the
+        # blocker B in inwardIssue (jira.md listIssueRelations - the entry
+        # holds outwardIssue XOR inwardIssue from A's perspective). An
+        # outwardIssue=B entry means "A blocks B" - the REVERSE edge, which
+        # must NOT match (mirrors gitlab_probe_pair direction handling).
+        inward = link.get("inwardIssue") if isinstance(link.get("inwardIssue"), dict) else {}
+        if inward.get("id") is not None and str(inward.get("id")) == str(to_id):
+            return True
+    return False
+
+
+def jira_set(config: dict, execute: Execute, *, from_id: str, to_id: str,
+             from_display: str, to_display: str) -> Result:
+    # Presence classification is relate.__init__'s job (4-way probe) -
+    # set() performs the mutation only.
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    blocks_type = jira_blocks_type(config, execute)
+    if isinstance(blocks_type, TrackerError):
+        return blocks_type
+    # Measured live 2026-07-28 (JQL linkedIssues tiebreak): POST
+    # {inwardIssue: X, outwardIssue: Y} creates "X blocks Y". For
+    # "A blocked-by B" the blocker B goes in inwardIssue and the blocked
+    # A in outwardIssue; the readback on A then shows B in inwardIssue,
+    # which is exactly what _jira_edge_exists matches.
+    data = _jira(
+        execute, "relate-create", "POST",
+        f"{base}/rest/api/2/issueLink",
+        body={"type": {"name": blocks_type},
+              "inwardIssue": {"id": str(to_id)},
+              "outwardIssue": {"id": str(from_id)}},
+    )
+    if isinstance(data, TrackerError):
+        return data
+    return {"projected": True, "already": False, "form": "blocks"}
+
+
+# ---------------------------------------------------------------------------
+# GitLab
+# ---------------------------------------------------------------------------
+
+def _gitlab_links(config: dict, execute: Execute, *, iid: int
+                  ) -> Union[tuple, TrackerError]:
+    """Drain issue links to the shared wire cap. Returns (links, truncated).
+
+    Mirror of the GitHub sub_issues probe drain (fn-64 read-before-write): a
+    single-page probe would report a later-page link ABSENT, falsely queueing
+    a ledgered edge as a human removal (or duplicating the create on an
+    unledgered one). Truncation is unproven absence, never absence.
+    """
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    drained = _rest_drain(lambda page: _cli(
+        execute, "gitlab", config, "relate-list", "GET",
+        f"projects/{pid}/issues/{iid}/links"
+        f"?per_page={_PAGE_SIZE}&page={page}", idempotent=True))
+    return drained
+
+
+def _gitlab_pair_present(links: list, *, target_iid: int,
+                         link_types: set) -> bool:
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        if link.get("iid") == target_iid and link.get("link_type") in link_types:
+            return True
+    return False
+
+
+# GitHub and GitLab relation paths address issues by DISPLAY (issue number /
+# IID); Linear and Jira address by durable id and need no guard.
+_DISPLAY_ADDRESSED = ("github", "gitlab")
+
+
+def display_durable_guard(provider: str, config: dict, execute: Execute, *,
+                          locators: tuple) -> Optional[TrackerError]:
+    """Pre-mutation display -> durable identity check (wire-verb parity).
+
+    GitHub/GitLab probes and setters address issues by display; a destination
+    move, repoint, or stale stored identifier would otherwise inspect and then
+    relate UNRELATED issues. Mirror the wire write verbs: read each display
+    locator and compare the returned durable id against the linked durable id
+    (`_check_durable`), aborting as CONFLICT/durable_mismatch on drift. Never
+    raises - returns a TrackerError or None.
+    """
+    if provider not in _DISPLAY_ADDRESSED:
+        return None
+    from ..wire import github as _wire_github  # noqa: PLC0415
+    from ..wire import gitlab as _wire_gitlab  # noqa: PLC0415
+    mod = _wire_github if provider == "github" else _wire_gitlab
+    for locator in locators:
+        got = mod.parent_read(config, locator, execute,
+                              op="relate-parent-read")
+        if isinstance(got, TrackerError):
+            return got
+    return None
+
+
+_FLOW_DEPS_RE = re.compile(
+    re.escape(FLOW_DEPS_OPEN) + r".*?" + re.escape(FLOW_DEPS_CLOSE),
+    re.DOTALL,
+)
+_BLOCKED_BY_RE = re.compile(r"(?m)^\*\*Blocked by:\*\*[ \t]*(.*)$")
+
+
+def _gitlab_deps_body(description: object, blocker_ref: str
+                      ) -> Union[str, TrackerError]:
+    """Add one exact blocker ref inside flow's fenced dependency block."""
+    if description is None:
+        text = ""
+    elif isinstance(description, str):
+        text = description
+    else:
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab issue description is not text",
+            subtype="malformed_body")
+    opens = text.count(FLOW_DEPS_OPEN)
+    closes = text.count(FLOW_DEPS_CLOSE)
+    if (opens != closes or opens > 1
+            or (opens == 1
+                and text.find(FLOW_DEPS_OPEN) > text.find(FLOW_DEPS_CLOSE))):
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            "gitlab flow:deps block is malformed; refusing to rewrite issue body",
+            subtype="deps_block")
+    match = _FLOW_DEPS_RE.search(text)
+    if match is None:
+        prefix = text.rstrip("\n")
+        block = (
+            f"{FLOW_DEPS_OPEN}\n"
+            f"**Blocked by:** {blocker_ref}\n"
+            f"{FLOW_DEPS_CLOSE}"
+        )
+        return f"{prefix}\n\n{block}" if prefix else block
+
+    region = match.group(0)
+    blocked = _BLOCKED_BY_RE.search(region)
+    if blocked is not None:
+        refs = [ref.strip() for ref in blocked.group(1).split(",") if ref.strip()]
+        if blocker_ref in refs:
+            return text
+        replacement = f"**Blocked by:** {', '.join([*refs, blocker_ref])}"
+        updated_region = (
+            region[:blocked.start()] + replacement + region[blocked.end():])
+    else:
+        updated_region = region.replace(
+            FLOW_DEPS_CLOSE, f"**Blocked by:** {blocker_ref}\n{FLOW_DEPS_CLOSE}",
+            1)
+    return text[:match.start()] + updated_region + text[match.end():]
+
+
+def gitlab_ensure_deps_block(config: dict, execute: Execute, *,
+                             from_id: str, from_display: str,
+                             to_display: str) -> Result:
+    """Idempotently write GitLab's direction/provenance body twin."""
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = _gl_project(dest)
+    iid = _gitlab_iid(from_display)
+    if isinstance(pid, TrackerError):
+        return pid
+    if isinstance(iid, TrackerError):
+        return iid
+    locator = {"durable": from_id, "display": from_display}
+    parent = _cli(
+        execute, "gitlab", config, "relate-body-read", "GET",
+        f"projects/{pid}/issues/{iid}", idempotent=True)
+    if isinstance(parent, TrackerError):
+        return parent
+    if not isinstance(parent, dict):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab dependency body read returned no object",
+            subtype="malformed_body")
+    err = _check_durable("gitlab", locator, parent)
+    if err:
+        return err
+    current = parent.get("description")
+    body = _gitlab_deps_body(current, to_display)
+    if isinstance(body, TrackerError):
+        return body
+    current = "" if current is None else current
+    if body == current:
+        return {"written": False, "body": body}
+    data = _cli(
+        execute, "gitlab", config, "relate-body-write", "PUT",
+        f"projects/{pid}/issues/{iid}", body={"description": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab dependency body update returned no object",
+            subtype="malformed_body")
+    err = _check_durable("gitlab", locator, data)
+    if err:
+        return err
+    if data.get("description") != body:
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab dependency body readback did not match requested body",
+            subtype="readback_mismatch")
+    return {"written": True, "body": body}
+
+
+def gitlab_set(config: dict, execute: Execute, *, from_id: str, to_id: str,
+               from_display: str, to_display: str, blocked_by: bool,
+               plan: Optional[str]) -> Result:
+    from_iid = _gitlab_iid(from_display)
+    to_iid = _gitlab_iid(to_display)
+    if isinstance(from_iid, TrackerError):
+        return from_iid
+    if isinstance(to_iid, TrackerError):
+        return to_iid
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    # Presence classification is relate.__init__'s job (4-way probe).
+    degraded = None
+    if blocked_by:
+        link_type = "is_blocked_by"
+        form = "is_blocked_by"
+    else:
+        link_type = "relates_to"
+        form = "relates_to"
+        degraded = {
+            "kind": "relates_to",
+            "capability": "blockedBy",
+            "reason": "blockedBy unavailable on this GitLab tier",
+            "plan": plan,
+        }
+
+    target_project = dest.get("projectId")
+    body = {
+        "target_project_id": target_project,
+        "target_issue_iid": to_iid,
+        "link_type": link_type,
+    }
+    data = _cli(execute, "gitlab", config, "relate-create", "POST",
+                f"projects/{pid}/issues/{from_iid}/links", body=body)
+    if isinstance(data, TrackerError):
+        return data
+    body_out = gitlab_ensure_deps_block(
+        config, execute, from_id=from_id, from_display=from_display,
+        to_display=to_display)
+    if isinstance(body_out, TrackerError):
+        import dataclasses  # noqa: PLC0415
+        return dataclasses.replace(body_out, details={
+            **(body_out.details or {}),
+            "recoverable": True,
+            "completed_steps": ["relate-create"],
+            "form": form,
+        })
+    out = {"projected": True, "already": False, "form": form}
+    if degraded:
+        out["degraded"] = degraded
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GitHub - sub_issues hierarchy ONLY (never blocked-by)
+# ---------------------------------------------------------------------------
+
+_GITHUB_HIERARCHY_DEGRADED = {
+    "kind": "hierarchy",
+    "form": "sub_issues",
+    "note": "GitHub sub_issues is hierarchy, never blocked-by",
+}
+
+
+def github_set(config: dict, execute: Execute, *, from_id: str, to_id: str,
+               from_display: str, to_display: str) -> Result:
+    """Degraded hierarchy: B (blocker) is parent, A (blocked) is sub-issue.
+
+    Body-block (<!-- flow:deps -->) writing is owned by task .5 - not here.
+    """
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    parent_num = _github_number(to_display)  # blocker = parent
+    child_num = _github_number(from_display)
+    if isinstance(parent_num, TrackerError):
+        return parent_num
+    if isinstance(child_num, TrackerError):
+        return child_num
+
+    # Need child's numeric DB id (not node_id, not number).
+    child = _cli(execute, "github", config, "relate-child-read", "GET",
+                 f"repos/{repo}/issues/{child_num}", idempotent=True)
+    if isinstance(child, TrackerError):
+        return child
+    if not isinstance(child, dict) or not isinstance(child.get("id"), int):
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "github child issue carries no numeric id",
+                            subtype="malformed_body")
+    child_db_id = child["id"]
+
+    # Presence classification is relate.__init__'s job (4-way probe).
+    data = _cli(execute, "github", config, "relate-create", "POST",
+                f"repos/{repo}/issues/{parent_num}/sub_issues",
+                body={"sub_issue_id": child_db_id})
+    if isinstance(data, TrackerError):
+        return data
+    return {
+        "projected": True, "already": False, "form": "sub_issues",
+        "degraded": dict(_GITHUB_HIERARCHY_DEGRADED),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Removal - reconcile stale flow-owned blocking edges (fn-135 chart repoint).
+# Absence remotely is convergence, never an error; truncation is unproven
+# absence (same read-before-write discipline as the probes above).
+# ---------------------------------------------------------------------------
+
+def linear_remove(config: dict, execute: Execute, *, from_id: str,
+                  to_id: str) -> Result:
+    """Delete the native blocks relation `from is-blocked-by to`."""
+    def pluck(data: dict) -> Union[dict, TrackerError]:
+        issue = data.get("issue")
+        conn = (issue.get("inverseRelations")
+                if isinstance(issue, dict) else None)
+        if not isinstance(conn, dict):
+            return TrackerError(ErrorClass.TRANSPORT,
+                                "linear relate list malformed",
+                                subtype="malformed_body")
+        return conn
+
+    drained = _gql_connection_drain(
+        execute, "relate-list",
+        "query($id: String!, $after: String) { issue(id: $id) { id "
+        f"inverseRelations(first: {_PAGE_SIZE}, after: $after) "
+        "{ nodes { id type issue { id } } "
+        "pageInfo { hasNextPage endCursor } } } }",
+        {"id": from_id}, pluck)
+    if isinstance(drained, TrackerError):
+        return drained
+    nodes, truncated = drained
+    rel_id = None
+    for n in nodes:
+        if n.get("type") != "blocks":
+            continue
+        blocker = n.get("issue") if isinstance(n.get("issue"), dict) else {}
+        if blocker.get("id") == to_id and n.get("id"):
+            rel_id = str(n["id"])
+            break
+    if rel_id is None:
+        if truncated:
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "linear relation pages truncated at drain cap; edge absence "
+                "unproven",
+                subtype="truncated")
+        return {"removed": False, "already_absent": True, "form": "blocks"}
+    data = _gql(
+        execute, "relate-delete",
+        "mutation($id: String!) { issueRelationDelete(id: $id) { success } }",
+        {"id": rel_id})
+    if isinstance(data, TrackerError):
+        return data
+    mut = data.get("issueRelationDelete")
+    if not isinstance(mut, dict) or mut.get("success") is not True:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "linear issueRelationDelete failed",
+                            subtype="mutation_failed")
+    return {"removed": True, "form": "blocks"}
+
+
+def jira_remove(config: dict, execute: Execute, *, from_id: str,
+                to_id: str) -> Result:
+    """Delete the site's blocks link carrying `from is-blocked-by to`."""
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    blocks_type = jira_blocks_type(config, execute)
+    if isinstance(blocks_type, TrackerError):
+        return blocks_type
+    data = _jira(
+        execute, "relate-list", "GET",
+        f"{base}/rest/api/2/issue/{quote(str(from_id), safe='')}"
+        f"?fields=issuelinks",
+        idempotent=True,
+    )
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "jira relate list malformed",
+                            subtype="malformed_body")
+    fields = data.get("fields") if isinstance(data.get("fields"), dict) else {}
+    link_id = None
+    for link in fields.get("issuelinks") or []:
+        if not isinstance(link, dict):
+            continue
+        typ = link.get("type") if isinstance(link.get("type"), dict) else {}
+        if str(typ.get("name") or "").casefold() != blocks_type.casefold():
+            continue
+        # Same direction rule as _jira_edge_exists: the blocker rides in
+        # inwardIssue from the blocked issue's perspective.
+        inward = (link.get("inwardIssue")
+                  if isinstance(link.get("inwardIssue"), dict) else {})
+        if (inward.get("id") is not None and str(inward.get("id")) == str(to_id)
+                and link.get("id") is not None):
+            link_id = str(link["id"])
+            break
+    if link_id is None:
+        return {"removed": False, "already_absent": True, "form": "blocks"}
+    out = _jira(
+        execute, "relate-delete", "DELETE",
+        f"{base}/rest/api/2/issueLink/{quote(link_id, safe='')}")
+    if isinstance(out, TrackerError):
+        return out
+    return {"removed": True, "form": "blocks"}
+
+
+def _gitlab_deps_body_remove(description: object, drop_refs: set
+                             ) -> Union[str, TrackerError]:
+    """Drop stale blocker refs from flow's fenced dependency block."""
+    if description is None:
+        return ""
+    if not isinstance(description, str):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab issue description is not text",
+            subtype="malformed_body")
+    text = description
+    match = _FLOW_DEPS_RE.search(text)
+    if match is None:
+        return text
+    region = match.group(0)
+    blocked = _BLOCKED_BY_RE.search(region)
+    if blocked is None:
+        return text
+    refs = [ref.strip() for ref in blocked.group(1).split(",") if ref.strip()]
+    kept = [ref for ref in refs if ref not in drop_refs]
+    if kept == refs:
+        return text
+    if kept:
+        replacement = f"**Blocked by:** {', '.join(kept)}"
+        updated_region = (
+            region[:blocked.start()] + replacement + region[blocked.end():])
+    else:
+        # Drop the whole line (and one trailing newline) - an empty
+        # Blocked-by line would read as malformed provenance.
+        updated_region = (
+            region[:blocked.start()]
+            + region[blocked.end():].lstrip("\n"))
+    return text[:match.start()] + updated_region + text[match.end():]
+
+
+def _gitlab_absent_body_reconcile(config: dict, execute: Execute, *, pid,
+                                  from_iid: int, to_id: str
+                                  ) -> Optional[TrackerError]:
+    """Scrub body refs to `to_id` when the native link is already absent.
+
+    An earlier attempt may have landed the native DELETE and then failed the
+    flow:deps body-twin write; the retry reaches absence here, so absence
+    alone must not report success while the body still claims the removed
+    blocker. Each blocked-by ref in flow's owned block resolves through the
+    destination project (the only project gitlab_set links against); a ref
+    whose issue read proves durable id == to_id is dropped. Returns None when
+    the twin no longer references the removed edge, else the retryable error.
+    """
+    parent = _cli(execute, "gitlab", config, "relate-body-read", "GET",
+                  f"projects/{pid}/issues/{from_iid}", idempotent=True)
+    if isinstance(parent, TrackerError):
+        return parent
+    if not isinstance(parent, dict):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab dependency body read returned no object",
+            subtype="malformed_body")
+    current = parent.get("description")
+    if not isinstance(current, str):
+        return None
+    match = _FLOW_DEPS_RE.search(current)
+    if match is None:
+        return None
+    blocked = _BLOCKED_BY_RE.search(match.group(0))
+    if blocked is None:
+        return None
+    drop_refs = set()
+    for ref in [r.strip() for r in blocked.group(1).split(",") if r.strip()]:
+        iid = _gitlab_iid(ref)
+        if isinstance(iid, TrackerError):
+            continue  # not an issue ref the set path writes; leave it
+        issue = _cli(execute, "gitlab", config, "relate-body-target-read",
+                     "GET", f"projects/{pid}/issues/{iid}", idempotent=True)
+        if isinstance(issue, TrackerError):
+            if issue.cls is ErrorClass.NOT_FOUND:
+                continue  # issue gone; unprovable as to_id, leave the ref
+            return issue
+        if isinstance(issue, dict) and str(issue.get("id")) == str(to_id):
+            drop_refs.add(ref)
+    if not drop_refs:
+        return None
+    body = _gitlab_deps_body_remove(current, drop_refs)
+    if isinstance(body, TrackerError):
+        return body
+    if body != current:
+        data = _cli(
+            execute, "gitlab", config, "relate-body-write", "PUT",
+            f"projects/{pid}/issues/{from_iid}", body={"description": body})
+        if isinstance(data, TrackerError):
+            return data
+    return None
+
+
+def gitlab_remove(config: dict, execute: Execute, *, from_id: str,
+                  from_display: str, to_id: str) -> Result:
+    """Delete the native issue link AND the flow:deps body ref twin."""
+    from_iid = _gitlab_iid(from_display)
+    if isinstance(from_iid, TrackerError):
+        return from_iid
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    guard = display_durable_guard(
+        "gitlab", config, execute,
+        locators=({"durable": from_id, "display": from_display},))
+    if guard:
+        return guard
+    drained = _gitlab_links(config, execute, iid=from_iid)
+    if isinstance(drained, TrackerError):
+        return drained
+    links, truncated = drained
+    target = None
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        if (str(link.get("id")) == str(to_id)
+                and link.get("link_type") in ("is_blocked_by", "relates_to")
+                and link.get("issue_link_id") is not None):
+            target = link
+            break
+    if target is None:
+        if truncated:
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "gitlab issue link pages truncated at drain cap; edge absence "
+                "unproven",
+                subtype="truncated")
+        # A prior attempt may have deleted the link and failed only the body
+        # twin - never report absence as success while the flow:deps block
+        # still claims the removed blocker.
+        err = _gitlab_absent_body_reconcile(
+            config, execute, pid=pid, from_iid=from_iid, to_id=to_id)
+        if err is not None:
+            return _removal_body_failure(err)
+        return {"removed": False, "already_absent": True, "form": "blocks"}
+    data = _cli(execute, "gitlab", config, "relate-delete", "DELETE",
+                f"projects/{pid}/issues/{from_iid}/links/"
+                f"{target['issue_link_id']}")
+    if isinstance(data, TrackerError):
+        return data
+    # Body twin: drop the blocker ref gitlab_set recorded. Candidate refs
+    # cover both identifier shapes the set path may have written.
+    drop_refs = set()
+    refs = target.get("references")
+    if isinstance(refs, dict):
+        for key in ("full", "relative", "short"):
+            if isinstance(refs.get(key), str) and refs[key]:
+                drop_refs.add(refs[key])
+    if target.get("iid") is not None:
+        drop_refs.add(f"#{target['iid']}")
+    parent = _cli(
+        execute, "gitlab", config, "relate-body-read", "GET",
+        f"projects/{pid}/issues/{from_iid}", idempotent=True)
+    if isinstance(parent, TrackerError):
+        return _removal_body_failure(parent)
+    if not isinstance(parent, dict):
+        return _removal_body_failure(TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab dependency body read returned no object",
+            subtype="malformed_body"))
+    current = parent.get("description")
+    body = _gitlab_deps_body_remove(current, drop_refs)
+    if isinstance(body, TrackerError):
+        return _removal_body_failure(body)
+    if body != ("" if current is None else current):
+        data = _cli(
+            execute, "gitlab", config, "relate-body-write", "PUT",
+            f"projects/{pid}/issues/{from_iid}", body={"description": body})
+        if isinstance(data, TrackerError):
+            return _removal_body_failure(data)
+    return {"removed": True, "form": "blocks"}
+
+
+def _removal_body_failure(err: TrackerError) -> TrackerError:
+    """Native link removal landed; the deps-body twin update did not."""
+    import dataclasses  # noqa: PLC0415
+    return dataclasses.replace(err, details={
+        **(err.details or {}),
+        "recoverable": True,
+        "completed_steps": ["relate-delete"],
+        "form": "blocks",
+    })
+
+
+PROVIDERS = {
+    "linear": linear_set,
+    "jira": jira_set,
+    "gitlab": gitlab_set,
+    "github": github_set,
+}
+
+# ---------------------------------------------------------------------------
+# Probe-only presence (read, never mutate) - the 4-way ledger x remote
+# classification in relate.__init__ needs presence WITHOUT a write attempt.
+# ---------------------------------------------------------------------------
+
+def linear_probe(config, execute, *, from_id, to_id, **_kw):
+    return _linear_edge_exists(execute, from_id, to_id)
+
+
+def jira_probe(config, execute, *, from_id, to_id, **_kw):
+    return _jira_edge_exists(config, execute, from_id=from_id, to_id=to_id)
+
+
+def gitlab_probe_pair(config, execute, *, from_display, to_display, **_kw):
+    from ..wire import _gitlab_iid  # noqa: PLC0415
+    self_iid = _gitlab_iid(from_display)
+    if isinstance(self_iid, TrackerError):
+        return self_iid
+    target_iid = _gitlab_iid(to_display)
+    if isinstance(target_iid, TrackerError):
+        return target_iid
+    drained = _gitlab_links(config, execute, iid=self_iid)
+    if isinstance(drained, TrackerError):
+        return drained
+    links, truncated = drained
+    # link_type is expressed relative to the QUERIED issue (from):
+    # "is_blocked_by" is the requested edge (from blocked by target);
+    # "blocks" is the REVERSE direction (from blocks target) and must NOT
+    # match - a reverse edge is not the requested one. "relates_to" stays:
+    # it is flow's own degraded projection form on tiers without blockedBy
+    # (symmetric, direction-free).
+    if _gitlab_pair_present(links, target_iid=target_iid,
+                            link_types={"is_blocked_by", "relates_to"}):
+        return True
+    if truncated:
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab issue link pages truncated at drain cap; edge absence "
+            "unproven",
+            subtype="truncated")
+    return False
+
+
+def github_probe(config, execute, *, from_display, to_display, **_kw):
+    # Direction matches github_set: the PARENT is the BLOCKER (to_display);
+    # the blocked issue (from_display) appears among its sub_issues.
+    from ..wire import (_cli, _destination, _gh_repo,  # noqa: PLC0415
+                        _github_number, _rest_drain)
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    parent = _github_number(to_display)
+    if isinstance(parent, TrackerError):
+        return parent
+    child = _github_number(from_display)
+    if isinstance(child, TrackerError):
+        return child
+    # Drain every page to the shared wire cap (fn-64 read-before-write): a
+    # single-page probe would report a later-page child ABSENT, falsely
+    # queueing a ledgered edge as a human removal (or duplicating the create
+    # on an unledgered one). Truncation is unproven absence, never absence.
+    drained = _rest_drain(lambda page: _cli(
+        execute, "github", config, "wire-relate-probe", "GET",
+        f"repos/{repo}/issues/{parent}/sub_issues"
+        f"?per_page={_PAGE_SIZE}&page={page}", idempotent=True))
+    if isinstance(drained, TrackerError):
+        return drained
+    subs, truncated = drained
+    if any(isinstance(x, dict) and x.get("number") == child for x in subs):
+        return True
+    if truncated:
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "github sub_issues pages truncated at drain cap; edge absence "
+            "unproven",
+            subtype="truncated")
+    return False
+
+
+PROBES = {
+    "linear": linear_probe,
+    "jira": jira_probe,
+    "gitlab": gitlab_probe_pair,
+    "github": github_probe,
+}

--- a/.flow/bin/flowctl_tracker/resolve_verb.py
+++ b/.flow/bin/flowctl_tracker/resolve_verb.py
@@ -1,0 +1,343 @@
+"""`flowctl tracker resolve` orchestration (fn-139.6, R9/R11/R12).
+
+The EXPLICIT backfill: `resolve` populates an absent `tracker.resolved` block
+(destination + ids scope + capabilities per provider). This is deliberately
+distinct from a consuming verb meeting an absent block - that returns
+`class: unresolved` and never resolves implicitly mid-operation.
+
+`--scope` re-resolves only the named nested path (its own timestamp).
+`--refresh` forces re-resolution of already-fresh scopes.
+`--select slot=id` persists ONE human tiebreak, validated against live
+candidates; repeatable; re-select overwrites.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+from . import envelope
+from .credentials import redact
+from .executor import execute as default_execute
+from .providers import resolver_for
+from .resolved_cache import (SCOPES, apply_capability_probe, capabilities_stale,
+                             resolve_transaction)
+from .states import Assignment, is_alias, validate_select
+from .types import ErrorClass, TrackerError
+
+#: Scopes each provider resolves, in dependency order (destination first: the
+#: ids scopes and the GitLab tier probe consume pinned destination fields).
+SCOPES_BY_PROVIDER = {
+    "github": ("destination", "capabilities"),
+    "gitlab": ("destination", "capabilities"),
+    "linear": ("destination", "destination.stateIds", "capabilities"),
+    "jira": ("destination", "destination.statusIds", "capabilities"),
+}
+
+_IDS_SCOPE = {"linear": "destination.stateIds", "jira": "destination.statusIds"}
+
+_ACTIVE_TYPES = {"github", "gitlab", "linear", "jira"}
+
+
+def _dict(value) -> dict:
+    """Malformed-but-valid config shapes must produce the JSON error envelope,
+    never an AttributeError - `{"tracker": "bad"}` is a thing users write."""
+    return value if isinstance(value, dict) else {}
+
+
+def _tracker_type(config: dict) -> Optional[str]:
+    t = _dict(config.get("tracker")).get("type")
+    return t if t in _ACTIVE_TYPES else None
+
+
+def _stderr_sink(message: str) -> None:
+    """R-observability: every attempt/backoff/scope/downgrade/probe event lands
+    on stderr, redacted. stdout stays reserved for the single JSON envelope."""
+    print(redact(str(message)), file=sys.stderr)
+
+
+def _float_or_none(value, lo: float, hi: float) -> Optional[float]:
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if lo < f <= hi else None
+
+
+def bound_executor(config: dict, execute: Callable,
+                   on_event: Callable[[str], None] = _stderr_sink) -> Callable:
+    """Bind the PERSISTED transport policy onto the raw executor.
+
+    This is the wiring the completion review caught missing: `authScheme`
+    decided at the discovery ceremony, `sslVerify` (+ `JIRA_SSL_VERIFY` env
+    override), the stderr event sink, and the R7 config-overridable bounds
+    (`tracker.transport.timeoutS/maxRetries/backoffCapS/concurrency`) - none
+    of which reached a real request when adapters called `execute` bare.
+    """
+    tracker = _dict(config.get("tracker"))
+    per = _dict(tracker.get("perTracker"))
+    transport = _dict(tracker.get("transport"))
+
+    auth_scheme = per.get("authScheme")
+    verify_tls = per.get("sslVerify")
+    verify_tls = True if verify_tls is None else bool(verify_tls)
+    env_ssl = os.environ.get("JIRA_SSL_VERIFY")
+    if tracker.get("type") == "jira" and env_ssl is not None:
+        verify_tls = env_ssl.strip().lower() not in ("false", "0", "no")
+
+    timeout_s = _float_or_none(transport.get("timeoutS"), 0, 600)
+    backoff_cap = _float_or_none(transport.get("backoffCapS"), 0, 300)
+    retries = transport.get("maxRetries")
+    retries = retries if isinstance(retries, int) and 0 <= retries <= 5 else None
+    concurrency = transport.get("concurrency")
+    concurrency = (concurrency if isinstance(concurrency, int)
+                   and 1 <= concurrency <= 16 else None)
+
+    if execute is not default_execute:
+        # Injected fake (tests): policy kwargs would explode a plain callable.
+        return execute
+
+    def bound(request):
+        if timeout_s is not None and request.timeout_s == type(request).__dataclass_fields__["timeout_s"].default:
+            import dataclasses
+            request = dataclasses.replace(request, timeout_s=timeout_s)
+        return default_execute(request, auth_scheme=auth_scheme,
+                               verify_tls=verify_tls, on_event=on_event,
+                               max_retries=retries, backoff_cap_s=backoff_cap,
+                               concurrency=concurrency)
+    return bound
+
+
+def _config_shape_error(config: dict) -> Optional[TrackerError]:
+    tracker = config.get("tracker")
+    if tracker is not None and not isinstance(tracker, dict):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"tracker config is {type(tracker).__name__}, not an "
+                            "object", subtype="config")
+    per = _dict(tracker).get("perTracker")
+    if per is not None and not isinstance(per, dict):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"tracker.perTracker is {type(per).__name__}, not an "
+                            "object", subtype="config")
+    return None
+
+
+def _read_raw(flow_dir: Path) -> dict:
+    import json
+    try:
+        data = json.loads((Path(flow_dir) / "config.json").read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _assignment_to_data(assignment: Assignment) -> Union[dict, TrackerError]:
+    if assignment.conflict is not None:
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"slot {assignment.conflict['normalized']!r} is ambiguous; pick one "
+            "with `flowctl tracker resolve --select <slot>=<id>`",
+            subtype="ambiguous_slot", details=assignment.conflict)
+    if assignment.missing_required:
+        slot = assignment.missing_required[0]
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"required slot {slot!r} has no live candidate in this workflow; "
+            "alias it explicitly with `--select {slot}=<id>`".format(slot=slot),
+            subtype="missing_slot",
+            details={"normalized": slot, "candidates": []})
+    return dict(assignment.mapping)
+
+
+def _ids_resolver(provider_mod, provider: str) -> Callable:
+    return (provider_mod.resolve_state_ids if provider == "linear"
+            else provider_mod.resolve_status_ids)
+
+
+def _fetch_pools(provider_mod, provider: str, config: dict, execute: Callable):
+    return (provider_mod.fetch_states(config, execute) if provider == "linear"
+            else provider_mod.fetch_statuses(config, execute))
+
+
+def run(flow_dir: Path, *, scope: Optional[str] = None, refresh: bool = False,
+        select: Optional[str] = None,
+        execute: Callable = default_execute) -> tuple[str, int]:
+    """Returns (stdout payload, exit code) - the single result envelope."""
+    config = _read_raw(flow_dir)
+    shape_error = _config_shape_error(config)
+    if shape_error is not None:
+        return envelope.failure(shape_error)
+    provider = _tracker_type(config)
+    if provider is None:
+        return envelope.inactive()
+    try:
+        mod = resolver_for(provider)
+    except KeyError as exc:
+        return envelope.failure(TrackerError(ErrorClass.INVALID_INPUT, str(exc),
+                                             subtype="provider"))
+
+    warnings: list = []
+    aliases: dict = {}
+
+    if select is not None:
+        return _run_select(flow_dir, config, mod, provider, select, execute)
+
+    if scope is not None:
+        if scope not in SCOPES:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"unknown scope {scope!r}; canonical scopes are {SCOPES}",
+                subtype="scope"))
+        if scope not in SCOPES_BY_PROVIDER[provider]:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"scope {scope!r} does not apply to provider {provider!r}",
+                subtype="scope"))
+        scopes = (scope,)
+    else:
+        scopes = SCOPES_BY_PROVIDER[provider]
+
+    probe_field = None
+    degraded_field = None
+    for s in scopes:
+        current = _read_raw(flow_dir)
+        already = _dict(_dict(_dict(_dict(current.get("tracker"))
+                                    .get("resolved")).get("scopeResolvedAt")))
+        if s in already and not refresh and scope is None:
+            # Backfill touches only what is absent - EXCEPT the one dynamic
+            # capability: GitLab's plan-gated blockedBy re-probes when its
+            # scope timestamp is older than the TTL (24h). This is the wiring
+            # that makes `capabilities_stale` reachable in production.
+            if (s == "capabilities" and provider == "gitlab"
+                    and capabilities_stale(current)):
+                _stderr_sink(f"scope={s} provider={provider} ttl-reprobe")
+                outcome = _ttl_reprobe(flow_dir, current, mod, execute)
+                if isinstance(outcome, TrackerError):
+                    return envelope.failure(outcome)
+                probe_field, degraded_field = outcome
+            continue
+
+        _stderr_sink(f"scope={s} provider={provider} resolving")
+
+        def network_fn(cfg: dict, _s: str = s) -> Union[dict, TrackerError]:
+            ex = bound_executor(cfg, execute)
+            if _s == "destination":
+                return mod.resolve_destination(cfg, ex)
+            if _s in ("destination.stateIds", "destination.statusIds"):
+                out = _ids_resolver(mod, provider)(cfg, ex)
+                if isinstance(out, TrackerError):
+                    return out
+                warnings.extend(out.warnings)
+                aliases.update(out.aliases)
+                return _assignment_to_data(out)
+            return mod.resolve_capabilities(cfg, ex)
+
+        result = resolve_transaction(flow_dir, s, network_fn)
+        if isinstance(result, TrackerError):
+            return envelope.failure(result)
+
+    final = _read_raw(flow_dir)
+    resolved = _dict(_dict(final.get("tracker")).get("resolved"))
+    data = {"resolved": resolved, "warnings": warnings, "aliases": aliases}
+    return envelope.success(data, degraded=degraded_field, probe=probe_field)
+
+
+_PROBE_FAILED = "ttl_probe_failed_keep_prior"
+
+
+def _ttl_reprobe(flow_dir: Path, config: dict, mod, execute: Callable):
+    """One synchronous, bounded re-probe; a FAILED probe keeps the prior value
+    and reports via `probe`, never `degraded`. Returns (probe, degraded).
+
+    The probe runs INSIDE the transaction's `network_fn`, so the R8 discovery
+    fingerprint covers the exact config it queried: probing before the
+    transaction let a mid-probe repoint commit project A's plan under
+    project B (reproduced by the completion review).
+    """
+    outcome_box = {}
+
+    def network_fn(cfg: dict):
+        ex = bound_executor(cfg, execute)
+        ok, plan, reason = mod.probe_plan(cfg, ex)
+        staged = {"tracker": {"type": "gitlab",
+                              "resolved": _dict(_dict(cfg.get("tracker"))
+                                                .get("resolved"))}}
+        outcome_box.clear()
+        outcome_box.update(apply_capability_probe(staged, ok=ok, plan=plan,
+                                                  reason=reason))
+        if not ok:
+            _stderr_sink(f"probe scope=capabilities ok=false reason={reason}")
+            # No write on a failed probe - but not a failed COMMAND either.
+            # The sentinel aborts the transaction; the caller maps it back to
+            # success-with-probe-field.
+            return TrackerError(ErrorClass.TRANSPORT, "ttl probe failed",
+                                subtype=_PROBE_FAILED)
+        return _dict(_dict(staged["tracker"]["resolved"]).get("capabilities"))
+
+    result = resolve_transaction(flow_dir, "capabilities", network_fn)
+    if isinstance(result, TrackerError):
+        if result.subtype == _PROBE_FAILED:
+            return outcome_box.get("probe"), None
+        return result
+    if outcome_box.get("degraded"):
+        _stderr_sink(f"capability degraded: {outcome_box['degraded']}")
+    return outcome_box.get("probe"), outcome_box.get("degraded")
+
+
+def _run_select(flow_dir: Path, config: dict, mod, provider: str,
+                select: str, execute: Callable) -> tuple[str, int]:
+    if provider not in _IDS_SCOPE:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"--select applies to linear/jira slot resolution, not {provider!r}",
+            subtype="select"))
+    if "=" not in select:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "--select takes <normalized>=<id> (exactly one slot per call)",
+            subtype="select"))
+    slot, chosen = select.split("=", 1)
+    slot, chosen = slot.strip(), chosen.strip()
+
+    ids_scope = _IDS_SCOPE[provider]
+    key = ids_scope.split(".", 1)[1]
+    seen = {}  # pools captured by network_fn for the alias verdict
+
+    def network_fn(cfg: dict) -> object:
+        # Fetch + validate INSIDE the transaction's network step, against the
+        # config the transaction fingerprints: fetching before the transaction
+        # let a concurrent destination repoint slip between validation and the
+        # merge - team A's state id written into team B's config.
+        fetched = _fetch_pools(mod, provider, cfg, bound_executor(cfg, execute))
+        if isinstance(fetched, TrackerError):
+            return fetched
+        pools, live = fetched
+        error = validate_select(slot, chosen, pools, live)
+        if error:
+            return TrackerError(ErrorClass.INVALID_INPUT, error, subtype="select")
+        seen["pools"] = pools
+        return {slot: chosen}
+
+    def finalize_fn(current_cfg: dict, data: dict) -> dict:
+        # Merge INSIDE the lock so a concurrent select of another slot is not
+        # clobbered by a whole-map replace computed from a stale read.
+        existing = _dict(_dict(_dict(_dict(current_cfg.get("tracker"))
+                                     .get("resolved")).get("destination")).get(key))
+        return {**existing, **data}
+
+    result = resolve_transaction(flow_dir, ids_scope, network_fn,
+                                 finalize_fn=finalize_fn)
+    if isinstance(result, TrackerError):
+        return envelope.failure(result)
+    aliased = is_alias(slot, chosen, seen.get("pools", {}))
+    final_map = _dict(_dict(_dict(_dict(result.get("tracker"))
+                                 .get("resolved")).get("destination")).get(key))
+    return envelope.success({
+        "selected": {slot: chosen},
+        "alias": aliased,
+        key: final_map,
+        "warnings": ([f"{slot!r} aliases a state outside its natural candidates "
+                      f"(recorded, not silent)"] if aliased else []),
+    })

--- a/.flow/bin/flowctl_tracker/resolved_cache.py
+++ b/.flow/bin/flowctl_tracker/resolved_cache.py
@@ -1,0 +1,444 @@
+"""`tracker.resolved`: resolve once, consume deterministically (fn-139.3).
+
+This module owns the cache schema, the scoped-timestamp rules, the resolve
+TRANSACTION, the cache state machine (behind a seam - spec B wires the real
+verbs), and the `apiVersion: 3 -> 2` migration.
+
+The transaction is the hard part. Atomic write plus a lock does NOT prevent
+stale resolution: a resolver can query project A, then a `config set` repoints
+the tracker to project B, and the resolver merges A's ids into B's config.
+Required order, implemented in `resolve_transaction`:
+
+    network work OUTSIDE the lock
+    acquire the lock shared by every .flow/config.json writer
+    re-read INSIDE
+    compare the discovery-input FINGERPRINT
+    merge ONLY the resolved scope
+    validate
+    atomically replace
+
+Fingerprint mismatch has ONE bounded behavior: discard and re-resolve once; a
+second mismatch returns `class: conflict` rather than looping.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+from .config_lock import ConfigLockTimeout, ConfigLockUnsafe, config_lock
+from .types import ErrorClass, TrackerError
+
+#: Canonical scope paths - the ONLY keys `scopeResolvedAt` may contain.
+SCOPES = ("destination", "destination.statusIds", "destination.stateIds", "capabilities")
+
+#: Only GitLab has a dynamic capability (plan-gated blockedBy); everyone else
+#: is static and never re-probed.
+CAPABILITY_TTL_HOURS = 24.0
+
+CAPABILITY_KEYS = ("attachments", "blockedBy", "subIssues", "deleteIssue")
+
+#: Fields `resolvedAt` requires per tracker (spec A resolved-fields table).
+#: `resolvedAt` is a completeness statement, never a TTL input.
+REQUIRED_DESTINATION_FIELDS = {
+    "github": ("owner", "repo"),
+    "gitlab": ("projectId", "projectPath", "host", "namespaceId"),
+    "linear": ("teamId", "teamKey", "stateIds", "labelIds"),
+    "jira": ("baseUrl", "projectKey", "projectId", "issueTypeId",
+             "apiVersion", "style", "statusIds"),
+}
+
+#: Capability truth table, decided in spec A so B cannot leave it open. GitLab
+#: `blockedBy` is plan-dependent and filled by the tier probe, not this table.
+STATIC_CAPABILITIES = {
+    "github": {"attachments": False, "blockedBy": False, "subIssues": True, "deleteIssue": False},
+    "gitlab": {"attachments": True, "subIssues": False, "deleteIssue": True},
+    "linear": {"attachments": True, "blockedBy": True, "subIssues": False, "deleteIssue": True},
+    "jira": {"attachments": True, "blockedBy": True, "subIssues": False, "deleteIssue": True},
+}
+
+#: GitLab plans that unlock `blockedBy` (measured: Free rejects, Ultimate
+#: accepts; trials are group-scoped).
+_GITLAB_BLOCKEDBY_PLANS = frozenset({
+    "premium", "premium_trial", "ultimate", "ultimate_trial", "gold", "silver",
+})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Discovery fingerprint (R8)
+# ---------------------------------------------------------------------------
+
+#: Every discovery input the network work depends on. A resolver that queried
+#: with one set of these must not merge its answer into a config where any of
+#: them changed.
+_FINGERPRINT_KEYS = ("type", "host", "baseUrl", "project", "projectId",
+                     "projectKey", "teamId", "owner", "repo")
+
+
+def discovery_fingerprint(config: dict) -> str:
+    tracker = config.get("tracker") or {}
+    per = tracker.get("perTracker") or {}
+    material = {"type": tracker.get("type")}
+    for k in _FINGERPRINT_KEYS[1:]:
+        material[k] = per.get(k)
+    return hashlib.sha256(
+        json.dumps(material, sort_keys=True, default=str).encode()
+    ).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Timestamp + merge rules (R10, R12-partial)
+# ---------------------------------------------------------------------------
+
+def _required_complete(resolved: dict, tracker_type: str) -> bool:
+    dest = resolved.get("destination")
+    caps = resolved.get("capabilities")
+    if not isinstance(dest, dict) or not isinstance(caps, dict):
+        return False
+    required = REQUIRED_DESTINATION_FIELDS.get(tracker_type)
+    if required is None:
+        return False
+    for f in required:
+        value = dest.get(f)
+        if value is None or value == "":
+            # NOTE: an empty dict is PRESENT (a team with zero labels has
+            # labelIds {}); slot-level completeness below is what guards the
+            # ids maps, not container non-emptiness.
+            return False
+    # Slot-level rule: resolution completes only when every REQUIRED normalized
+    # slot is filled (todo / in_progress / done - fn-139.6 vocabulary).
+    ids_key = {"linear": "stateIds", "jira": "statusIds"}.get(tracker_type)
+    if ids_key:
+        from .states import REQUIRED_SLOTS
+        ids = dest.get(ids_key)
+        if not isinstance(ids, dict) or not all(s in ids for s in REQUIRED_SLOTS):
+            return False
+    return all(isinstance(caps.get(k), bool) for k in CAPABILITY_KEYS)
+
+
+def _recompute_resolved_at(resolved: dict, tracker_type: str, now: str) -> None:
+    """`resolvedAt` rule, verbatim from the epic:
+
+    set ONLY when every required field is present; PRESERVED across a partial
+    refresh; CLEARED if a refresh reveals a now-missing required field.
+    """
+    if _required_complete(resolved, tracker_type):
+        if not resolved.get("resolvedAt"):
+            resolved["resolvedAt"] = now
+        # else: preserved - a partial refresh never bumps it.
+    else:
+        resolved["resolvedAt"] = None
+
+
+def apply_scope_result(config: dict, scope: str, data: Any, *,
+                       now: Optional[str] = None) -> dict:
+    """Pure scope merge: stamp exactly one `scopeResolvedAt` entry and touch
+    ONLY that scope's data. Returns the same config object, mutated.
+
+    A destination refresh must not clobber `statusIds`/`stateIds` (their own
+    scopes) and must not make capabilities look fresh - scope isolation is the
+    reason the map exists.
+    """
+    if scope not in SCOPES:
+        raise ValueError(f"unknown scope {scope!r}; canonical scopes are {SCOPES}")
+    now = now or _now_iso()
+    tracker = config.setdefault("tracker", {})
+    resolved = tracker.setdefault("resolved", {})
+    sra = resolved.setdefault("scopeResolvedAt", {})
+
+    if scope == "destination":
+        if not isinstance(data, dict):
+            raise ValueError("destination scope data must be a mapping")
+        dest = resolved.setdefault("destination", {})
+        for k, v in data.items():
+            if k in ("statusIds", "stateIds"):
+                raise ValueError(
+                    f"{k} belongs to scope 'destination.{k}'; a destination "
+                    "refresh must not write it"
+                )
+            dest[k] = v
+    elif scope in ("destination.statusIds", "destination.stateIds"):
+        key = scope.split(".", 1)[1]
+        if not isinstance(data, dict):
+            raise ValueError(f"{scope} data must be a mapping of normalized -> id")
+        resolved.setdefault("destination", {})[key] = dict(data)
+    else:  # capabilities
+        if not isinstance(data, dict) or not all(
+                isinstance(data.get(k), bool) for k in CAPABILITY_KEYS):
+            raise ValueError(
+                f"capabilities data must carry booleans for all of {CAPABILITY_KEYS}")
+        allowed = set(CAPABILITY_KEYS) | {"_source"}
+        unknown = set(data) - allowed
+        if unknown:
+            raise ValueError(f"unknown capability keys: {sorted(unknown)}")
+        resolved["capabilities"] = dict(data)
+
+    sra[scope] = now
+    _recompute_resolved_at(resolved, (tracker.get("type") or ""), now)
+    return config
+
+
+def validate_resolved_block(resolved: dict) -> None:
+    """Schema guard run inside the transaction, before the atomic replace."""
+    if not isinstance(resolved, dict):
+        raise ValueError("tracker.resolved must be an object")
+    sra = resolved.get("scopeResolvedAt", {})
+    if not isinstance(sra, dict):
+        raise ValueError("scopeResolvedAt must be an object")
+    unknown = set(sra) - set(SCOPES)
+    if unknown:
+        raise ValueError(f"scopeResolvedAt has non-canonical keys: {sorted(unknown)}")
+    for legacy in ("destinationResolvedAt", "capabilitiesCheckedAt"):
+        if legacy in resolved:
+            raise ValueError(f"legacy field {legacy!r} is not part of the schema")
+
+
+def capabilities_stale(config: dict, *, ttl_hours: float = CAPABILITY_TTL_HOURS,
+                       now_ts: Optional[float] = None) -> bool:
+    """TTL re-probe eligibility. ONLY GitLab has a dynamic capability; every
+    other tracker returns False unconditionally (static, never re-probed)."""
+    tracker = config.get("tracker") or {}
+    if tracker.get("type") != "gitlab":
+        return False
+    stamp = ((tracker.get("resolved") or {}).get("scopeResolvedAt") or {}).get("capabilities")
+    if not stamp:
+        return True
+    try:
+        parsed = datetime.fromisoformat(str(stamp).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return True
+    now_ts = time.time() if now_ts is None else now_ts
+    return (now_ts - parsed) > ttl_hours * 3600.0
+
+
+# ---------------------------------------------------------------------------
+# Migration (task: apiVersion 3 -> 2)
+# ---------------------------------------------------------------------------
+
+def migrate_config(config: dict) -> bool:
+    """`perTracker.apiVersion: 3` -> `2`. Measured: v2 round-trips plain
+    strings byte-exact on Cloud AND DC; v3 forces ADF. Returns True if changed.
+    """
+    per = (config.get("tracker") or {}).get("perTracker")
+    if isinstance(per, dict) and per.get("apiVersion") == 3:
+        per["apiVersion"] = 2
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# The resolve transaction (R8 / R8b)
+# ---------------------------------------------------------------------------
+
+def _read_config(config_path: Path) -> dict:
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"unreadable config at {config_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        # A present-but-non-object config is CORRUPT, not absent. Treating it
+        # as {} made the transaction atomically overwrite the file with a fresh
+        # document - silently destroying whatever the user had.
+        raise ValueError(
+            f"config at {config_path} is valid JSON but not an object; "
+            "refusing to overwrite it")
+    return data
+
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
+            f.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def resolve_transaction(
+    flow_dir: Path,
+    scope: str,
+    network_fn: Callable[[dict], Union[dict, TrackerError]],
+    *,
+    now: Optional[str] = None,
+    finalize_fn: Optional[Callable[[dict, dict], dict]] = None,
+) -> Union[dict, TrackerError]:
+    """Run one scoped resolve with the R8 ordering. Returns the merged config,
+    or a TrackerError (never raises for the specified failure modes).
+
+    `network_fn(config)` performs the provider round-trip OUTSIDE the lock and
+    returns the scope data (or a TrackerError to propagate verbatim).
+
+    `finalize_fn(current_config, data)`, when given, recomputes the scope data
+    INSIDE the lock against the just-re-read config. `--select` needs it: its
+    data is one slot merged into the current map, and computing that merge from
+    the pre-lock read would let two concurrent selects clobber each other with
+    whole-map replaces.
+    """
+    if scope not in SCOPES:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"unknown scope {scope!r}", subtype="scope")
+    config_path = Path(flow_dir) / "config.json"
+    for _attempt in (1, 2):
+        try:
+            before = _read_config(config_path)
+        except ValueError as exc:
+            return TrackerError(ErrorClass.INVALID_INPUT, str(exc), subtype="config")
+        fingerprint = discovery_fingerprint(before)
+
+        data = network_fn(before)  # network work OUTSIDE the lock
+        if isinstance(data, TrackerError):
+            return data
+
+        try:
+            with config_lock(flow_dir):
+                current = _read_config(config_path)  # re-read INSIDE
+                if discovery_fingerprint(current) != fingerprint:
+                    # Discovery inputs changed mid-resolve (e.g. a repoint to
+                    # another project). Merging would write the OLD project's
+                    # ids into the NEW project's config. Bounded: retry once.
+                    continue
+                migrate_config(current)
+                final_data = finalize_fn(current, data) if finalize_fn else data
+                apply_scope_result(current, scope, final_data, now=now)
+                validate_resolved_block(current["tracker"]["resolved"])
+                _atomic_write_json(config_path, current)
+                return current
+        except ConfigLockTimeout as exc:
+            return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+        except ConfigLockUnsafe as exc:
+            return TrackerError(ErrorClass.INVALID_INPUT, str(exc), subtype="lock_unsafe")
+        except ValueError as exc:
+            return TrackerError(ErrorClass.INVALID_INPUT, str(exc), subtype="validate")
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        "discovery inputs changed twice during resolve; refusing to merge "
+        "a resolution computed against a repointed tracker",
+        subtype="fingerprint",
+        details={"scope": scope},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache state machine, behind a seam (R10, spec-B rows unit-tested here)
+# ---------------------------------------------------------------------------
+
+class Trigger(str, enum.Enum):
+    ABSENT_BLOCK = "absent_block"            # consuming verb met no cache
+    ABSENT_FIELD = "absent_field"            # partial prior resolution
+    STALE_ID = "stale_id"                    # write rejected stale_id (spec B)
+    CAPABILITY_REJECTED = "capability_rejected"  # write rejected capability (spec B)
+    CAPABILITY_TTL = "capability_ttl"        # capabilities scope older than TTL
+    AMBIGUOUS_STATE = "ambiguous_state"      # cached stateId gone, >1 candidate
+    AUTH_FAILURE = "auth_failure"            # 401/403
+    RETRY_EXHAUSTED = "retry_exhausted"      # both attempts failed (spec B)
+
+
+@dataclass(frozen=True)
+class Action:
+    """What a trigger requires. Spec B's verbs execute these; A tests them."""
+
+    kind: str                                # "fail" | "resolve_scope" | "degrade" | "probe"
+    error_class: Optional[ErrorClass] = None
+    scope: Optional[str] = None
+    retry_operation: bool = False
+    needs_human: bool = False
+    note: Optional[str] = None
+
+
+#: Max scoped re-resolve attempts for a stale id: attempt 1 and attempt 2, then
+#: retry-exhausted. From the state table, not tunable.
+STALE_ID_MAX_ATTEMPTS = 2
+
+
+def plan_transition(trigger: Trigger, *, attempt: int = 1,
+                    scope: Optional[str] = None) -> Action:
+    """The state table as one total function. No trigger falls through."""
+    if trigger is Trigger.ABSENT_BLOCK:
+        # A consuming verb NEVER resolves implicitly mid-operation and NEVER
+        # invents a false capability `false`. Backfill is `resolve`'s job (R9).
+        return Action(kind="fail", error_class=ErrorClass.UNRESOLVED,
+                      note="run `flowctl tracker resolve` to backfill")
+    if trigger is Trigger.ABSENT_FIELD:
+        return Action(kind="resolve_scope", scope=scope, retry_operation=True)
+    if trigger is Trigger.STALE_ID:
+        if attempt <= STALE_ID_MAX_ATTEMPTS:
+            return Action(kind="resolve_scope", scope=scope, retry_operation=True)
+        return plan_transition(Trigger.RETRY_EXHAUSTED)
+    if trigger is Trigger.CAPABILITY_REJECTED:
+        # Degrade with a structured `degraded` field; existing relations are
+        # left intact (removal would be data loss on a plan downgrade).
+        return Action(kind="degrade", scope="capabilities")
+    if trigger is Trigger.CAPABILITY_TTL:
+        # Synchronous, bounded re-probe - one request, own timeout, no daemon.
+        return Action(kind="probe", scope="capabilities")
+    if trigger is Trigger.AMBIGUOUS_STATE:
+        return Action(kind="fail", error_class=ErrorClass.CONFLICT, needs_human=True,
+                      note="surface both candidates; a human picks the slot")
+    if trigger is Trigger.AUTH_FAILURE:
+        # No retry and NO degradation: a 401/403 must never be misread as a
+        # tier downgrade.
+        return Action(kind="fail", error_class=ErrorClass.AUTH, needs_human=True)
+    if trigger is Trigger.RETRY_EXHAUSTED:
+        # Operation fails cleanly, cache untouched.
+        return Action(kind="fail", error_class=ErrorClass.UNRESOLVED, needs_human=True,
+                      note="cache untouched")
+    raise ValueError(f"unknown trigger: {trigger!r}")  # pragma: no cover - enum-total
+
+
+# ---------------------------------------------------------------------------
+# GitLab tier probe application (R10: transient 403 never flips a capability)
+# ---------------------------------------------------------------------------
+
+def apply_capability_probe(config: dict, *, ok: bool, plan: Optional[str] = None,
+                           reason: Optional[str] = None,
+                           now: Optional[str] = None) -> dict:
+    """Fold one tier-probe outcome into the cache.
+
+    A FAILED probe is not a capability change: the prior value stays, nothing
+    is re-stamped, and the outcome is reported via the returned `probe` field
+    `{scope, at, ok, reason}` - distinct from `degraded`, which means an actual
+    transition. Returns `{"probe": ..., "degraded": ...}` for the envelope.
+    """
+    now = now or _now_iso()
+    probe = {"scope": "capabilities", "at": now, "ok": bool(ok),
+             "reason": None if ok else (reason or "probe failed")}
+    if not ok:
+        return {"probe": probe, "degraded": None}
+
+    tracker = config.setdefault("tracker", {})
+    resolved = tracker.setdefault("resolved", {})
+    caps = resolved.get("capabilities")
+    prior = caps.get("blockedBy") if isinstance(caps, dict) else None
+    new_blocked_by = (plan or "").lower() in _GITLAB_BLOCKEDBY_PLANS
+
+    merged = dict(caps) if isinstance(caps, dict) else {
+        **STATIC_CAPABILITIES["gitlab"], "blockedBy": new_blocked_by}
+    merged["blockedBy"] = new_blocked_by
+    source = dict(merged.get("_source") or {})
+    source["gitlabPlan"] = plan
+    merged["_source"] = source
+    apply_scope_result(config, "capabilities", merged, now=now)
+
+    degraded = None
+    if prior is True and new_blocked_by is False:
+        degraded = {"capability": "blockedBy", "from": True, "to": False,
+                    "reason": f"gitlab plan is {plan!r}"}
+    return {"probe": probe, "degraded": degraded}

--- a/.flow/bin/flowctl_tracker/states.py
+++ b/.flow/bin/flowctl_tracker/states.py
@@ -1,0 +1,169 @@
+"""Normalized state vocabulary + the shared slot-assignment algorithm (fn-139.6).
+
+Shared with fn-66's status policy: `backlog`, `todo`, `in_progress`,
+`in_review`, `done`, `cancelled`. Only `todo`, `in_progress`, `done` are
+REQUIRED - many real Jira workflows lack backlog or cancelled entirely, so
+requiring them makes completeness unreachable.
+
+Ambiguity is per normalized SLOT, not per provider: Linear's `type: started`
+covers both In Progress and In Review, so both slots are ambiguous until a
+human picks one at a time (`--select`, repeatable, one slot per call).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+REQUIRED_SLOTS = ("todo", "in_progress", "done")
+OPTIONAL_SLOTS = ("backlog", "in_review", "cancelled")
+#: Canonical resolution order: required first, deterministic conflict order.
+ALL_SLOTS = REQUIRED_SLOTS + OPTIONAL_SLOTS
+
+_NAME_TO_SLOT = {
+    "todo": "todo", "to do": "todo",
+    "in progress": "in_progress",
+    "in review": "in_review",
+    "done": "done",
+    "backlog": "backlog",
+    "cancelled": "cancelled", "canceled": "cancelled",
+}
+
+
+def normalize_name(name: str) -> str:
+    return " ".join(str(name).lower().split())
+
+
+@dataclass
+class Assignment:
+    """The outcome of one slot-assignment run."""
+
+    mapping: dict = field(default_factory=dict)          # slot -> id
+    #: First ambiguous REQUIRED slot (canonical order) + its live candidates -
+    #: the typed `conflict` details variant. None when no required ambiguity.
+    conflict: Optional[dict] = None
+    #: Required slots with no candidate at all (workflow lacks the category).
+    missing_required: list = field(default_factory=list)
+    #: Kept-but-unnatural selections (a slot whose chosen id is outside its
+    #: natural candidate pool) - recorded, never silent.
+    aliases: dict = field(default_factory=dict)          # slot -> id
+    warnings: list = field(default_factory=list)
+
+    @property
+    def complete(self) -> bool:
+        return (self.conflict is None and not self.missing_required
+                and all(s in self.mapping for s in REQUIRED_SLOTS))
+
+
+def assign_slots(pools: dict, live: dict, existing: Optional[dict] = None,
+                 *, policy: str = "jira") -> Assignment:
+    """One deterministic pass over the vocabulary, with a PER-PROVIDER policy -
+    the two trackers' specs mandate different ambiguity contracts and one
+    generic heuristic erased Linear's.
+
+    `policy="linear"` - TYPE-ONLY, per the mapping algorithm verbatim: where a
+    type yields exactly one state, take it; where it yields more than one
+    (`started` -> In Progress + In Review), the slot is AMBIGUOUS and requires
+    `--select` - even when the state names look obvious, and selecting one slot
+    NEVER infers a sibling (no cross-slot candidate elimination). `in_review`
+    (the secondary slot of `started`) is never auto-filled at all: with a
+    single started state that state IS in_progress, and auto-reusing it for
+    in_review would be a silent alias.
+
+    `policy="jira"` - statusCategory pools PLUS status-name hints (the spec
+    sanctions names here because three categories cannot separate six slots),
+    then the single-remaining-candidate rule.
+
+    `pools[slot]` - the slot's NATURAL candidates, `[{id, name, ...}]`.
+    `live` - every live state/status by id (validation set for kept entries).
+    `existing` - prior entries (a previous resolution or a human's `--select`
+    tiebreak). Kept where the id is still live - a refresh must not clobber a
+    human decision; dropped WITH A WARNING where dead.
+    """
+    if policy not in ("jira", "linear"):
+        raise ValueError(f"unknown assignment policy {policy!r}")
+    out = Assignment()
+    used: set = set()
+
+    # 0) Keep still-valid existing entries (human tiebreaks survive refresh).
+    for slot in ALL_SLOTS:
+        prior = (existing or {}).get(slot)
+        if prior is None:
+            continue
+        if prior in live:
+            out.mapping[slot] = prior
+            used.add(prior)
+            if prior not in {c["id"] for c in pools.get(slot, [])}:
+                out.aliases[slot] = prior
+        else:
+            out.warnings.append(
+                f"dropped {slot}: previous id {prior!r} no longer resolves to a "
+                "live state")
+
+    if policy == "jira":
+        # 1) Exact-name matches inside the natural pool.
+        for slot in ALL_SLOTS:
+            if slot in out.mapping:
+                continue
+            named = [c for c in pools.get(slot, [])
+                     if _NAME_TO_SLOT.get(normalize_name(c.get("name", ""))) == slot
+                     and c["id"] not in used]
+            if len(named) == 1:
+                out.mapping[slot] = named[0]["id"]
+                used.add(named[0]["id"])
+
+        # 2) Single-remaining-candidate rule; multiple -> ambiguous.
+        for slot in ALL_SLOTS:
+            if slot in out.mapping:
+                continue
+            remaining = [c for c in pools.get(slot, []) if c["id"] not in used]
+            if len(remaining) == 1:
+                out.mapping[slot] = remaining[0]["id"]
+                used.add(remaining[0]["id"])
+            elif len(remaining) > 1 and slot in REQUIRED_SLOTS and out.conflict is None:
+                out.conflict = {"normalized": slot, "candidates": remaining}
+            elif not remaining and slot in REQUIRED_SLOTS:
+                out.missing_required.append(slot)
+            # optional slot with 0 or >1 remaining candidates stays unfilled -
+            # never auto-aliased (aliasing is a HUMAN act via --select).
+        return out
+
+    # policy == "linear": type-only, no names, no cross-slot elimination.
+    for slot in ALL_SLOTS:
+        if slot in out.mapping:
+            continue
+        pool = pools.get(slot, [])
+        if slot == "in_review":
+            # Secondary slot of `started`: NEVER auto-filled. A single started
+            # state is in_progress; reusing it here would be a silent alias,
+            # and two started states are the mandated --select case.
+            continue
+        if len(pool) == 1:
+            out.mapping[slot] = pool[0]["id"]
+        elif len(pool) > 1:
+            if slot in REQUIRED_SLOTS and out.conflict is None:
+                out.conflict = {"normalized": slot, "candidates": list(pool)}
+            # optional multi-candidate slot stays unfilled until --select
+        elif slot in REQUIRED_SLOTS:
+            out.missing_required.append(slot)
+    return out
+
+
+def validate_select(slot: str, chosen_id: str, pools: dict, live: dict) -> Optional[str]:
+    """Validate one `--select slot=id` against LIVE candidates.
+
+    Returns an error message, or None when valid. A selection outside the
+    slot's natural pool is an ALIAS - allowed (workflows with fewer states
+    need it) and recorded by the caller, but the id must exist at all.
+    """
+    if slot not in ALL_SLOTS:
+        return f"unknown normalized slot {slot!r}; slots are {ALL_SLOTS}"
+    if chosen_id not in live:
+        return (f"{chosen_id!r} is not a live state/status id for this "
+                f"destination; candidates for {slot!r}: "
+                f"{[c['id'] for c in pools.get(slot, [])]}")
+    return None
+
+
+def is_alias(slot: str, chosen_id: str, pools: dict) -> bool:
+    return chosen_id not in {c["id"] for c in pools.get(slot, [])}

--- a/.flow/bin/flowctl_tracker/status/__init__.py
+++ b/.flow/bin/flowctl_tracker/status/__init__.py
@@ -1,0 +1,65 @@
+"""Spec-aware `tracker status` verb (fn-140.3).
+
+Thin envelope shell over `status.verb`. Embeds fn-66's merge-evidence gate
+and the who-wins ladder (deadlock first). Never raises across the boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import ACTIVE, Execute, dict_, read_config, tracker_type
+from ..types import ErrorClass, TrackerError
+from .policy import (Decision, decide, flow_to_normalized, is_deadlock,
+                     merge_evidence, terminal_wins_matches,
+                     in_progress_wins_matches, validate_to_reason)
+from .verb import status
+
+__all__ = [
+    "Decision",
+    "decide",
+    "flow_to_normalized",
+    "in_progress_wins_matches",
+    "is_deadlock",
+    "merge_evidence",
+    "run",
+    "status",
+    "terminal_wins_matches",
+    "validate_to_reason",
+]
+
+
+def run(flow_dir, *, spec_id: Optional[str] = None, to: Optional[str] = None,
+        reason: Optional[str] = None, event: Optional[str] = None,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """Thin envelope shell — never raises across the boundary."""
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        t = dict_(config.get("tracker")).get("type")
+        if t is not None and t not in ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}",
+                subtype="provider"))
+        return envelope.inactive()
+
+    if not spec_id or not to:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "status requires <spec-id> --to <slot>",
+            subtype="args"))
+
+    try:
+        out = status(flow_dir, spec_id, to=to, reason=reason, event=event,
+                     execute=execute)
+    except Exception as exc:  # noqa: BLE001 - boundary must never raise
+        return envelope.failure(TrackerError(
+            ErrorClass.TRANSPORT, f"status verb raised: {exc}",
+            subtype="unexpected"))
+
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/status/policy.py
+++ b/.flow/bin/flowctl_tracker/status/policy.py
@@ -1,0 +1,463 @@
+"""fn-66 merge-evidence gate + who-wins ladder (fn-140.3).
+
+Ports status-sync.md faithfully into the CLI six-slot vocabulary
+(backlog|todo|in_progress|in_review|done|cancelled). Legacy names map:
+planned→todo, in-progress→in_progress, done/verified→done (verified keeps
+its evidence distinction in the gate, not the slot name), deferred/wontfix→
+cancelled-family (surfaced, never auto-applied).
+
+Deadlock check fires FIRST — a terminal×in_progress pair matches BOTH
+single-field rules; reordering silently auto-closes (reordering test must fail).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ..types import ErrorClass, Request, Response, TrackerError
+from ..lifecycle.helpers import Execute
+
+#: CLI vocabulary (fn-139).
+SLOTS = frozenset({"backlog", "todo", "in_progress", "in_review", "done", "cancelled"})
+TERMINAL = frozenset({"done"})  # verified collapses to done at the slot layer
+EARLY = frozenset({"backlog", "todo"})
+ACTIVE_IN_PROGRESS = "in_progress"
+NEEDS_HUMAN_EVIDENCE = frozenset({"closed-unmerged", "ambiguous", "probe-error"})
+PR_EVIDENCE = frozenset({
+    "merged", "open", "closed-unmerged", "none", "ambiguous", "probe-error",
+})
+CONFLICT_TIEBREAKS = frozenset({"always-ask", "flow-wins", "tracker-wins"})
+
+#: GitHub close/reopen reasons — docs list completed|not_planned|reopened;
+#: undocumented `duplicate` is accepted live; anything else is invalid_input
+#: BEFORE a mutation request is issued (GitHub would 422).
+GITHUB_REASONS = frozenset({"completed", "not_planned", "duplicate", "reopened"})
+
+DecisionKind = str  # apply | noop | defer | conflict | invalid_input
+
+
+@dataclass(frozen=True)
+class Decision:
+    kind: DecisionKind
+    target_slot: Optional[str] = None
+    reason: Optional[str] = None
+    details: dict = field(default_factory=dict)
+    close_reason: Optional[str] = None  # github state_reason when applying terminal
+
+
+def validate_to_reason(requested_to: Any, reason: Optional[str]
+                       ) -> Optional[TrackerError]:
+    if not isinstance(requested_to, str) or requested_to not in SLOTS:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"--to must be one of {sorted(SLOTS)}, got {requested_to!r}",
+            subtype="to",
+        )
+    if reason is None:
+        return None
+    if reason not in GITHUB_REASONS:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"invalid --reason {reason!r}; allowed: {sorted(GITHUB_REASONS)}",
+            subtype="reason",
+        )
+    # Reason/slot pairing follows the normalized read surface. GitHub reports
+    # not_planned as cancelled, while completed/duplicate normalize to done.
+    if reason == "reopened" and requested_to == "done":
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "--reason reopened is not valid with --to done",
+            subtype="reason",
+        )
+    if reason == "not_planned" and requested_to != "cancelled":
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "--reason 'not_planned' requires --to cancelled",
+            subtype="reason",
+        )
+    if reason in {"completed", "duplicate"} and requested_to != "done":
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"--reason {reason!r} requires --to done",
+            subtype="reason",
+        )
+    return None
+
+
+def validate_conflict_tiebreak(config: dict) -> str | TrackerError:
+    """Return the exact configured deadlock policy, defaulting only if absent.
+
+    Runtime config is user-editable. A malformed persisted value must fail
+    before any claim or sequence work rather than silently changing authority.
+    """
+    tracker = config.get("tracker")
+    if not isinstance(tracker, dict) or "conflictTiebreak" not in tracker:
+        return "always-ask"
+    value = tracker["conflictTiebreak"]
+    if isinstance(value, str) and value in CONFLICT_TIEBREAKS:
+        return value
+    return TrackerError(
+        ErrorClass.INVALID_INPUT,
+        f"tracker.conflictTiebreak must be one of "
+        f"{sorted(CONFLICT_TIEBREAKS)}, got {value!r}",
+        subtype="conflict_tiebreak",
+    )
+
+
+# ---------------------------------------------------------------------------
+# merge evidence (gh pr list — probes the REPO, not the tracker type)
+# ---------------------------------------------------------------------------
+
+def merge_evidence(config: dict, spec_data: dict, execute: Execute) -> str:
+    """Probe `gh pr list --head <branch>` via the executor CLI route.
+
+    Returns one of: merged|open|closed-unmerged|none|ambiguous|probe-error.
+    Empty/missing branch_name → probe-error (never none, never merged).
+    """
+    branch = spec_data.get("branch_name")
+    if not isinstance(branch, str) or not branch.strip():
+        return "probe-error"
+    branch = branch.strip()
+    # Run in the current Git checkout and let gh resolve THAT repository.
+    # tracker.perTracker.repo may intentionally point at an out-of-tree issue
+    # repository; PR merge evidence belongs to the code repository instead.
+    argv = ["gh", "pr", "list", "--head", branch, "--state", "all",
+            "--json", "url,state,number,isDraft"]
+    result = execute(Request(
+        provider="github", op="merge-evidence", method="GET",
+        url_or_argv=argv, idempotent=True,
+    ))
+    if isinstance(result, TrackerError):
+        return "probe-error"
+    if not isinstance(result, Response):
+        return "probe-error"
+    # Non-200 / empty-failed body → probe-error (executor may return Response
+    # with status for CLI failures before classify wraps them — bound path
+    # usually returns TrackerError; be defensive).
+    if result.status and result.status >= 400:
+        return "probe-error"
+    try:
+        rows = json.loads(result.body or b"[]")
+    except (ValueError, TypeError):
+        return "probe-error"
+    if not isinstance(rows, list):
+        return "probe-error"
+    return _classify_pr_rows(rows)
+
+
+def _classify_pr_rows(rows: list) -> str:
+    merged = open_ = closed = draft = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        state = str(row.get("state") or "").upper()
+        if state == "MERGED":
+            merged += 1
+        elif state == "OPEN":
+            # Drafts are not clean open evidence - counted separately so a
+            # draft-only branch classifies ambiguous per status-sync.md.
+            if row.get("isDraft"):
+                draft += 1
+            else:
+                open_ += 1
+        elif state == "CLOSED":
+            closed += 1
+    # Canonical buckets, status-sync.md verbatim: BOTH an open AND a
+    # closed-unmerged PR is explicitly named ambiguous, as is "a draft-only
+    # result where no clear merge/open/closed signal dominates" (a host
+    # "recreate-PR" simplification was reverted here - the doc decides, not
+    # intuition).
+    if merged >= 1:
+        return "merged"
+    if open_ >= 1 and closed == 0:
+        return "open"
+    if open_ >= 1 and closed >= 1:
+        return "ambiguous"
+    if draft >= 1:
+        # Draft-only (possibly alongside closed rows): no clear signal
+        # dominates - ambiguous, never clean open or closed-unmerged.
+        return "ambiguous"
+    if closed >= 1:
+        return "closed-unmerged"
+    if not rows:
+        return "none"
+    return "ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# flow → normalized (8-row table; prEvidence first; CLI slots)
+# ---------------------------------------------------------------------------
+
+def flow_to_normalized(spec_data: dict, pr_evidence: str,
+                       completion_review_configured: bool,
+                       *, tasks: Optional[list] = None) -> str:
+    """8-row table from status-sync.md, emitting CLI slots.
+
+    Row order is load-bearing: PR signal rows (1–6) beat local task rows (7–8).
+    Terminal (`done`) is reachable ONLY from pr_evidence == merged.
+    `verified` (row 2) maps to the `done` slot; ship evidence is kept for the
+    caller (completion_review_status), not as a separate slot name.
+    """
+    if pr_evidence not in PR_EVIDENCE:
+        pr_evidence = "probe-error"
+    spec_status = str(spec_data.get("status") or "open")
+    review = str(spec_data.get("completion_review_status") or "unknown")
+    task_list = tasks if tasks is not None else list(spec_data.get("tasks") or [])
+
+    # Rows 1–3: merged
+    if pr_evidence == "merged":
+        if spec_status == "done":
+            if not completion_review_configured:
+                return "done"  # row 1
+            if review == "ship":
+                return "done"  # row 2 (verified → done slot)
+            return "in_review"  # row 3 (configured, not ship)
+        # Merged PR + still-open spec: PR signal wins over local task rows.
+        return "in_review"
+
+    # Row 4: open PR — any local status
+    if pr_evidence == "open":
+        return "in_review"
+
+    # Rows 5–6: done + non-terminal evidence
+    if spec_status == "done":
+        # none / closed-unmerged / ambiguous / probe-error → in_review (NOT terminal)
+        return "in_review"
+
+    # Rows 7–8: open spec, no PR signal. `blocked` counts as work underway:
+    # status-sync.md says blocked tasks do not change the spec-level
+    # normalized status - "the issue stays in-progress" - so an all-blocked
+    # spec must not regress to todo (that would conflict against an
+    # already-in-progress tracker or hide that work started).
+    statuses = [_task_status(t) for t in task_list]
+    if not task_list:
+        return "backlog"  # row 8 — no tasks
+    if any(s in ("in_progress", "done", "blocked") for s in statuses):
+        return "in_progress"  # row 7
+    return "todo"  # row 8 — all todo (planned→todo)
+
+
+def _task_status(task: Any) -> str:
+    if isinstance(task, dict):
+        return str(task.get("status") or "todo")
+    return "todo"
+
+
+# ---------------------------------------------------------------------------
+# who-wins decide (deadlock FIRST)
+# ---------------------------------------------------------------------------
+
+def is_deadlock(flow_norm: str, tracker_norm: str) -> bool:
+    """Terminal on one side × in_progress on the other — matches BOTH rules."""
+    return (
+        (tracker_norm in TERMINAL and flow_norm == ACTIVE_IN_PROGRESS)
+        or (flow_norm in TERMINAL and tracker_norm == ACTIVE_IN_PROGRESS)
+    )
+
+
+def terminal_wins_matches(flow_norm: str, tracker_norm: str) -> bool:
+    """Single-field rule: tracker terminal (used by the reordering test)."""
+    return tracker_norm in TERMINAL
+
+
+def in_progress_wins_matches(flow_norm: str, tracker_norm: str) -> bool:
+    """Single-field rule: flow in_progress vs early tracker."""
+    return flow_norm == ACTIVE_IN_PROGRESS and tracker_norm in EARLY
+
+
+def decide(requested_to: str, reason: Optional[str], flow_norm: str,
+           tracker_norm: str, pr_evidence: str,
+           conflict_tiebreak: str = "always-ask") -> Decision:
+    """`--to` is a REQUEST, not an authority — the gate decides.
+
+    Order (load-bearing):
+      0. validate --to/--reason
+      1. cancelled-family request → defer (never auto-apply)
+      2. DEADLOCK CHECK FIRST
+      3. closed-unmerged / ambiguous / probe-error → defer (needs-human)
+      4. terminal request refused by merge-evidence gate → conflict
+      5. noop / terminal-wins / in-progress-wins / preserve / push / surface
+      6. residual → conflict (never silent default)
+    """
+    bad = validate_to_reason(requested_to, reason)
+    if bad:
+        return Decision("invalid_input", reason=bad.subtype,
+                        details={"message": bad.message, "error": bad})
+
+    if requested_to == "cancelled" or tracker_norm == "cancelled":
+        return Decision(
+            "defer", reason="cancelled-family",
+            details={"flow": flow_norm, "tracker": tracker_norm,
+                     "requested": requested_to},
+        )
+
+    # ── DEADLOCK FIRST ──────────────────────────────────────────────
+    if is_deadlock(flow_norm, tracker_norm):
+        if conflict_tiebreak == "flow-wins":
+            close = (
+                reason
+                if reason in {"completed", "duplicate"}
+                else "completed"
+            )
+            return Decision(
+                "apply",
+                target_slot=flow_norm,
+                close_reason=close if flow_norm in TERMINAL else None,
+                details={
+                    "who": "flow-wins",
+                    "flow": flow_norm,
+                    "tracker": tracker_norm,
+                    "requested": requested_to,
+                },
+            )
+        if conflict_tiebreak == "tracker-wins":
+            if tracker_norm in TERMINAL:
+                return Decision(
+                    "apply_local",
+                    target_slot=tracker_norm,
+                    details={
+                        "who": "tracker-wins",
+                        "flow": flow_norm,
+                        "tracker": tracker_norm,
+                        "requested": requested_to,
+                    },
+                )
+            return Decision(
+                "conflict",
+                reason="status-deadlock-unrepresentable",
+                details={
+                    "flow": flow_norm,
+                    "tracker": tracker_norm,
+                    "requested": requested_to,
+                    "policy": conflict_tiebreak,
+                    "unrepresentable": True,
+                    "both_sides": {
+                        "flow": flow_norm,
+                        "tracker": tracker_norm,
+                    },
+                },
+            )
+        return Decision(
+            "conflict", reason="status-deadlock",
+            details={"flow": flow_norm, "tracker": tracker_norm,
+                     "requested": requested_to,
+                     "both_sides": {"flow": flow_norm, "tracker": tracker_norm}},
+        )
+
+    # ── CLOSED-UNMERGED / AMBIGUOUS / PROBE-ERROR — genuinely ambiguous
+    #    evidence is a CONFLICT for the skill's recovery surface (R7), never
+    #    a successful defer envelope. Evaluated BEFORE the equality
+    #    no-op AND the terminal fold: non-clean merge evidence must reach a human even when the
+    #    tracker side happens to read terminal. ──
+    if pr_evidence in NEEDS_HUMAN_EVIDENCE and (
+        requested_to == "done" or flow_norm == "in_review"
+    ):
+        return Decision(
+            "conflict", reason=pr_evidence,
+            details={"flow": flow_norm, "tracker": tracker_norm,
+                     "pr_evidence": pr_evidence, "requested": requested_to},
+        )
+
+    # ── ALREADY IN AGREEMENT: a synchronized pair is a no-op BEFORE any
+    #    folding - re-writing it would advance lastSyncedAt and emit a receipt
+    #    for a sync that did not happen (R6 no-op invariant). ──
+    if flow_norm == tracker_norm:
+        return Decision("noop", target_slot=tracker_norm,
+                        details={"who": "already-agree"})
+
+    # ── TRACKER-TERMINAL WINS: fold into LOCAL state (no tracker write).
+    #    After the agreement no-op and the evidence conflicts; deadlock
+    #    (terminal x in_progress) was caught above, so this branch is a REAL
+    #    local disagreement with clean evidence - a PM closing the issue is
+    #    authoritative for closure. ──
+    if tracker_norm in TERMINAL and flow_norm != ACTIVE_IN_PROGRESS:
+        return Decision("apply_local", target_slot=tracker_norm,
+                        details={"who": "tracker-terminal"})
+
+    # Merge-evidence gate: --to done is refused unless flow_norm is terminal
+    if requested_to == "done" and flow_norm not in TERMINAL:
+        return Decision(
+            "conflict", reason="merge-evidence-gate",
+            details={"flow": flow_norm, "tracker": tracker_norm,
+                     "requested": requested_to, "pr_evidence": pr_evidence},
+        )
+
+    if flow_norm == tracker_norm and (
+        requested_to == tracker_norm
+        or (requested_to == "done" and tracker_norm in TERMINAL)
+    ):
+        return Decision("noop", target_slot=tracker_norm)
+
+    # flow wins in-progress — push when tracker is early
+    if flow_norm == ACTIVE_IN_PROGRESS and tracker_norm in EARLY:
+        if requested_to in (ACTIVE_IN_PROGRESS, "todo", "backlog") or requested_to == flow_norm:
+            return Decision("apply", target_slot=ACTIVE_IN_PROGRESS)
+        # caller asked for something else the ladder would not push → conflict
+        return Decision(
+            "conflict", reason="unmapped",
+            details={"flow": flow_norm, "tracker": tracker_norm,
+                     "requested": requested_to},
+        )
+
+    # S-G: no-PR preserve — locally done projects in_review but do not force
+    if (flow_norm == "in_review" and pr_evidence == "none"
+            and tracker_norm in EARLY | {ACTIVE_IN_PROGRESS, "in_review"}):
+        if requested_to == "done":
+            return Decision(
+                "conflict", reason="merge-evidence-gate",
+                details={"flow": flow_norm, "tracker": tracker_norm,
+                         "pr_evidence": pr_evidence},
+            )
+        return Decision("noop", target_slot=tracker_norm,
+                        details={"who": "no-pr-preserve"})
+
+    # open-PR (or gated in_review) push - one branch; --to done was already
+    # refused by the merge-evidence gate above, so every path lands in_review.
+    if flow_norm == "in_review" and tracker_norm in EARLY | {ACTIVE_IN_PROGRESS}:
+        return Decision("apply", target_slot="in_review")
+
+    # flow terminal, tracker pre-terminal (not in_progress → not deadlock)
+    if flow_norm in TERMINAL and tracker_norm in EARLY | {"in_review"}:
+        close = reason if reason in {"completed", "not_planned", "duplicate"} else "completed"
+        return Decision("apply", target_slot="done", close_reason=close)
+
+    if tracker_norm == requested_to:
+        return Decision("noop", target_slot=tracker_norm)
+
+    # Unmapped / residual — conflict, never silent
+    return Decision(
+        "conflict", reason="unmapped",
+        details={"flow": flow_norm, "tracker": tracker_norm,
+                 "requested": requested_to, "pr_evidence": pr_evidence},
+    )
+
+
+def decision_as_error(decision: Decision) -> Optional[TrackerError]:
+    if decision.kind == "invalid_input":
+        err = decision.details.get("error")
+        if isinstance(err, TrackerError):
+            return err
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            decision.details.get("message") or "invalid input",
+                            subtype=decision.reason or "input")
+    if decision.kind == "conflict":
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"status conflict ({decision.reason or 'unmapped'}): "
+            f"flow={decision.details.get('flow')!r} "
+            f"tracker={decision.details.get('tracker')!r}",
+            subtype=decision.reason or "status",
+            details={
+                "normalized": "status",
+                "candidates": [
+                    {"side": "flow", "slot": decision.details.get("flow")},
+                    {"side": "tracker", "slot": decision.details.get("tracker")},
+                    {"side": "requested", "slot": decision.details.get("requested")},
+                ],
+                **{k: v for k, v in decision.details.items()
+                   if k not in {"error"}},
+            },
+        )
+    return None

--- a/.flow/bin/flowctl_tracker/status/providers.py
+++ b/.flow/bin/flowctl_tracker/status/providers.py
@@ -1,0 +1,679 @@
+"""Provider status writes + tracker-norm reads (fn-140.3).
+
+GitHub: PATCH issue {state, state_reason}; duplicate accepted, garbage rejected
+upstream of this module. GitLab: PUT {state_event: close|reopen}; states are
+opened/closed. Linear: issueUpdate {stateId} from destination.stateIds. Jira:
+GET …/transitions, match to.id == cached destination.statusIds[slot], POST;
+never a cached transition id.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+from urllib.parse import quote
+
+from ..lifecycle.helpers import Execute, Result, destination, dict_
+from ..types import ErrorClass, TrackerError
+from .policy import TERMINAL
+
+# Slot → status: label token (github/gitlab reduced-fidelity recovery).
+_LABEL = {
+    "backlog": "status:backlog",
+    "todo": "status:todo",
+    "in_progress": "status:in-progress",
+    "in_review": "status:in-review",
+    "done": "status:done",
+}
+
+
+def _status_labels(labels: Any) -> list[str]:
+    names: list[str] = []
+    for x in labels or []:
+        if isinstance(x, dict):
+            n = x.get("name")
+        else:
+            n = x
+        if isinstance(n, str) and n.startswith("status:"):
+            names.append(n)
+    return names
+
+
+def _recognized_slot(name: str) -> Optional[str]:
+    token = name.split(":", 1)[-1].strip().lower().replace("-", "_")
+    # legacy planned → todo
+    if token == "planned":
+        return "todo"
+    if token in {"backlog", "todo", "in_progress", "in_review", "done"}:
+        return token
+    if token in {"verified"}:
+        return "done"
+    if token in {"deferred", "wontfix", "cancelled", "canceled"}:
+        return "cancelled"
+    return None
+
+
+def _slot_from_status_label(labels: Any) -> Union[Optional[str], TrackerError]:
+    """Classify the issue's status:* labels into a single slot.
+
+    The status:* namespace is single-valued (github.md/gitlab.md "Idempotent
+    status: labels"). More than one recognized status:* label is a violated
+    invariant: picking whichever the provider lists first would be arbitrary
+    (order-dependent transitions) and can no-op into permanently leaving the
+    namespace inconsistent — so it is a CONFLICT for the recovery surface,
+    never a silent first-match. Unrecognized status:* labels are ignored.
+    """
+    recognized: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for name in _status_labels(labels):
+        slot = _recognized_slot(name)
+        if slot is None or name in seen:
+            continue
+        seen.add(name)
+        recognized.append((name, slot))
+    if len(recognized) > 1:
+        names = [n for n, _ in recognized]
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"ambiguous status labels {names!r}: status:* is single-valued",
+            subtype="ambiguous-status-labels",
+            details={"normalized": "status", "labels": names,
+                     "slots": sorted({s for _, s in recognized})},
+        )
+    if recognized:
+        return recognized[0][1]
+    return None
+
+
+def tracker_norm_from_parent(provider: str, parent: dict, dest: dict
+                             ) -> Union[str, TrackerError]:
+    """Map a parent-read payload to a CLI slot. Unmapped → conflict."""
+    if provider == "github":
+        return _norm_github(parent)
+    if provider == "gitlab":
+        return _norm_gitlab(parent)
+    if provider == "linear":
+        return _norm_linear(parent, dest)
+    if provider == "jira":
+        return _norm_jira(parent, dest)
+    return TrackerError(ErrorClass.INVALID_INPUT, f"unknown provider {provider!r}",
+                        subtype="provider")
+
+
+def github_native_status(parent: dict) -> str:
+    """Normalize only GitHub's authoritative native state.
+
+    Used narrowly by the retry repair path when status labels are ambiguous.
+    It does not guess a label target; callers must still prove the requested
+    transition safe through merge evidence and the decision policy.
+    """
+    state = str(parent.get("state") or "").upper()
+    reason = parent.get("state_reason") or parent.get("stateReason")
+    if state == "CLOSED":
+        return "cancelled" if str(reason or "").lower() == "not_planned" else "done"
+    return "in_progress"
+
+
+def _norm_github(parent: dict) -> Union[str, TrackerError]:
+    state = str(parent.get("state") or "").upper()
+    if state == "CLOSED":
+        labeled = _slot_from_status_label(parent.get("labels"))
+        if isinstance(labeled, TrackerError):
+            return labeled
+        return github_native_status(parent)
+    # OPEN
+    labeled = _slot_from_status_label(parent.get("labels"))
+    if isinstance(labeled, TrackerError):
+        return labeled
+    # Native OPEN is authoritative over a stale terminal label. A manual
+    # reopen must not be normalized back to done/cancelled by the label left
+    # behind from the earlier close.
+    if labeled in TERMINAL or labeled == "cancelled":
+        return "in_progress"
+    if labeled:
+        return labeled
+    return "in_progress"  # open + no status: label
+
+
+def _norm_gitlab(parent: dict) -> Union[str, TrackerError]:
+    # GitLab states are opened/closed (NOT open/closed).
+    state = str(parent.get("state") or "").lower()
+    if state == "closed":
+        labeled = _slot_from_status_label(parent.get("labels"))
+        if isinstance(labeled, TrackerError):
+            return labeled
+        if labeled == "cancelled":
+            return "cancelled"
+        return "done"
+    if state != "opened":
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            f"unmapped gitlab state {state!r}",
+            subtype="unmapped-state",
+            details={"normalized": "status", "raw": state},
+        )
+    labeled = _slot_from_status_label(parent.get("labels"))
+    if isinstance(labeled, TrackerError):
+        return labeled
+    # Native opened is authoritative over a stale terminal label, matching
+    # GitHub's manual-reopen contract above.
+    if labeled in TERMINAL or labeled == "cancelled":
+        return "in_progress"
+    if labeled:
+        return labeled
+    return "in_progress"
+
+
+# Canonical progression order for READ-side disambiguation of aliased maps.
+_READ_ORDER = ("backlog", "todo", "in_progress", "in_review", "done", "cancelled")
+
+
+def _reverse_state_map(ids: dict) -> dict:
+    """Invert a slot->id map deterministically for the read direction.
+
+    validate_select (states.py) sanctions ALIASING: one live state id may
+    serve multiple slots (e.g. in_review sharing in_progress's state on teams
+    without a review column). The write direction is per-slot and unaffected,
+    but inverting with a plain comprehension makes the read direction depend
+    on JSON key order: the same issue could normalize as in_progress or
+    in_review from serialization alone and flip the merge-gate decision
+    (terminal x in_progress deadlocks; terminal x in_review applies).
+
+    A duplicate id is therefore resolved to the EARLIEST aliased slot in the
+    canonical progression order, not by dict order: the least-advanced
+    reading never over-claims progress, and a terminal-vs-aliased pair routes
+    through the deadlock conflict surface instead of an order-dependent
+    silent apply. Erroring instead would make sanctioned aliases unreadable.
+    """
+    reverse: dict = {}
+    for slot in _READ_ORDER:
+        v = ids.get(slot)
+        if v is not None and str(v) not in reverse:
+            reverse[str(v)] = slot
+    # Defensive: keys outside the canonical vocabulary still invert, in
+    # sorted-key order (deterministic), and never shadow a canonical slot.
+    for slot in sorted(k for k in ids if k not in _READ_ORDER):
+        v = ids.get(slot)
+        if v is not None and str(v) not in reverse:
+            reverse[str(v)] = slot
+    return reverse
+
+
+def _norm_linear(parent: dict, dest: dict) -> Union[str, TrackerError]:
+    state = parent.get("state")
+    if not isinstance(state, dict):
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "linear parent carries no state",
+                            subtype="malformed_body")
+    sid = state.get("id")
+    state_ids = dict_(dest.get("stateIds"))
+    reverse = _reverse_state_map(state_ids)
+    if sid is not None and str(sid) in reverse:
+        slot = reverse[str(sid)]
+        return slot if slot in {"backlog", "todo", "in_progress", "in_review",
+                                "done", "cancelled"} else "done"
+    # Fall back to Linear type taxonomy
+    stype = str(state.get("type") or "").lower()
+    name = str(state.get("name") or "").lower()
+    if stype in {"triage", "backlog"}:
+        return "backlog"
+    if stype == "unstarted":
+        return "todo"
+    if stype == "started":
+        if "review" in name:
+            return "in_review"
+        return "in_progress"
+    if stype == "completed":
+        return "done"
+    if stype == "canceled":
+        return "cancelled"
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"unmapped linear state {state.get('name')!r} (type {stype!r})",
+        subtype="unmapped-state",
+        details={"normalized": "status", "raw": state.get("name"), "type": stype},
+    )
+
+
+def _norm_jira(parent: dict, dest: dict) -> Union[str, TrackerError]:
+    fields = dict_(parent.get("fields"))
+    status = dict_(fields.get("status"))
+    sid = status.get("id")
+    status_ids = dict_(dest.get("statusIds"))
+    reverse = _reverse_state_map(status_ids)
+    if sid is not None and str(sid) in reverse:
+        return reverse[str(sid)]
+    cat = dict_(status.get("statusCategory")).get("key")
+    if cat == "done":
+        return "done"
+    if cat == "new":
+        return "todo"
+    if cat == "indeterminate":
+        name = str(status.get("name") or "").lower()
+        if "review" in name:
+            return "in_review"
+        return "in_progress"
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"unmapped jira status {status.get('name')!r}",
+        subtype="unmapped-state",
+        details={"normalized": "status", "raw": status.get("name")},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writes
+# ---------------------------------------------------------------------------
+
+def apply_status(provider: str, config: dict, locator: dict, parent: dict,
+                 execute: Execute, *, target_slot: str,
+                 close_reason: Optional[str] = None,
+                 use_verified_label: bool = False) -> Result:
+    if provider == "github":
+        return _apply_github(config, locator, parent, execute,
+                             target_slot=target_slot, close_reason=close_reason,
+                             use_verified_label=use_verified_label)
+    if provider == "gitlab":
+        return _apply_gitlab(config, locator, parent, execute,
+                             target_slot=target_slot,
+                             use_verified_label=use_verified_label)
+    if provider == "linear":
+        return _apply_linear(config, locator, parent, execute,
+                             target_slot=target_slot)
+    if provider == "jira":
+        return _apply_jira(config, locator, execute, target_slot=target_slot)
+    return TrackerError(ErrorClass.INVALID_INPUT, f"unknown provider {provider!r}",
+                        subtype="provider")
+
+
+def github_status_label(target_slot: str, *,
+                        use_verified_label: bool = False) -> str:
+    return ("status:verified"
+            if target_slot == "done" and use_verified_label
+            else _LABEL.get(target_slot, f"status:{target_slot}"))
+
+
+def github_status_labels_match(parent: dict, *, target_slot: str,
+                               use_verified_label: bool = False) -> bool:
+    labels = _status_labels(parent.get("labels"))
+    if len(labels) != 1:
+        return False
+    if use_verified_label:
+        return labels[0] == "status:verified"
+    return _recognized_slot(labels[0]) == target_slot
+
+
+def repair_github_status_labels(config: dict, locator: dict, parent: dict,
+                                execute: Execute, *, target_slot: str,
+                                use_verified_label: bool = False) -> Result:
+    """Repair only GitHub's status-label namespace, never native state.
+
+    The status verb calls this only after the ordinary merge-evidence and
+    decision policy prove a noop target. Failures remain retryable because a
+    later invocation re-evaluates label consistency even when normalization
+    succeeds from native state.
+    """
+    from ..wire import _cli, _destination, _gh_repo, _github_number  # noqa: PLC0415
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    number = _github_number(locator["display"])
+    repo = _gh_repo(dest)
+    if isinstance(number, TrackerError):
+        return number
+    if isinstance(repo, TrackerError):
+        return repo
+
+    label = github_status_label(
+        target_slot, use_verified_label=use_verified_label)
+    failures: list[dict] = []
+    for old in [x for x in _status_labels(parent.get("labels"))
+                if x != label]:
+        removed = _cli(
+            execute, "github", config, "status-label-rm", "DELETE",
+            f"repos/{repo}/issues/{number}/labels/{quote(old, safe='')}",
+            idempotent=False)
+        if isinstance(removed, TrackerError):
+            failures.append({
+                "op": "repair-remove", "label": old,
+                "error": removed.message})
+    added = _cli(
+        execute, "github", config, "status-label-add", "POST",
+        f"repos/{repo}/issues/{number}/labels", body={"labels": [label]})
+    if isinstance(added, TrackerError):
+        failures.append({
+            "op": "repair-add", "label": label, "error": added.message})
+
+    readback = _cli(
+        execute, "github", config, "status-label-readback", "GET",
+        f"repos/{repo}/issues/{number}/labels", idempotent=True)
+    if isinstance(readback, list):
+        present = [
+            x.get("name") for x in readback
+            if isinstance(x, dict) and isinstance(x.get("name"), str)
+            and x["name"].startswith("status:")
+        ]
+        if present == [label]:
+            return {
+                "applied": target_slot,
+                "label": label,
+                "completed_steps": ["labels"],
+                "repair": "labels-only",
+                "degraded": None,
+            }
+        error_class = ErrorClass.CONFLICT
+        detail = None
+    else:
+        present = _status_labels(parent.get("labels"))
+        error_class = ErrorClass.TRANSPORT
+        detail = (readback.message if isinstance(readback, TrackerError)
+                  else "unexpected repair readback shape")
+    if detail:
+        failures.append({"op": "repair-readback", "error": detail})
+    return TrackerError(
+        error_class,
+        "github status-label repair did not converge",
+        subtype="status_labels_partial",
+        details={
+            "completed_steps": ([] if isinstance(added, TrackerError)
+                                else ["label-add"]),
+            "target": target_slot,
+            "expected": [label],
+            "present": present,
+            "failures": failures,
+        },
+        auto_retryable=True,
+    )
+
+
+def _apply_github(config, locator, parent, execute, *, target_slot, close_reason,
+                  use_verified_label) -> Result:
+    from ..wire import _cli, _destination, _gh_repo, _github_number  # noqa: PLC0415
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    number = _github_number(locator["display"])
+    repo = _gh_repo(dest)
+    if isinstance(number, TrackerError):
+        return number
+    if isinstance(repo, TrackerError):
+        return repo
+    label = github_status_label(
+        target_slot, use_verified_label=use_verified_label)
+    remove = [x for x in _status_labels(parent.get("labels")) if x != label]
+    # Native open/close
+    if target_slot in TERMINAL:
+        payload = {"state": "closed",
+                   "state_reason": close_reason or "completed"}
+    else:
+        payload = {"state": "open"}
+        if close_reason == "reopened":
+            payload["state_reason"] = "reopened"
+    data = _cli(execute, "github", config, "status-set", "PATCH",
+                f"repos/{repo}/issues/{number}", body=payload)
+    if isinstance(data, TrackerError):
+        return data
+    # Labels: status:* is single-valued. The STATE change above is the
+    # operation and has ALREADY landed - every label failure from here on is
+    # reported as explicit partial evidence, never a bare failure a retry
+    # would misread as nothing-happened (the re-run would noop on the closed
+    # issue and silently lose the label + receipt).
+    label_failures: list = []
+    for old in remove:
+        rm = _cli(execute, "github", config, "status-label-rm", "DELETE",
+                  f"repos/{repo}/issues/{number}/labels/{quote(old, safe='')}",
+                  idempotent=False)
+        if isinstance(rm, TrackerError):
+            label_failures.append({"op": "remove", "label": old,
+                                   "error": rm.message})
+    add = _cli(execute, "github", config, "status-label-add", "POST",
+               f"repos/{repo}/issues/{number}/labels",
+               body={"labels": [label]})
+    add_failed = isinstance(add, TrackerError)
+    if add_failed:
+        label_failures.append({"op": "add", "label": label, "error": add.message})
+    # Read back and verify the single-valued invariant actually holds.
+    labels_degraded = None
+    readback = _cli(execute, "github", config, "status-label-readback", "GET",
+                    f"repos/{repo}/issues/{number}/labels", idempotent=True)
+    if isinstance(readback, list):
+        present = [x.get("name") for x in readback
+                   if isinstance(x, dict) and isinstance(x.get("name"), str)
+                   and x["name"].startswith("status:")]
+        if present != [label]:
+            if add_failed:
+                # The target label did not land. Preserve the earlier
+                # partial-success contract; cleanup cannot manufacture the
+                # requested target.
+                labels_degraded = {
+                    "kind": "status_labels_inconsistent",
+                    "expected": [label], "present": present,
+                    "failures": label_failures,
+                }
+            else:
+                # A successful add plus a failed/stale remove leaves an
+                # ambiguous namespace. Make one bounded cleanup pass over
+                # every unexpected status label, then verify once more.
+                # Never advance durable success while readback still proves
+                # multiple status labels.
+                for unexpected in [x for x in present if x != label]:
+                    repaired = _cli(
+                        execute, "github", config, "status-label-rm", "DELETE",
+                        f"repos/{repo}/issues/{number}/labels/"
+                        f"{quote(unexpected, safe='')}",
+                        idempotent=False)
+                    if isinstance(repaired, TrackerError):
+                        label_failures.append({
+                            "op": "repair-remove", "label": unexpected,
+                            "error": repaired.message})
+                repaired_readback = _cli(
+                    execute, "github", config, "status-label-readback", "GET",
+                    f"repos/{repo}/issues/{number}/labels", idempotent=True)
+                if isinstance(repaired_readback, list):
+                    repaired_present = [
+                        x.get("name") for x in repaired_readback
+                        if isinstance(x, dict)
+                        and isinstance(x.get("name"), str)
+                        and x["name"].startswith("status:")
+                    ]
+                    if repaired_present == [label]:
+                        present = repaired_present
+                        label_failures = []
+                    else:
+                        return TrackerError(
+                            ErrorClass.CONFLICT,
+                            "github state change landed but status labels "
+                            "remain ambiguous after bounded repair",
+                            subtype="status_labels_partial",
+                            details={
+                                "completed_steps": ["state", "label-add"],
+                                "target": target_slot,
+                                "expected": [label],
+                                "present": repaired_present,
+                                "failures": label_failures,
+                            },
+                            auto_retryable=True,
+                        )
+                else:
+                    detail = (
+                        repaired_readback.message
+                        if isinstance(repaired_readback, TrackerError)
+                        else "unexpected repair readback shape")
+                    return TrackerError(
+                        ErrorClass.TRANSPORT,
+                        "github state change landed but status-label repair "
+                        "could not be verified",
+                        subtype="status_labels_partial",
+                        details={
+                            "completed_steps": ["state", "label-add"],
+                            "target": target_slot,
+                            "expected": [label],
+                            "present": present,
+                            "failures": label_failures
+                            + [{"op": "repair-readback", "error": detail}],
+                        },
+                        auto_retryable=True,
+                    )
+    else:
+        # Readback failed or returned an unusable shape: the invariant is
+        # unverifiable even when every label op above succeeded.
+        detail = (readback.message if isinstance(readback, TrackerError)
+                  else "unexpected readback shape")
+        labels_degraded = {"kind": "status_labels_unverified",
+                           "failures": label_failures
+                           + [{"op": "readback", "error": detail}]}
+    return {"applied": target_slot, "state_reason": payload.get("state_reason"),
+            "label": label,
+            "completed_steps": ["state"] + ([] if label_failures else ["labels"]),
+            "degraded": labels_degraded}
+
+
+def _apply_gitlab(config, locator, parent, execute, *, target_slot,
+                  use_verified_label) -> Result:
+    from ..wire import _cli, _destination, _gl_project, _gitlab_iid  # noqa: PLC0415
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    label = ("status:verified" if (target_slot == "done" and use_verified_label)
+             else _LABEL.get(target_slot, f"status:{target_slot}"))
+    remove = [x for x in _status_labels(parent.get("labels")) if x != label]
+    if target_slot in TERMINAL:
+        state_event = "close"
+    else:
+        state_event = "reopen"
+    body: dict = {"state_event": state_event, "add_labels": label}
+    if remove:
+        body["remove_labels"] = ",".join(remove)
+    data = _cli(execute, "gitlab", config, "status-set", "PUT",
+                f"projects/{pid}/issues/{iid}", body=body)
+    if isinstance(data, TrackerError):
+        return data
+    # Readback must understand opened/closed
+    state = None
+    if isinstance(data, dict):
+        state = data.get("state")
+    return {"applied": target_slot, "state_event": state_event,
+            "state": state, "label": label}
+
+
+def _apply_linear(config, locator, parent, execute, *, target_slot) -> Result:
+    from ..wire import _gql  # noqa: PLC0415
+    dest = destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    state_ids = dict_(dest.get("stateIds"))
+    state_id = state_ids.get(target_slot)
+    if not state_id:
+        return TrackerError(
+            ErrorClass.UNRESOLVED,
+            f"destination.stateIds missing slot {target_slot!r}",
+            subtype="stateIds",
+        )
+    # Already-current? Mirror the Jira writer's check. A sanctioned aliased
+    # map (e.g. in_progress/in_review sharing one live state) reads back as
+    # the EARLIEST slot, so the gate can request the exact state id the issue
+    # already carries; writing it would report "applied", advance
+    # lastSyncedAt, and repeat on every subsequent sync. The verb layer maps
+    # a write-noop to kind=noop (no lastSyncedAt advance), which is honest:
+    # the native state already satisfies the request. Parent is enriched with
+    # state before apply (enrich_linear_parent); missing state falls through
+    # to the mutation, never raises.
+    cur_id = dict_(dict_(parent).get("state")).get("id")
+    if cur_id is not None and str(cur_id) == str(state_id):
+        return {"noop": True, "applied": target_slot, "stateId": str(state_id)}
+    data = _gql(execute, "status-set",
+                "mutation($id: String!, $stateId: String!) { "
+                "issueUpdate(id: $id, input: { stateId: $stateId }) "
+                "{ success issue { id } } }",
+                {"id": locator["durable"], "stateId": str(state_id)})
+    if isinstance(data, TrackerError):
+        return data
+    payload = data.get("issueUpdate") if isinstance(data, dict) else None
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "linear issueUpdate reported failure",
+                            subtype="mutation_failed")
+    return {"applied": target_slot, "stateId": str(state_id)}
+
+
+def _apply_jira(config, locator, execute, *, target_slot) -> Result:
+    """GET legal transitions; match to.id == cached statusIds[slot]; POST.
+
+    No legal transition → returns a defer sentinel dict (not a forced jump).
+    Never uses a cached transition id.
+    """
+    from ..wire import _destination, _jira, _jira_base  # noqa: PLC0415
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    status_ids = dict_(dest.get("statusIds"))
+    target_id = status_ids.get(target_slot)
+    if target_id is None:
+        return {"defer": True, "reason": "status-unmapped",
+                "target_slot": target_slot}
+    issue_key = locator["display"]  # transitions addressed by key/id
+    # Prefer durable id for mutation path; transitions accept either.
+    issue_ref = locator.get("durable") or issue_key
+    # Already-current? Read status from a cheap GET (parent may be stale).
+    cur = _jira(execute, "status-current", "GET",
+                f"{base}/rest/api/2/issue/{quote(str(issue_ref), safe='')}"
+                f"?fields=status", idempotent=True)
+    if isinstance(cur, TrackerError):
+        return cur
+    cur_status = dict_(dict_(dict_(cur).get("fields")).get("status"))
+    if str(cur_status.get("id")) == str(target_id):
+        return {"noop": True, "applied": target_slot}
+    trs = _jira(execute, "status-transitions", "GET",
+                f"{base}/rest/api/2/issue/{quote(str(issue_ref), safe='')}"
+                f"/transitions", idempotent=True)
+    if isinstance(trs, TrackerError):
+        return trs
+    transitions = list(dict_(trs).get("transitions") or [])
+    tid = None
+    for t in transitions:
+        if not isinstance(t, dict):
+            continue
+        to = dict_(t.get("to"))
+        if str(to.get("id")) == str(target_id):
+            tid = t.get("id")
+            break
+    if tid is None:
+        return {"defer": True, "reason": "transition-unreachable",
+                "target_slot": target_slot, "target_status_id": str(target_id)}
+    posted = _jira(execute, "status-set", "POST",
+                   f"{base}/rest/api/2/issue/{quote(str(issue_ref), safe='')}"
+                   f"/transitions",
+                   body={"transition": {"id": str(tid)}})
+    if isinstance(posted, TrackerError):
+        return posted
+    return {"applied": target_slot, "transition_id": str(tid),
+            "target_status_id": str(target_id)}
+
+
+def enrich_linear_parent(execute: Execute, locator: dict, parent: dict
+                         ) -> Union[dict, TrackerError]:
+    """Parent-read for wire omits state; fetch it for norm extraction."""
+    if isinstance(parent.get("state"), dict) and parent["state"].get("id"):
+        return parent
+    from ..wire import _gql  # noqa: PLC0415
+    data = _gql(execute, "status-state-read",
+                "query($id: String!) { issue(id: $id) { id "
+                "state { id name type } } }",
+                {"id": locator["display"]}, idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    issue = data.get("issue")
+    if not isinstance(issue, dict):
+        return TrackerError(ErrorClass.NOT_FOUND, "linear issue not found",
+                            subtype="parent")
+    merged = dict(parent)
+    merged["state"] = issue.get("state")
+    return merged

--- a/.flow/bin/flowctl_tracker/status/verb.py
+++ b/.flow/bin/flowctl_tracker/status/verb.py
@@ -1,0 +1,587 @@
+"""`tracker status` verb orchestration (fn-140.3).
+
+require_durable → wire parent_read → merge_evidence → flow_to_normalized →
+decide → provider write. Applied advances lastSyncedAt (+ receipt);
+noop/conflict do not; defer writes a receipt (status deferred) without
+advancing lastSyncedAt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import (Execute, Result, atomic_write_json, dict_,
+                                 leaf_is_safe, load_spec, merged_tracker,
+                                 now_iso, read_config, tracker_type,
+                                 write_sync_receipt, write_tracker_block)
+from ..lifecycle.linkstate import require_durable
+from ..lifecycle.verbs import (_claim_is_stale, _ensure_create_first_ignored,
+                               _release_claim)
+from ..types import ErrorClass, TrackerError
+from .policy import (Decision, decide, decision_as_error, flow_to_normalized,
+                     merge_evidence, validate_conflict_tiebreak,
+                     validate_to_reason)
+from .providers import (apply_status, enrich_linear_parent, github_native_status,
+                        github_status_labels_match, repair_github_status_labels,
+                        tracker_norm_from_parent)
+
+
+def _backend_off(value: str) -> bool:
+    """A backend spec is backend[:model[:effort]]; only the backend part
+    decides configured-ness."""
+    return value.split(":", 1)[0].strip().lower() in ("", "none", "off")
+
+
+def _completion_review_configured(config: dict,
+                                  spec_data: Optional[dict] = None) -> bool:
+    """Effective review backend with resolve_review_spec's precedence:
+    spec default_review > FLOW_REVIEW_BACKEND env > config review.backend.
+    Reading only the config half made a spec pinned to codex (or an env
+    override) project as review-ungated - a merged spec folded to done with
+    no shipped completion review - and vice versa."""
+    per = (spec_data or {}).get("default_review")
+    if isinstance(per, str) and per.strip():
+        return not _backend_off(per)
+    env = os.environ.get("FLOW_REVIEW_BACKEND")
+    if isinstance(env, str) and env.strip():
+        return not _backend_off(env)
+    review = dict_(config.get("review")).get("backend")
+    if review is None:
+        return False
+    if isinstance(review, str):
+        return not _backend_off(review)
+    return True
+
+
+def _state_dir(flow_dir: Path) -> Path:
+    """Mirror flowctl's get_state_dir: FLOW_STATE_DIR env, then the git
+    common-dir (shared across worktrees), then .flow/state for non-git."""
+    env = os.environ.get("FLOW_STATE_DIR")
+    if env:
+        return Path(env).resolve()
+    try:
+        # --path-format modifies only the options AFTER it (PR #246 wave-14
+        # P1): trailing placement returned a cwd-relative ".git", which broke
+        # as soon as the caller's cwd differed from flow_dir.parent.
+        result = subprocess.run(  # noqa: S603 - fixed argv, shell=False
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, encoding="utf-8", check=True,
+            cwd=flow_dir.parent,
+        )
+        return Path(result.stdout.strip()) / "flow-state"
+    except (subprocess.CalledProcessError, OSError):
+        return flow_dir / "state"
+
+
+def _load_tasks(flow_dir: Path, spec_id: str) -> list:
+    """Task definitions overlaid with runtime state. Since the fn-111 storage
+    split, .flow/tasks/<id>.json is the DEFINITION (status is the scaffold
+    value); the live status (claimed/in_progress/done) lives in the runtime
+    store at <state-dir>/tasks/<id>.state.json. Reading only the definition
+    made every started spec normalize as todo (measured live 2026-07-28)."""
+    tasks_dir = flow_dir / "tasks"
+    if not tasks_dir.is_dir():
+        return []
+    runtime_dir = _state_dir(flow_dir) / "tasks"
+    out = []
+    for path in sorted(tasks_dir.glob(f"{spec_id}.*.json")):
+        if path.name.endswith(".state.json"):
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        status = data.get("status") or "todo"
+        state_path = runtime_dir / f"{path.name[:-len('.json')]}.state.json"
+        try:
+            runtime = json.loads(state_path.read_text(encoding="utf-8"))
+            if isinstance(runtime, dict) and runtime.get("status"):
+                status = runtime["status"]
+        except (OSError, ValueError):
+            pass
+        out.append({"id": data.get("id"), "status": status})
+    return out
+
+
+def _locator(tracker: dict) -> Result:
+    durable = tracker.get("id")
+    display = tracker.get("identifier")
+    if not isinstance(durable, str) or not durable.strip():
+        return TrackerError(ErrorClass.UNRESOLVED, "tracker.id missing",
+                            subtype="durable")
+    if not isinstance(display, str) or not display.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "tracker.identifier (display) required for status",
+                            subtype="locator")
+    return {"durable": durable.strip(), "display": display.strip()}
+
+
+def _persist_applied_state(flow_dir: Path, spec_id: str, *,
+                           fold_local_done: bool,
+                           expected_durable: Optional[str] = None,
+                           expected_display: Optional[str] = None) -> Result:
+    """Reload + merge ONLY status-owned fields + persist, serialized under the
+    shared .flow writer lock (same pattern as relate._ledger_write and
+    syncbody._commit_paired_base). The spec snapshot loaded before the parent,
+    PR-evidence, and provider requests must never be written back wholesale -
+    that would silently erase a concurrent update to the same spec.
+
+    Identity guard (linkstate._complete pattern): the parent read, PR probe,
+    and provider status write all ran against the identity captured BEFORE
+    this lock. If the spec was repointed to a different issue while those
+    were in flight, an unconditional merge would advance lastSyncedAt on the
+    NEW link after mutating the OLD issue (and apply_local would fold done
+    from the old issue's terminal state). Compare the reloaded block's
+    durable/display identity inside the lock; on drift return a structured
+    CONFLICT and persist nothing. Returns the persisted tracker block, or a
+    TrackerError - never raises."""
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            reloaded = load_spec(flow_dir, spec_id)
+            if isinstance(reloaded, TrackerError):
+                return reloaded
+            path, spec = reloaded
+            tracker = merged_tracker(spec)
+            if expected_durable is not None or expected_display is not None:
+                got_durable = tracker.get("id")
+                got_display = tracker.get("identifier")
+                if got_durable != expected_durable or got_display != expected_display:
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"spec {spec_id!r} tracker identity changed while the "
+                        f"status write was in flight (evaluated "
+                        f"{expected_display!r}/{expected_durable!r}, now "
+                        f"{got_display!r}/{got_durable!r}); refusing to "
+                        "persist; re-run status against the new link",
+                        subtype="identity_drift",
+                        details={
+                            "expected": {"id": expected_durable,
+                                         "identifier": expected_display},
+                            "found": {"id": got_durable,
+                                      "identifier": got_display},
+                        },
+                    )
+            if fold_local_done:
+                spec = dict(spec)
+                spec["status"] = "done"
+            tracker["lastSyncedAt"] = now_iso()
+            werr = write_tracker_block(path, spec, tracker)
+            if werr:
+                return werr
+            return tracker
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+
+
+def _claim_status(flow_dir: Path, spec_id: str, rec_path: Path,
+                  provider: str, *, to: str) -> Optional[TrackerError]:
+    """Reserve the spec's status transaction under the shared writer lock
+    BEFORE the parent read / PR probe / provider mutation (syncbody's claim
+    pattern, keyed on the spec id). The identity guard in
+    _persist_applied_state can only DETECT a relink after the provider
+    mutation has landed on the old issue; the claim makes the whole window
+    exclusive instead: `sync set-tracker-id` honors live per-spec claims and
+    refuses to relink while one exists, so a repoint can no longer land
+    between the initial reads and the locked persistence. Under the lock: a
+    live claim from another process refuses (status_in_flight, retryable), a
+    stale claim (dead pid on this host past the stale window,
+    _claim_is_stale's owner rules) is reclaimed by overwriting, and OUR
+    pending claim lands durably before any remote I/O. The claim is always
+    released when the invocation finishes (success or failure): the spec's
+    tracker block, not the claim file, is the durable record."""
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"status for spec {spec_id!r} is already in flight "
+                        "in another process; retry after it finishes",
+                        subtype="status_in_flight",
+                        details={"specId": spec_id,
+                                 "claim": {"pid": prior.get("pid"),
+                                           "host": prior.get("host"),
+                                           "claimedAt": prior.get("claimedAt")}},
+                        auto_retryable=True)
+                # A STALE pending claim (crashed run) is reclaimed by
+                # overwriting it with OURS - same rule as create-first.
+            claim = {"specId": spec_id, "status": "pending",
+                     "op": "status", "to": to,
+                     "pid": os.getpid(), "host": socket.gethostname(),
+                     "claimedAt": time.time(), "transport": provider}
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    return None
+
+
+def status(flow_dir, spec_id: str, *, to: str, reason: Optional[str] = None,
+           event: Optional[str] = None,
+           execute: Execute = default_execute,
+           write_receipt: bool = True) -> Result:
+    """Spec-aware status verb. Never raises across the boundary.
+
+    Serialized per spec via a create-first claim (`status-<spec-id>.json`)
+    taken before any spec read or tracker I/O; a live foreign claim refuses
+    with structured CONFLICT (status_in_flight, retryable). The same claim is
+    honored by `sync set-tracker-id`, so a relink cannot land anywhere inside
+    the claimed window.
+    """
+    flow_dir = Path(flow_dir)
+    # Validate --to/--reason BEFORE any mutation / network (garbage reason).
+    bad = validate_to_reason(to, reason)
+    if bad:
+        return bad
+    if not spec_id:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "status requires <spec-id>", subtype="args")
+
+    config = read_config(flow_dir)
+    conflict_tiebreak = validate_conflict_tiebreak(config)
+    if isinstance(conflict_tiebreak, TrackerError):
+        return conflict_tiebreak
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    rec_path = flow_dir / "create-first" / f"status-{spec_id}.json"
+    claimed = _claim_status(flow_dir, spec_id, rec_path, provider, to=to)
+    if claimed is not None:
+        return claimed
+    try:
+        return _status_txn(
+            flow_dir, spec_id, config=config, provider=provider,
+            conflict_tiebreak=conflict_tiebreak,
+            to=to, reason=reason, event=event, execute=execute,
+            write_receipt=write_receipt)
+    finally:
+        _release_claim(rec_path)
+
+
+def _status_txn(flow_dir: Path, spec_id: str, *, config: dict, provider: str,
+                conflict_tiebreak: str,
+                to: str, reason: Optional[str], event: Optional[str],
+                execute: Execute, write_receipt: bool) -> Result:
+    """The claimed transaction body: spec loaded AFTER the claim, so every
+    read (spec snapshot, parent, PR evidence) and the provider mutation run
+    inside the relink-excluded window."""
+    loaded = load_spec(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    path, spec_data = loaded
+    tracker = merged_tracker(spec_data)
+
+    durable = require_durable(tracker)
+    if isinstance(durable, TrackerError):
+        return durable
+
+    locator = _locator(tracker)
+    if isinstance(locator, TrackerError):
+        return locator
+
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    from ..wire import parent_read  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+
+    # Wire-style pre-mutation parent read + durable check.
+    parent = parent_read(provider, config, locator, ex, op="status-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    if provider == "linear":
+        parent = enrich_linear_parent(ex, locator, parent)
+        if isinstance(parent, TrackerError):
+            return parent
+
+    from ..lifecycle.helpers import destination as dest_of  # noqa: PLC0415
+    dest = dest_of(config)
+    if isinstance(dest, TrackerError):
+        return dest
+
+    # PR evidence belongs to the source Git checkout, not the configured
+    # tracker transport. In particular, Jira DC sslVerify=false is valid for
+    # Jira HTTP but cannot be applied to the independent gh CLI route.
+    pr_evidence = merge_evidence(config, spec_data, execute)
+    tasks = _load_tasks(flow_dir, spec_id)
+    flow_norm = flow_to_normalized(
+        spec_data, pr_evidence,
+        _completion_review_configured(config, spec_data),
+        tasks=tasks,
+    )
+
+    tracker_norm = tracker_norm_from_parent(provider, parent, dest)
+    repair_retry = False
+    if isinstance(tracker_norm, TrackerError):
+        # A prior GitHub write may have landed native state + target label but
+        # failed to remove the old label even after its bounded repair. On a
+        # later invocation normalization sees an ambiguous namespace before
+        # the ordinary decision ladder. Recover only when native state,
+        # requested target, merge evidence, and the policy all prove the
+        # requested transition is already the intended state. Then replay the
+        # idempotent provider write as an APPLY so repaired convergence earns
+        # lastSyncedAt + receipt instead of being mistaken for a noop.
+        if (provider == "github"
+                and tracker_norm.subtype == "ambiguous-status-labels"):
+            native_norm = github_native_status(parent)
+            repair_decision = decide(
+                to, reason, flow_norm, native_norm, pr_evidence,
+                conflict_tiebreak)
+            if repair_decision.kind == "noop" and native_norm == to:
+                tracker_norm = native_norm
+                repair_retry = True
+                decision = repair_decision
+            elif (repair_decision.kind == "apply"
+                  and repair_decision.target_slot):
+                tracker_norm = native_norm
+                repair_retry = True
+                decision = repair_decision
+            else:
+                return tracker_norm
+        else:
+            return tracker_norm
+    if not repair_retry:
+        decision = decide(
+            to, reason, flow_norm, tracker_norm, pr_evidence,
+            conflict_tiebreak)
+    err = decision_as_error(decision)
+    if err:
+        return err
+
+    verified_target = decision.target_slot or to
+    use_verified = (
+        verified_target == "done"
+        and str(spec_data.get("completion_review_status") or "") == "ship"
+        and pr_evidence == "merged"
+    )
+    label_only_repair = False
+    if (provider == "github" and decision.kind == "noop"
+            and github_native_status(parent) == to
+            and not github_status_labels_match(
+                parent, target_slot=to,
+                use_verified_label=use_verified)):
+        # Native state + flow policy + requested target already agree. Repair
+        # only the reduced-fidelity label namespace; replaying PATCH state
+        # here could overwrite an authoritative close reason such as
+        # `duplicate`. Promoting to APPLY ensures repaired convergence earns
+        # lastSyncedAt and a receipt.
+        decision = Decision(
+            "apply", target_slot=to, reason="status-label-repair")
+        label_only_repair = True
+
+    prior_synced = tracker.get("lastSyncedAt")
+
+    def noop_result(*, noop_reason: Optional[str] = None) -> Result:
+        # A prior applied run may have landed its state/base but failed only
+        # while writing the lifecycle receipt. Re-emit event evidence from
+        # the converged retry without mutating or advancing lastSyncedAt.
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="noop",
+                tracker_id=durable, event=event, transport=provider,
+                note=(
+                    f"status already converged ({noop_reason})"
+                    if noop_reason else "status already converged"),
+            )
+            if rerr:
+                return rerr
+        result = {
+            "kind": "noop",
+            "to": to,
+            "flow": flow_norm,
+            "tracker": tracker_norm,
+            "pr_evidence": pr_evidence,
+            "lastSyncedAt": prior_synced,
+        }
+        if noop_reason:
+            result["reason"] = noop_reason
+        return result
+
+    if decision.kind == "noop":
+        return noop_result()
+
+    if decision.kind == "apply_local":
+        # Convergence: the fold writes RAW spec.status=done. When a
+        # completion-review backend is configured and no ship is recorded,
+        # flow_to_normalized keeps deriving in_review from that done, so the
+        # same terminal disagreement re-classifies as apply_local on every
+        # run - each pass rewriting the identical status and advancing
+        # lastSyncedAt for a sync that changed nothing. The raw local status
+        # is the honest convergence check: already folded -> noop, no write,
+        # no lastSyncedAt advance (the residual review gate is derived
+        # state, not sync work).
+        if spec_data.get("status") == "done":
+            return noop_result(noop_reason="already_folded")
+        # Tracker-terminal wins: fold into the LOCAL spec (status + lastSyncedAt),
+        # never issue a tracker mutation. A PM closing the issue is authoritative.
+        persisted = _persist_applied_state(
+            flow_dir, spec_id, fold_local_done=True,
+            expected_durable=locator["durable"],
+            expected_display=locator["display"])
+        if isinstance(persisted, TrackerError):
+            return persisted
+        tracker = persisted
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="pulled",
+                tracker_id=durable, event=event, transport=provider,
+                note=f"tracker-terminal folded locally ({tracker_norm})",
+            )
+            if rerr:
+                import dataclasses  # noqa: PLC0415
+                return dataclasses.replace(rerr, details={
+                    **(rerr.details or {}),
+                    "completed_steps": ["local-status", "lastSyncedAt"]})
+        return {
+            "kind": "applied_local",
+            "to": to,
+            "applied": decision.target_slot,
+            "flow": flow_norm,
+            "tracker": tracker_norm,
+            "pr_evidence": pr_evidence,
+            "lastSyncedAt": tracker["lastSyncedAt"],
+        }
+
+    if decision.kind == "defer":
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="deferred",
+                tracker_id=durable, event=event, transport=provider,
+                note=f"status deferred ({decision.reason})",
+                degraded=None,
+            )
+            if rerr:
+                import dataclasses  # noqa: PLC0415
+                return dataclasses.replace(rerr, details={
+                    **(rerr.details or {}), "defer_reason": decision.reason,
+                    "defer_details": decision.details})
+        return {
+            "kind": "defer",
+            "reason": decision.reason,
+            "to": to,
+            "flow": flow_norm,
+            "tracker": tracker_norm,
+            "pr_evidence": pr_evidence,
+            "lastSyncedAt": prior_synced,
+            "details": decision.details,
+        }
+
+    # apply
+    if decision.kind != "apply" or not decision.target_slot:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"unhandled decision kind {decision.kind!r}",
+                            subtype="decision")
+    if label_only_repair:
+        written = repair_github_status_labels(
+            config, locator, parent, ex,
+            target_slot=decision.target_slot,
+            use_verified_label=use_verified)
+    else:
+        written = apply_status(
+            provider, config, locator, parent, ex,
+            target_slot=decision.target_slot,
+            close_reason=decision.close_reason or reason,
+            use_verified_label=use_verified,
+        )
+    if isinstance(written, TrackerError):
+        return written
+
+    # Jira defer-from-apply (no legal transition) — receipt, no lastSyncedAt.
+    if isinstance(written, dict) and written.get("defer"):
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="deferred",
+                tracker_id=durable, event=event, transport=provider,
+                note=f"status deferred ({written.get('reason')})",
+            )
+            if rerr:
+                import dataclasses  # noqa: PLC0415
+                return dataclasses.replace(rerr, details={
+                    **(rerr.details or {}), "defer_reason": written.get("reason"),
+                    "defer_details": written})
+        return {
+            "kind": "defer",
+            "reason": written.get("reason"),
+            "to": to,
+            "target": decision.target_slot,
+            "flow": flow_norm,
+            "tracker": tracker_norm,
+            "pr_evidence": pr_evidence,
+            "lastSyncedAt": prior_synced,
+            "details": written,
+        }
+
+    if isinstance(written, dict) and written.get("noop"):
+        return noop_result(noop_reason=str(
+            written.get("reason") or "provider_already_current"))
+
+    # Applied — advance lastSyncedAt + receipt.
+    persisted = _persist_applied_state(
+        flow_dir, spec_id, fold_local_done=False,
+        expected_durable=locator["durable"],
+        expected_display=locator["display"])
+    if isinstance(persisted, TrackerError):
+        # Provider mutation LANDED; only local persistence failed. Report the
+        # completed write in the error details (mirrors the syncbody
+        # post-write pattern) so receipts reflect the landed mutation and a
+        # retry that sees the remote no-op is explainable. lastSyncedAt stays
+        # behind on purpose - it advances only on fully applied.
+        return TrackerError(
+            persisted.cls,
+            f"status persist failed after tracker write: {persisted.message}",
+            subtype=persisted.subtype,
+            details={**(persisted.details or {}),
+                     "completed_steps": ["status-write"],
+                     "target": decision.target_slot,
+                     "write": written if isinstance(written, dict) else None},
+            auto_retryable=persisted.auto_retryable,
+        )
+    tracker = persisted
+    if write_receipt:
+        rerr = write_sync_receipt(
+            flow_dir, spec_id=spec_id, status="updated",
+            tracker_id=durable, event=event, transport=provider,
+            note=f"status applied → {decision.target_slot}",
+            degraded=written.get("degraded") if isinstance(written, dict) else None,
+        )
+        if rerr:
+            import dataclasses  # noqa: PLC0415
+            return dataclasses.replace(rerr, details={
+                **(rerr.details or {}),
+                "completed_steps": ["status-write", "lastSyncedAt"],
+                "target": decision.target_slot,
+            })
+    return {
+        "kind": "applied",
+        "to": to,
+        "applied": decision.target_slot,
+        "flow": flow_norm,
+        "tracker": tracker_norm,
+        "pr_evidence": pr_evidence,
+        "lastSyncedAt": tracker["lastSyncedAt"],
+        "write": written,
+    }

--- a/.flow/bin/flowctl_tracker/subjects.py
+++ b/.flow/bin/flowctl_tracker/subjects.py
@@ -1,0 +1,478 @@
+"""Typed tracker subjects (spec | chart | decision) for the lifecycle facade.
+
+fn-135.5 / R42: chart projection reuses the facade through subject-aware
+load/write/collision paths. Spec remains the default kind; chart and decision
+subjects store locator + provenance on their own sidecars without mutating
+spec metadata or treating tracker ids as chart identity.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import re
+import stat as stat_mod
+import time
+from pathlib import Path
+from typing import Iterator, Optional, Union
+
+from .lifecycle.helpers import (Result, atomic_write_json, default_tracker,
+                                derive_link_state, dict_, leaf_is_safe,
+                                merged_tracker, now_iso)
+from .types import ErrorClass, TrackerError
+
+SUBJECT_KINDS = frozenset({"spec", "chart", "decision"})
+
+# Canonical decision id: fn-N.D<n> (chart-qualified).
+_DECISION_ID_RE = re.compile(r"^(?P<chart>fn-\d+)\.D(?P<n>[1-9]\d*)$", re.I)
+_CHART_ID_RE = re.compile(r"^fn-\d+$", re.I)
+
+
+def parse_decision_id(raw: str) -> Optional[tuple[str, int]]:
+    m = _DECISION_ID_RE.fullmatch((raw or "").strip())
+    if not m:
+        return None
+    return m.group("chart").lower(), int(m.group("n"))
+
+
+def validate_subject_id(kind: str, subject_id: str) -> Optional[TrackerError]:
+    kind = (kind or "").strip().lower()
+    sid = (subject_id or "").strip()
+    if kind not in SUBJECT_KINDS:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"unknown subject kind {kind!r}",
+            subtype="subject_kind",
+        )
+    if not sid:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "subject id required",
+            subtype="subject_id",
+        )
+    if kind == "spec":
+        # Spec ids are free-form (fn-N-slug or tracker-keyed); non-empty is enough.
+        return None
+    if kind == "chart":
+        if not _CHART_ID_RE.fullmatch(sid):
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"invalid chart id {sid!r}",
+                subtype="subject_id",
+            )
+        return None
+    if parse_decision_id(sid) is None:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"invalid decision id {sid!r} (expected <chart-id>.D<n>)",
+            subtype="subject_id",
+        )
+    return None
+
+
+def subject_json_path(flow_dir: Path, kind: str, subject_id: str) -> Path:
+    kind = kind.strip().lower()
+    sid = subject_id.strip()
+    flow_dir = Path(flow_dir)
+    if kind == "spec":
+        return flow_dir / "specs" / f"{sid}.json"
+    if kind == "chart":
+        return flow_dir / "charts" / f"{sid}.json"
+    parsed = parse_decision_id(sid)
+    if parsed is None:
+        # Caller should have validated; fall back to a non-resolving path.
+        return flow_dir / "charts" / "_invalid" / f"{sid}.json"
+    chart_id, n = parsed
+    return flow_dir / "charts" / chart_id / f"{n}.json"
+
+
+def load_subject(
+    flow_dir: Path, kind: str, subject_id: str
+) -> Union[tuple[Path, dict, dict], TrackerError]:
+    """Load subject sidecar + merged tracker block.
+
+    Returns (path, data, tracker) or TrackerError.
+    """
+    bad = validate_subject_id(kind, subject_id)
+    if bad:
+        return bad
+    kind = kind.strip().lower()
+    sid = subject_id.strip()
+    if kind == "chart":
+        sid = sid.lower()
+    elif kind == "decision":
+        parsed = parse_decision_id(sid)
+        assert parsed is not None
+        chart_id, n = parsed
+        sid = f"{chart_id.lower()}.D{n}"
+    path = subject_json_path(flow_dir, kind, sid)
+    if kind in ("decision", "chart"):
+        unsafe = leaf_is_safe(Path(flow_dir) / "charts", path)
+    else:
+        unsafe = leaf_is_safe(Path(flow_dir) / "specs", path)
+    if unsafe:
+        return unsafe
+    if not path.is_file():
+        return TrackerError(
+            ErrorClass.NOT_FOUND,
+            f"{kind} {sid!r} not found",
+            subtype=kind,
+        )
+    try:
+        data = path.read_text(encoding="utf-8")
+        import json  # noqa: PLC0415
+
+        obj = json.loads(data)
+    except (OSError, ValueError) as exc:
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            f"unreadable {kind}: {exc}",
+            subtype=kind,
+        )
+    if not isinstance(obj, dict):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"{kind} json is not an object",
+            subtype=kind,
+        )
+    tracker = merged_tracker(obj)
+    return path, obj, tracker
+
+
+def write_subject_tracker(
+    path: Path, data: dict, tracker: dict
+) -> Optional[TrackerError]:
+    data = dict(data)
+    data["tracker"] = tracker
+    data["updated_at"] = now_iso()
+    return atomic_write_json(path, data)
+
+
+# Chart resource lock: the SAME lock file flowctl's chart WAL transactions
+# hold around their sidecar read-modify-write cycles. Projection sidecar
+# writes must contend on it, or a post-commit projection can persist a tracker
+# link between another chart command's load and publish and be clobbered by
+# that command's older JSON (duplicate remote issues on the next projection).
+_CHARTS_RESOURCE_LOCK_NAME = "charts-resource.lock"
+_CHART_PROJECTION_LOCK_NAME = "chart-projection.lock"
+_CHARTS_LOCK_TIMEOUT_S = 10.0
+# The projection waiter must outlast a normally-held lock: a holder spans
+# several remote requests, each with a 30s default budget
+# (types.DEFAULT_TIMEOUT_S), so a 10s wait would abandon projections that are
+# merely queued behind a healthy holder. A still-failing acquisition keeps the
+# best-effort lock_timeout error shape; convergence then rests on the holder's
+# drain loop in project_chart, which re-projects any state a timed-out waiter
+# committed locally.
+_CHART_PROJECTION_LOCK_TIMEOUT_S = 120.0
+_CHARTS_LOCK_POLL_S = 0.02
+
+
+def charts_resource_lock_file(flow_dir: Path) -> Path:
+    """Path of flowctl's chart WAL/mutation lock (.flow/locks/charts-resource.lock)."""
+    return Path(flow_dir) / "locks" / _CHARTS_RESOURCE_LOCK_NAME
+
+
+def chart_projection_lock_file(flow_dir: Path) -> Path:
+    """Path of the chart projection lock (.flow/locks/chart-projection.lock)."""
+    return Path(flow_dir) / "locks" / _CHART_PROJECTION_LOCK_NAME
+
+
+def _try_kernel_lock(fd: int) -> bool:
+    """One non-blocking exclusive acquisition - same mechanism as flowctl's
+    cross_process_lock (flock on POSIX, msvcrt byte lock on Windows) so the
+    two sides genuinely contend on the shared lock file."""
+    if os.name == "nt":  # pragma: no cover - exercised on the Windows CI row
+        import msvcrt  # noqa: PLC0415
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as e:
+            if e.errno in (errno.EACCES, errno.EAGAIN, errno.EDEADLK):
+                return False
+            raise
+
+    import fcntl  # noqa: PLC0415
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as e:
+        if e.errno in (errno.EACCES, errno.EAGAIN):
+            return False
+        raise
+
+
+def _release_kernel_lock(fd: int) -> None:
+    if os.name == "nt":  # pragma: no cover - exercised on the Windows CI row
+        import msvcrt  # noqa: PLC0415
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl  # noqa: PLC0415
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def _bounded_file_lock(
+    lock_path: Path, *, timeout_s: float, label: str
+) -> Iterator[None]:
+    """Bounded exclusive kernel lock on a named lock file.
+
+    Raises ConfigLockTimeout on timeout so callers map it to the same
+    CONFLICT/lock_timeout TrackerError as the config writer lock.
+    """
+    from .config_lock import ConfigLockTimeout  # noqa: PLC0415
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        st = os.lstat(lock_path)
+        if not stat_mod.S_ISREG(st.st_mode):
+            raise ConfigLockTimeout(
+                f"{label} lock path is not a regular file: {lock_path}"
+            )
+    except FileNotFoundError:
+        pass
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(lock_path, flags, 0o600)
+    acquired = False
+    try:
+        if os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+        deadline = time.monotonic() + max(0.0, timeout_s)
+        while not acquired:
+            acquired = _try_kernel_lock(fd)
+            if acquired:
+                break
+            if time.monotonic() >= deadline:
+                raise ConfigLockTimeout(
+                    f"timed out acquiring {label} lock {lock_path} "
+                    f"after {timeout_s:g}s"
+                )
+            time.sleep(_CHARTS_LOCK_POLL_S)
+        yield
+    finally:
+        if acquired:
+            with contextlib.suppress(OSError):
+                _release_kernel_lock(fd)
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+@contextlib.contextmanager
+def charts_resource_lock(
+    flow_dir: Path, *, timeout_s: float = _CHARTS_LOCK_TIMEOUT_S
+) -> Iterator[None]:
+    """Bounded exclusive kernel lock on the chart resource lock file."""
+    with _bounded_file_lock(
+        charts_resource_lock_file(flow_dir),
+        timeout_s=timeout_s, label="chart resource",
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def chart_projection_lock(
+    flow_dir: Path, *, timeout_s: float = _CHART_PROJECTION_LOCK_TIMEOUT_S
+) -> Iterator[None]:
+    """Cross-process serialization of whole chart projections.
+
+    A DEDICATED lock file, not the chart WAL lock: holding the WAL lock
+    across the remote read/update span would block local chart mutations on
+    network latency. The projection reloads chart + decision state inside
+    this lock, so an older caller re-projects the newest committed state
+    (convergent) instead of overwriting remote bodies with stale content.
+    Lock ordering: projection lock OUTERMOST, then charts_resource_lock,
+    then config_lock (via locked_subject_write).
+    """
+    with _bounded_file_lock(
+        chart_projection_lock_file(flow_dir),
+        timeout_s=timeout_s, label="chart projection",
+    ):
+        yield
+
+
+def locked_subject_write(
+    flow_dir: Path,
+    kind: str,
+    subject_id: str,
+    mutate,
+    *,
+    collision_id: Optional[str] = None,
+) -> Result:
+    """Reload + mutate + persist subject tracker under the shared writer lock.
+
+    Chart/decision subjects additionally serialize against flowctl's chart
+    resource lock (taken FIRST, matching chart commands' charts-then-inner
+    ordering) so projection writes cannot interleave with a chart command's
+    WAL read-modify-write on the same sidecar.
+    """
+    from .config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+
+    try:
+        with contextlib.ExitStack() as stack:
+            if (kind or "").strip().lower() in ("chart", "decision"):
+                stack.enter_context(charts_resource_lock(flow_dir))
+            stack.enter_context(config_lock(flow_dir))
+            loaded = load_subject(flow_dir, kind, subject_id)
+            if isinstance(loaded, TrackerError):
+                return loaded
+            path, data, tracker = loaded
+            if collision_id is not None:
+                hit = subject_collision(
+                    flow_dir, collision_id, except_kind=kind, except_id=subject_id
+                )
+                if hit:
+                    return hit
+            tracker = mutate(tracker)
+            if isinstance(tracker, TrackerError):
+                return tracker
+            werr = write_subject_tracker(path, data, tracker)
+            if werr:
+                return werr
+            return tracker
+    except ConfigLockTimeout as exc:
+        return TrackerError(
+            ErrorClass.CONFLICT, str(exc), subtype="lock_timeout"
+        )
+
+
+def iter_all_subject_trackers(flow_dir: Path):
+    """Yield (kind, subject_id, tracker) for specs, charts, and decisions."""
+    flow_dir = Path(flow_dir)
+    specs = flow_dir / "specs"
+    if specs.is_dir():
+        for path in sorted(specs.glob("*.json")):
+            try:
+                import json  # noqa: PLC0415
+
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            sid = data.get("id") or path.stem
+            yield "spec", str(sid), dict_(data.get("tracker"))
+
+    charts = flow_dir / "charts"
+    if not charts.is_dir():
+        return
+    for path in sorted(charts.glob("*.json")):
+        if path.name.startswith("."):
+            continue
+        try:
+            import json  # noqa: PLC0415
+
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        sid = data.get("id") or path.stem
+        yield "chart", str(sid), dict_(data.get("tracker"))
+        # Decision records live under charts/<chart-id>/<n>.json
+        chart_dir = charts / str(sid)
+        if not chart_dir.is_dir():
+            continue
+        for dpath in sorted(chart_dir.glob("*.json")):
+            if not dpath.stem.isdigit():
+                continue
+            try:
+                import json  # noqa: PLC0415
+
+                ddata = json.loads(dpath.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if not isinstance(ddata, dict):
+                continue
+            did = ddata.get("id") or f"{sid}.D{dpath.stem}"
+            yield "decision", str(did), dict_(ddata.get("tracker"))
+
+
+def subject_collision(
+    flow_dir: Path,
+    durable_id: str,
+    *,
+    except_kind: Optional[str] = None,
+    except_id: Optional[str] = None,
+) -> Optional[TrackerError]:
+    """One durable id per subject across specs, charts, and decisions."""
+    for kind, sid, state in iter_all_subject_trackers(flow_dir):
+        if (
+            except_kind is not None
+            and except_id is not None
+            and kind == except_kind
+            and str(sid) == str(except_id)
+        ):
+            continue
+        if state.get("id") and str(state["id"]) == str(durable_id):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                f"Tracker id {durable_id} already linked to {kind} {sid}",
+                subtype="durable_collision",
+                details={"owner": sid, "kind": kind, "durable": durable_id},
+            )
+    return None
+
+
+def ensure_tracker_block(data: dict) -> dict:
+    """Ensure subject data has a tracker block with schema defaults."""
+    raw = dict_(data.get("tracker"))
+    if not raw:
+        raw = default_tracker()
+    data = dict(data)
+    data["tracker"] = {**default_tracker(), **raw}
+    data["tracker"]["linkState"] = derive_link_state(raw)
+    return data
+
+
+def charts_projection_enabled(config: dict) -> bool:
+    """True iff tracker.charts is the literal string 'on' (fail-closed).
+
+    Bool true / typos / perEvent verbs never activate - same string-enum
+    discipline as pipeline.qa.
+    """
+    tracker = dict_(config.get("tracker"))
+    val = tracker.get("charts")
+    if isinstance(val, str):
+        return val.strip().lower() == "on"
+    return False
+
+
+def projection_gate(config: dict) -> dict:
+    """Structured skip/active gate for chart projection.
+
+    Local chart mutations always succeed; this only describes remote projection.
+    """
+    from .lifecycle.helpers import tracker_type  # noqa: PLC0415
+
+    if not charts_projection_enabled(config):
+        return {
+            "active": False,
+            "skipped": "tracker.charts_off",
+            "reason": "tracker.charts is off or unset",
+        }
+    provider = tracker_type(config)
+    if provider is None:
+        return {
+            "active": False,
+            "skipped": "bridge_inactive",
+            "reason": "tracker bridge is inactive or unconfigured",
+        }
+    return {"active": True, "provider": provider, "skipped": None}
+
+
+def caps_of(config: dict) -> dict:
+    from .relate.ledger import caps_of as _caps  # noqa: PLC0415
+
+    return _caps(config)
+
+
+def subject_marker_token(kind: str, subject_id: str) -> str:
+    """Stable token for event markers / receipts (replaces bare spec=)."""
+    return f"{kind}:{subject_id}"

--- a/.flow/bin/flowctl_tracker/syncbody/__init__.py
+++ b/.flow/bin/flowctl_tracker/syncbody/__init__.py
@@ -1,0 +1,742 @@
+"""`tracker sync-body` - write/readback + paired merge base (fn-140.5).
+
+Server readback is canonical for the tracker half. mergeBaseFlow stays the
+exact --flow-file body (comparable to the local spec); mergeBaseTracker is
+trackerBodyForMerge(readback). Both halves commit atomically under the shared
+config_lock. Partial failure leaves the prior base untouched.
+
+The WHOLE read/write/readback/commit transaction is serialized per spec via a
+create-first claim (`syncbody-<spec-id>.json`) taken BEFORE any tracker I/O -
+without it two overlapping invocations each finish their write/readback and
+the OLDER one can acquire config_lock last, overwriting the newer paired base
+with a stale pair (tracker holds body B, mergeBaseTracker records body A).
+Every transaction additionally takes a provider + durable-issue keyed body claim,
+shared with direct wire body updates and GitLab `relate`, because these paths
+must not change the remote body between sync-body's read and paired-base commit.
+
+<!-- flow:deps --> is stripped at the hash boundary (R10 half deferred from
+.4) and carried forward on every push write so a full-body update cannot
+self-delete the block.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import socket
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..lifecycle.helpers import (ACTIVE, Execute, Result, atomic_write_json,
+                                 dict_, leaf_is_safe, load_spec,
+                                 merged_tracker, now_iso, read_config,
+                                 tracker_type, write_sync_receipt,
+                                 write_tracker_block)
+from ..lifecycle.linkstate import require_durable
+from ..lifecycle.verbs import (_claim_body_mutation, _claim_is_stale,
+                               _ensure_create_first_ignored, _release_claim)
+from ..relate.ledger import FLOW_DEPS_CLOSE, FLOW_DEPS_OPEN
+from ..types import ErrorClass, TrackerError
+
+__all__ = [
+    "FLOW_DEPS_CLOSE",
+    "FLOW_DEPS_OPEN",
+    "run",
+    "sync_body",
+    "trackerBodyForMerge",
+]
+
+# Region match is DOTALL so multi-line dep blocks strip as one unit.
+_DEPS_RE = re.compile(
+    re.escape(FLOW_DEPS_OPEN) + r".*?" + re.escape(FLOW_DEPS_CLOSE),
+    re.DOTALL,
+)
+
+
+def trackerBodyForMerge(raw_body) -> str:
+    """Hash-boundary transform: strip flow:deps + trailing-newline only.
+
+    Does NOT predict Linear's markdown rewriting. Markers are included in the
+    strip so the block never differs hashes or folds into the spec.
+    """
+    if raw_body is None:
+        text = ""
+    elif isinstance(raw_body, str):
+        text = raw_body
+    else:
+        text = str(raw_body)
+    text = _DEPS_RE.sub("", text)
+    return text.rstrip("\n")
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _extract_deps_region(raw_body: str) -> Optional[str]:
+    m = _DEPS_RE.search(raw_body or "")
+    return m.group(0) if m else None
+
+
+def _deps_region_error(raw_body: str, *, label: str) -> Optional[TrackerError]:
+    """Reject marker shapes that a whole-body rewrite cannot preserve safely."""
+    text = raw_body or ""
+    opens = text.count(FLOW_DEPS_OPEN)
+    closes = text.count(FLOW_DEPS_CLOSE)
+    if opens == closes == 0:
+        return None
+    valid = (
+        opens == 1
+        and closes == 1
+        and text.find(FLOW_DEPS_OPEN) < text.find(FLOW_DEPS_CLOSE)
+    )
+    if valid:
+        return None
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"{label} has multiple or unbalanced flow:deps regions; refusing "
+        "lossy body normalization",
+        subtype="deps_block",
+        details={"openMarkers": opens, "closeMarkers": closes},
+    )
+
+
+def _carry_deps_forward(outgoing: str, current: str) -> str:
+    """Write-side rule: preserve the existing flow:deps region on full-body update.
+
+    renderFlowToTracker does not emit the block; without carry-forward a push
+    self-deletes it and the next relate misreads that as human removal.
+    """
+    base = _DEPS_RE.sub("", outgoing or "")
+    region = _extract_deps_region(current or "")
+    if region is None:
+        return base
+    base = base.rstrip("\n")
+    return f"{base}\n\n{region}\n"
+
+
+def _raw_body(provider: str, parent: dict) -> str:
+    """Extract issue body from a raw parent_read object (provider-shaped)."""
+    if provider == "github":
+        body = parent.get("body")
+    elif provider == "jira":
+        fields = parent.get("fields") if isinstance(parent.get("fields"), dict) else {}
+        body = fields.get("description")
+    else:
+        # gitlab + linear store the body as description
+        body = parent.get("description")
+    if body is None:
+        return ""
+    return body if isinstance(body, str) else str(body)
+
+
+def _raw_title(provider: str, parent: dict) -> str:
+    """Extract the native issue title from a raw parent-read object."""
+    if provider == "jira":
+        fields = parent.get("fields") if isinstance(parent.get("fields"), dict) else {}
+        title = fields.get("summary")
+    else:
+        title = parent.get("title")
+    if title is None:
+        return ""
+    return title if isinstance(title, str) else str(title)
+
+
+def _locator(tracker: dict) -> Result:
+    durable = tracker.get("id")
+    display = tracker.get("identifier")
+    if not isinstance(durable, str) or not durable.strip():
+        return TrackerError(ErrorClass.UNRESOLVED, "tracker.id missing",
+                            subtype="durable")
+    if not isinstance(display, str) or not display.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "tracker.identifier (display) required for sync-body",
+                            subtype="locator")
+    return {"durable": durable.strip(), "display": display.strip()}
+
+
+def _has_paired_base(tracker: dict) -> bool:
+    return (tracker.get("mergeBaseFlow") is not None
+            and tracker.get("mergeBaseTracker") is not None)
+
+
+def _commit_paired_base(flow_dir: Path, spec_id: str, *,
+                        locator: dict,
+                        flow_file_body: str, readback_body: str,
+                        advance_synced: bool) -> Result:
+    """Atomically write both merge-base halves (+ hashes, optional lastSyncedAt).
+
+    Never writes one half alone (paired-snapshot invariant). ``locator`` is
+    the durable/display identity the transaction's remote read/write used;
+    the reloaded tracker block is re-checked against it INSIDE the critical
+    section (linkstate's _complete pattern). The syncbody claim serializes
+    sibling sync-body runs, NOT ``sync set-tracker-id`` - if that repoints
+    the spec while our tracker I/O is in flight, committing bodies read from
+    the OLD issue as the NEW issue's paired merge base makes every later
+    reconcile merge against the wrong content. Refuse with structured
+    CONFLICT and persist nothing.
+    """
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+
+    merge_tracker = trackerBodyForMerge(readback_body)
+    base_flow = flow_file_body if isinstance(flow_file_body, str) else str(flow_file_body)
+    hash_flow = _content_hash(base_flow)
+    hash_tracker = _content_hash(merge_tracker)
+    try:
+        with config_lock(flow_dir):
+            loaded = load_spec(flow_dir, spec_id)
+            if isinstance(loaded, TrackerError):
+                return loaded
+            path, spec_data = loaded
+            tracker = merged_tracker(spec_data)
+            reloaded = _locator(tracker)
+            if isinstance(reloaded, TrackerError) or reloaded != locator:
+                now_id = tracker.get("id")
+                now_display = tracker.get("identifier")
+                return TrackerError(
+                    ErrorClass.CONFLICT,
+                    f"spec {spec_id!r} tracker identity changed while "
+                    f"sync-body was in flight (transaction used "
+                    f"{locator.get('display')!r}/{locator.get('durable')!r}, "
+                    f"spec now has {now_display!r}/{now_id!r}); refusing to "
+                    "commit merge base read from the old issue; re-run "
+                    "sync-body against the new link",
+                    subtype="identity_changed",
+                    details={"specId": spec_id,
+                             "transaction": dict(locator),
+                             "current": {"durable": now_id,
+                                         "display": now_display}})
+            tracker["mergeBaseFlow"] = base_flow
+            tracker["mergeBaseTracker"] = merge_tracker
+            tracker["baseHashFlow"] = hash_flow
+            tracker["baseHashTracker"] = hash_tracker
+            if advance_synced:
+                tracker["lastSyncedAt"] = now_iso()
+            werr = write_tracker_block(path, spec_data, tracker)
+            if werr:
+                return werr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc), subtype="lock_timeout")
+    return {
+        "mergeBaseFlow": base_flow,
+        "mergeBaseTracker": merge_tracker,
+        "baseHashFlow": hash_flow,
+        "baseHashTracker": hash_tracker,
+        "lastSyncedAt": tracker.get("lastSyncedAt"),
+        "tracker": tracker,
+    }
+
+
+def _claim_sync_body(flow_dir: Path, spec_id: str, rec_path: Path,
+                     provider: str, *,
+                     direction: str) -> Optional[TrackerError]:
+    """Reserve the spec's sync-body transaction under the shared writer lock
+    BEFORE any tracker read or write (create-first's claim pattern, keyed on
+    the spec id). Two overlapping sync-body invocations for the same spec
+    each perform write/readback before committing the paired base; without a
+    claim the OLDER invocation can acquire config_lock last and overwrite the
+    newer pair with a stale one - the tracker then holds body B while
+    mergeBaseTracker records body A, so the next reconcile reports false
+    divergence or merges against the wrong base. Under the lock: a live
+    claim from another process refuses (syncbody_in_flight, retryable), a
+    stale claim (dead pid on this host past the stale window,
+    _claim_is_stale's owner rules) is reclaimed by overwriting, and OUR
+    pending claim lands durably before any remote I/O. The claim is always
+    released when the invocation finishes (success or failure): the paired
+    base in the spec, not the claim file, is the durable record."""
+    unsafe = leaf_is_safe(flow_dir / "create-first", rec_path)
+    if unsafe:
+        return unsafe
+    secured = _ensure_create_first_ignored(flow_dir)
+    if secured is not None:
+        return secured
+    from ..config_lock import ConfigLockTimeout, config_lock  # noqa: PLC0415
+    try:
+        with config_lock(flow_dir):
+            if rec_path.is_file():
+                try:
+                    prior = json.loads(rec_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    prior = None
+                if (isinstance(prior, dict)
+                        and prior.get("status") == "pending"
+                        and not _claim_is_stale(prior, rec_path)):
+                    return TrackerError(
+                        ErrorClass.CONFLICT,
+                        f"sync-body for spec {spec_id!r} is already in "
+                        "flight in another process; retry after it finishes",
+                        subtype="syncbody_in_flight",
+                        details={"specId": spec_id,
+                                 "claim": {"pid": prior.get("pid"),
+                                           "host": prior.get("host"),
+                                           "claimedAt": prior.get("claimedAt")}},
+                        auto_retryable=True)
+                # A STALE pending claim (crashed run) is reclaimed by
+                # overwriting it with OURS - same rule as create-first.
+            claim = {"specId": spec_id, "status": "pending",
+                     "op": "sync-body", "direction": direction,
+                     "pid": os.getpid(), "host": socket.gethostname(),
+                     "claimedAt": time.time(), "transport": provider}
+            cerr = atomic_write_json(rec_path, claim)
+            if cerr:
+                return cerr
+    except ConfigLockTimeout as exc:
+        return TrackerError(ErrorClass.CONFLICT, str(exc),
+                            subtype="lock_timeout")
+    return None
+
+
+def sync_body(flow_dir, spec_id: str, *, flow_file_body: str,
+              tracker_body: Optional[str] = None,
+              expected_tracker_body: Optional[str] = None,
+              tracker_read: Optional[Callable[[dict], Result]] = None,
+              sync_title: bool = False,
+              direction: str = "push",
+              event: Optional[str] = None,
+              execute: Execute = default_execute,
+              write_receipt: bool = True) -> Result:
+    """Write (optional) + readback + paired merge base. Never raises.
+
+    Serialized per spec via a create-first claim taken before any tracker
+    I/O; a live foreign claim refuses with structured CONFLICT
+    (syncbody_in_flight, retryable) instead of interleaving to a mismatched
+    pair. ``tracker_read`` is honored ONLY for ``direction="pull"``: when
+    set, the transaction calls it with ITS OWN locator (loaded after the
+    claim) instead of parent_read, and persists the returned wire-read body
+    as the tracker half. The read therefore happens INSIDE the claimed
+    transaction - a snapshot captured before the claim could pair an older
+    read with a newer base, or commit the old issue's body under a
+    repointed locator. ``sync_title`` is an internal facade seam:
+    push/reconcile project the current spec title in the same update/readback
+    transaction as the body; the standalone body verb keeps its body-only
+    default.
+    """
+    flow_dir = Path(flow_dir)
+    if not spec_id:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "sync-body requires <spec-id>", subtype="args")
+    if flow_file_body is None:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "sync-body requires --flow-file", subtype="args")
+    if direction not in ("push", "pull"):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "direction must be push or pull", subtype="direction")
+
+    config = read_config(flow_dir)
+    provider = tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    rec_path = flow_dir / "create-first" / f"syncbody-{spec_id}.json"
+    claimed = _claim_sync_body(flow_dir, spec_id, rec_path, provider,
+                               direction=direction)
+    if claimed is not None:
+        return claimed
+    claimed_spec = load_spec(flow_dir, spec_id)
+    if isinstance(claimed_spec, TrackerError):
+        _release_claim(rec_path)
+        return claimed_spec
+    _claimed_path, claimed_data = claimed_spec
+    claimed_locator = _locator(merged_tracker(claimed_data))
+    if isinstance(claimed_locator, TrackerError):
+        _release_claim(rec_path)
+        return claimed_locator
+    body_claim = _claim_body_mutation(
+        flow_dir, provider, claimed_locator,
+        operation=f"sync-body-{direction}", spec_id=spec_id)
+    if isinstance(body_claim, TrackerError):
+        _release_claim(rec_path)
+        return body_claim
+    try:
+        return _sync_body_txn(
+            flow_dir, spec_id, config=config, provider=provider,
+            flow_file_body=flow_file_body, tracker_body=tracker_body,
+            expected_tracker_body=expected_tracker_body,
+            tracker_read=tracker_read, sync_title=sync_title,
+            direction=direction,
+            event=event, execute=execute, write_receipt=write_receipt)
+    finally:
+        _release_claim(body_claim)
+        _release_claim(rec_path)
+
+
+def _sync_body_txn(flow_dir: Path, spec_id: str, *, config: dict,
+                   provider: str, flow_file_body: str,
+                   tracker_body: Optional[str],
+                   expected_tracker_body: Optional[str],
+                   tracker_read: Optional[Callable[[dict], Result]],
+                   sync_title: bool,
+                   direction: str, event: Optional[str],
+                   execute: Execute, write_receipt: bool) -> Result:
+    """The claimed transaction body: spec is (re)loaded AFTER the claim so
+    the echo-fence/no-op checks see the base a just-finished sibling wrote,
+    never a pre-claim snapshot."""
+    loaded = load_spec(flow_dir, spec_id)
+    if isinstance(loaded, TrackerError):
+        return loaded
+    _path, spec_data = loaded
+    tracker = merged_tracker(spec_data)
+    desired_title = (
+        str(spec_data.get("title") or spec_id) if sync_title else None)
+
+    durable = require_durable(tracker)
+    if isinstance(durable, TrackerError):
+        return durable
+
+    locator = _locator(tracker)
+    if isinstance(locator, TrackerError):
+        return locator
+
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    from ..wire import dispatch as wire_dispatch  # noqa: PLC0415
+    from ..wire import parent_read  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+    current_title = ""
+
+    # Pull + caller-supplied reader: run the wire read HERE, inside the
+    # claimed transaction and against the transaction's own locator. The
+    # claim above and the identity guard in _commit_paired_base then cover
+    # the read too: an overlapping pull cannot pair an older read with a
+    # newer base, and a set-tracker-id repoint in the gap cannot commit the
+    # old issue's body under the new locator.
+    if direction == "pull" and tracker_read is not None:
+        read_out = tracker_read(locator)
+        if isinstance(read_out, TrackerError):
+            return read_out
+        raw = read_out.get("body") if isinstance(read_out, dict) else None
+        if raw is None:
+            current_body = ""
+        elif isinstance(raw, str):
+            current_body = raw
+        else:
+            current_body = str(raw)
+    else:
+        parent = parent_read(provider, config, locator, ex,
+                             op="sync-body-parent-read")
+        if isinstance(parent, TrackerError):
+            return parent
+        current_body = _raw_body(provider, parent)
+        current_title = _raw_title(provider, parent)
+
+    malformed = _deps_region_error(current_body, label="tracker body")
+    if malformed is not None:
+        return malformed
+    if expected_tracker_body is not None:
+        malformed = _deps_region_error(
+            expected_tracker_body, label="expected tracker body")
+        if malformed is not None:
+            return malformed
+    if tracker_body is not None:
+        malformed = _deps_region_error(
+            tracker_body, label="approved tracker body")
+        if malformed is not None:
+            return malformed
+
+    if direction == "pull":
+        if (expected_tracker_body is not None
+                and trackerBodyForMerge(current_body)
+                != trackerBodyForMerge(expected_tracker_body)):
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                "tracker body changed after the creating mutation; refusing "
+                "to adopt the later readback as synchronized",
+                subtype="readback_diverged",
+                details={
+                    "writtenHash": _content_hash(
+                        trackerBodyForMerge(expected_tracker_body)),
+                    "readbackHash": _content_hash(
+                        trackerBodyForMerge(current_body)),
+                },
+            )
+        committed = _commit_paired_base(
+            flow_dir, spec_id, locator=locator,
+            flow_file_body=flow_file_body,
+            readback_body=current_body,
+            advance_synced=True,
+        )
+        if isinstance(committed, TrackerError):
+            return committed
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="pulled",
+                tracker_id=durable, event=event, transport=provider,
+                note="sync-body pull seeded paired merge base",
+            )
+            if rerr:
+                return TrackerError(
+                    rerr.cls, rerr.message, subtype=rerr.subtype,
+                    details={**(rerr.details or {}),
+                             "completed_steps": ["paired-base"]},
+                    auto_retryable=rerr.auto_retryable)
+        return {
+            "kind": "pulled",
+            "direction": "pull",
+            "side_written": "none",
+            "mergeBaseFlow": committed["mergeBaseFlow"],
+            "mergeBaseTracker": committed["mergeBaseTracker"],
+            "baseHashFlow": committed["baseHashFlow"],
+            "baseHashTracker": committed["baseHashTracker"],
+            "lastSyncedAt": committed["lastSyncedAt"],
+            "degraded": None,
+        }
+
+    # --- push ---
+    if (expected_tracker_body is not None
+            and trackerBodyForMerge(current_body)
+            != trackerBodyForMerge(expected_tracker_body)):
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            "tracker body changed after the reconcile read; refusing to "
+            "overwrite the newer remote edit; re-run reconcile",
+            subtype="tracker_body_changed",
+            details={"specId": spec_id, "recoverable": True},
+            auto_retryable=True,
+        )
+
+    outgoing_src = tracker_body if tracker_body is not None else flow_file_body
+    outgoing = _carry_deps_forward(outgoing_src, current_body)
+
+    # No-write classification considers ALL THREE values (flow body, current
+    # tracker body, and any explicitly supplied tracker body):
+    #   * matches_current - the outgoing body already equals the tracker at
+    #     the hash boundary: nothing to write.
+    #   * echo fence - ONLY when no explicit tracker body was supplied: the
+    #     flow side equals mergeBaseFlow and the tracker equals
+    #     mergeBaseTracker, so Linear's rewrite of the last push must not look
+    #     like divergence. An explicitly supplied --tracker-body-file is a
+    #     newly APPROVED reconcile result and must never be suppressed by it.
+    has_base = _has_paired_base(tracker)
+    matches_current = (
+        trackerBodyForMerge(outgoing) == trackerBodyForMerge(current_body))
+    title_matches = desired_title is None or current_title == desired_title
+    echo_fence = (
+        tracker_body is None
+        and has_base
+        and flow_file_body == tracker.get("mergeBaseFlow")
+        and trackerBodyForMerge(current_body) == tracker.get("mergeBaseTracker"))
+    if title_matches and (matches_current or echo_fence):
+        # No tracker write beyond the parent read. But the FLOW half may have
+        # moved: a base whose mergeBaseFlow no longer equals the local body
+        # must be re-committed (no mutation) or every later flow-side diff
+        # against it is false.
+        flow_unchanged = (
+            has_base
+            and flow_file_body == tracker.get("mergeBaseFlow")
+            and trackerBodyForMerge(current_body) == tracker.get("mergeBaseTracker"))
+        if flow_unchanged:
+            if write_receipt:
+                rerr = write_sync_receipt(
+                    flow_dir, spec_id=spec_id, status="noop",
+                    tracker_id=durable, event=event, transport=provider,
+                    note="sync-body already converged")
+                if rerr:
+                    return rerr
+            return {
+                "kind": "noop",
+                "direction": "push",
+                "side_written": "none",
+                "reason": "unchanged",
+                "mergeBaseFlow": tracker.get("mergeBaseFlow"),
+                "mergeBaseTracker": tracker.get("mergeBaseTracker"),
+                "baseHashFlow": tracker.get("baseHashFlow"),
+                "baseHashTracker": tracker.get("baseHashTracker"),
+                "lastSyncedAt": tracker.get("lastSyncedAt"),
+                "degraded": None,
+            }
+        # No base yet: seed from current readback without writing.
+        committed = _commit_paired_base(
+            flow_dir, spec_id, locator=locator,
+            flow_file_body=flow_file_body,
+            readback_body=current_body,
+            advance_synced=True,
+        )
+        if isinstance(committed, TrackerError):
+            return committed
+        if write_receipt:
+            rerr = write_sync_receipt(
+                flow_dir, spec_id=spec_id, status="pushed",
+                tracker_id=durable, event=event, transport=provider,
+                note="sync-body no-op seeded paired merge base",
+            )
+            if rerr:
+                return TrackerError(
+                    rerr.cls, rerr.message, subtype=rerr.subtype,
+                    details={**(rerr.details or {}),
+                             "completed_steps": ["paired-base"]},
+                    auto_retryable=rerr.auto_retryable)
+        return {
+            "kind": "seeded",
+            "direction": "push",
+            "side_written": "none",
+            "mergeBaseFlow": committed["mergeBaseFlow"],
+            "mergeBaseTracker": committed["mergeBaseTracker"],
+            "baseHashFlow": committed["baseHashFlow"],
+            "baseHashTracker": committed["baseHashTracker"],
+            "lastSyncedAt": committed["lastSyncedAt"],
+            "degraded": None,
+        }
+
+    updated = wire_dispatch(
+        "update", config, locator=locator, title=desired_title, body=outgoing,
+        execute=ex)
+    if isinstance(updated, TrackerError):
+        return updated
+
+    readback = wire_dispatch("read", config, locator=locator, execute=ex)
+    if isinstance(readback, TrackerError):
+        # Write succeeded but readback failed: prior merge base untouched.
+        return TrackerError(
+            readback.cls,
+            f"sync-body readback failed after write: {readback.message}",
+            subtype=readback.subtype or "readback",
+            details={**(readback.details or {}),
+                     "completed_steps": ["wire-update"]},
+            auto_retryable=readback.auto_retryable,
+        )
+    readback_body = readback.get("body") if isinstance(readback, dict) else None
+    if readback_body is None:
+        readback_body = ""
+    elif not isinstance(readback_body, str):
+        readback_body = str(readback_body)
+
+    updated_body = updated.get("body") if isinstance(updated, dict) else None
+    if updated_body is None:
+        updated_body = ""
+    elif not isinstance(updated_body, str):
+        updated_body = str(updated_body)
+    if trackerBodyForMerge(updated_body) != trackerBodyForMerge(readback_body):
+        # The mutation response is the server's acknowledgement of OUR write.
+        # A different immediate readback means another remote edit won after
+        # that acknowledgement. Never absorb it into the paired ancestor:
+        # retain the prior base so the next pass surfaces real divergence.
+        return TrackerError(
+            ErrorClass.CONFLICT,
+            "tracker body changed after wire update; refusing to adopt the "
+            "later readback as synchronized",
+            subtype="readback_diverged",
+            details={
+                "completed_steps": ["wire-update", "wire-read"],
+                "writtenHash": _content_hash(
+                    trackerBodyForMerge(updated_body)),
+                "readbackHash": _content_hash(
+                    trackerBodyForMerge(readback_body)),
+            },
+        )
+    if desired_title is not None:
+        updated_title = (
+            updated.get("title") if isinstance(updated, dict) else None)
+        readback_title = (
+            readback.get("title") if isinstance(readback, dict) else None)
+        if updated_title != desired_title or readback_title != desired_title:
+            return TrackerError(
+                ErrorClass.CONFLICT,
+                "tracker title changed or was not applied after wire update; "
+                "refusing to commit the paired base",
+                subtype="title_readback_diverged",
+                details={
+                    "completed_steps": ["wire-update", "wire-read"],
+                    "requestedTitle": desired_title,
+                    "writtenTitle": updated_title,
+                    "readbackTitle": readback_title,
+                },
+            )
+
+    committed = _commit_paired_base(
+        flow_dir, spec_id, locator=locator,
+        flow_file_body=flow_file_body,
+        readback_body=readback_body,
+        advance_synced=True,
+    )
+    if isinstance(committed, TrackerError):
+        return TrackerError(
+            committed.cls, committed.message, subtype=committed.subtype,
+            details={**(committed.details or {}),
+                     "completed_steps": ["wire-update", "wire-read"]},
+            auto_retryable=committed.auto_retryable,
+        )
+
+    if write_receipt:
+        rerr = write_sync_receipt(
+            flow_dir, spec_id=spec_id, status="pushed",
+            tracker_id=durable, event=event, transport=provider,
+            note="sync-body push wrote body + paired merge base",
+        )
+        if rerr:
+            return TrackerError(
+                rerr.cls, rerr.message, subtype=rerr.subtype,
+                details={**(rerr.details or {}),
+                         "completed_steps": ["wire-update", "wire-read", "paired-base"]},
+                auto_retryable=rerr.auto_retryable)
+
+    return {
+        "kind": "pushed",
+        "direction": "push",
+        "side_written": "tracker",
+        "mergeBaseFlow": committed["mergeBaseFlow"],
+        "mergeBaseTracker": committed["mergeBaseTracker"],
+        "baseHashFlow": committed["baseHashFlow"],
+        "baseHashTracker": committed["baseHashTracker"],
+        "lastSyncedAt": committed["lastSyncedAt"],
+        "degraded": None,
+    }
+
+
+def run(flow_dir, *, spec_id: Optional[str] = None,
+        flow_file: Optional[str] = None,
+        tracker_body_file: Optional[str] = None,
+        direction: str = "push",
+        event: Optional[str] = None,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """Thin envelope shell - never raises across the boundary."""
+    config = read_config(flow_dir)
+    if tracker_type(config) is None:
+        t = dict_(config.get("tracker")).get("type")
+        if t is not None and t not in ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}",
+                subtype="provider"))
+        return envelope.inactive()
+
+    if not spec_id or not flow_file:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "sync-body requires <spec-id> --flow-file",
+            subtype="args"))
+
+    try:
+        flow_file_body = Path(flow_file).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return envelope.failure(TrackerError(
+            ErrorClass.INVALID_INPUT, f"cannot read --flow-file: {exc}",
+            subtype="flow_file"))
+
+    tracker_body = None
+    if tracker_body_file is not None:
+        try:
+            tracker_body = Path(tracker_body_file).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT,
+                f"cannot read --tracker-body-file: {exc}",
+                subtype="tracker_body_file"))
+
+    try:
+        out = sync_body(
+            flow_dir, spec_id, flow_file_body=flow_file_body,
+            tracker_body=tracker_body, direction=direction or "push",
+            event=event, execute=execute)
+    except Exception as exc:  # noqa: BLE001 - boundary must never raise
+        return envelope.failure(TrackerError(
+            ErrorClass.TRANSPORT, f"sync-body verb raised: {exc}",
+            subtype="unexpected"))
+
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/types.py
+++ b/.flow/bin/flowctl_tracker/types.py
@@ -1,0 +1,140 @@
+"""Typed transport contracts for the tracker executor (fn-139.2).
+
+Every field here is load-bearing and several are the result of a measurement
+rather than a preference - the comments say which, because the next reader will
+otherwise "simplify" them back into the bug.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# Default request deadline. There is exactly ONE, not a connect/read pair:
+# `urllib.request.urlopen` accepts a single `timeout`, and `gh api` / `glab api`
+# expose none at all, so a split contract could not be honoured on either route.
+# HTTP applies it per socket operation; CLI applies it as a total process
+# deadline via `subprocess.run(timeout=)`.
+DEFAULT_TIMEOUT_S = 30.0
+
+MAX_RETRIES = 2          # rate_limited only, and only when idempotent
+BACKOFF_CAP_S = 30.0
+CONCURRENCY_CAP = 4
+
+
+class ErrorClass(str, enum.Enum):
+    """Exhaustive. Callers branch on this, never on message text."""
+
+    INACTIVE = "inactive"
+    UNRESOLVED = "unresolved"
+    STALE_ID = "stale_id"
+    AUTH = "auth"
+    RATE_LIMITED = "rate_limited"
+    TRANSPORT = "transport"
+    NOT_FOUND = "not_found"
+    CAPABILITY = "capability"
+    CONFLICT = "conflict"
+    INVALID_INPUT = "invalid_input"
+    # fn-140's MCP continuation: flowctl cannot complete the operation and the
+    # agent must act. NOT a failure of the request, and never retryable.
+    EXTERNAL_ACTION_REQUIRED = "external_action_required"
+
+
+#: Fixed, numeric, 1:1 with ErrorClass so a caller can branch on exit status
+#: alone without parsing stdout.
+EXIT_CODES: dict[ErrorClass, int] = {
+    ErrorClass.INVALID_INPUT: 2,
+    ErrorClass.INACTIVE: 3,
+    ErrorClass.UNRESOLVED: 4,
+    ErrorClass.AUTH: 5,
+    ErrorClass.RATE_LIMITED: 6,
+    ErrorClass.TRANSPORT: 7,
+    ErrorClass.NOT_FOUND: 8,
+    ErrorClass.CAPABILITY: 9,
+    ErrorClass.CONFLICT: 10,
+    ErrorClass.STALE_ID: 11,
+    ErrorClass.EXTERNAL_ACTION_REQUIRED: 12,
+}
+
+
+class CredentialPolicy(str, enum.Enum):
+    """Per REQUEST, not per provider - an always-inject executor leaks.
+
+    Linear's attachment upload is a presigned PUT to a third-party asset host.
+    Attaching the Linear API key there would hand the credential to a host with
+    no business seeing it, so the policy is explicit rather than inferred.
+    """
+
+    PROVIDER_AUTH = "provider-auth"
+    PRESIGNED_ANONYMOUS = "presigned-anonymous"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class Request:
+    provider: str                 # github | gitlab | linear | jira
+    op: str                       # logical operation, for classification + logs
+    method: str
+    url_or_argv: Any              # str for HTTP, list[str] for CLI
+    headers: dict[str, str] = field(default_factory=dict)
+    body: Optional[bytes] = None
+    timeout_s: float = DEFAULT_TIMEOUT_S
+    idempotent: bool = False
+    credential_policy: CredentialPolicy = CredentialPolicy.PROVIDER_AUTH
+
+    def __post_init__(self) -> None:
+        # An adapter that sets its own authorization header has already carried
+        # the credential across the boundary redaction exists to protect.
+        for k in self.headers:
+            if k.lower() in {"authorization", "private-token", "x-api-key"}:
+                raise ValueError(
+                    f"adapter set credential header {k!r}; credentials are attached "
+                    "by the executor after the adapter boundary"
+                )
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+    elapsed_s: float
+
+
+@dataclass(frozen=True)
+class TrackerError:
+    """Normalized failure. Adapters never raise transport-native exceptions."""
+
+    cls: ErrorClass
+    message: str
+    #: Distinguishes cases that share a class but not a retry policy -
+    #: `transport/timeout` is auto-retryable, `transport/malformed_body` is not.
+    subtype: Optional[str] = None
+    retry_after_s: Optional[float] = None
+    details: Optional[dict[str, Any]] = None
+    #: Governs the EXECUTOR's internal retry. Distinct from the envelope's
+    #: `retryable`, which tells the CALLER whether re-invoking could help.
+    #: Different questions, so different fields.
+    auto_retryable: bool = False
+
+    @property
+    def exit_code(self) -> int:
+        return EXIT_CODES[self.cls]
+
+
+def gitlab_cli_hostname(host: str) -> str:
+    """glab's --hostname wants its config key: a BARE hostname. Self-managed
+    instances on http and/or a non-default port store a scheme-prefixed
+    origin in perTracker.host (the HTTP route derives its API base from it);
+    glab carries protocol/port itself under the bare-hostname key (measured
+    live 2026-07-28: --hostname http://gitlab.localhost:8929 is rejected 400,
+    while the profile key is gitlab.localhost with api_protocol/api_host)."""
+    if "://" in host:
+        from urllib.parse import urlparse
+        try:
+            parsed = urlparse(host)
+        except ValueError:
+            return host
+        return parsed.hostname or host
+    return host.split(":", 1)[0] if host.count(":") == 1 and host.rsplit(":", 1)[-1].isdigit() else host

--- a/.flow/bin/flowctl_tracker/wire/__init__.py
+++ b/.flow/bin/flowctl_tracker/wire/__init__.py
@@ -1,0 +1,817 @@
+"""Wire verbs: locator-addressed tracker operations (fn-140.1).
+
+Wire verbs take a locator `{durable, display}` (except `list-open`), touch no
+config / receipt, and every WRITE validates the parent BEFORE mutating.
+`question` additionally uses one transient local claim to serialize its
+list-then-add dedup transaction; the claim is always released and is not a
+receipt.
+
+Every write validates the parent before mutating:
+
+    1. resolve the display address → one parent read
+    2. compare the returned durable id to `locator.durable`
+    3. mismatch → `class: conflict`, and the mutation request is never issued
+
+Response-side validation is a cheaper second check, applied ONLY where the
+provider response actually carries parent identity. Several comment responses
+do not - those are marked `parent_identity: "not_available"`, never faked.
+
+Parent-identity availability (measured; do not invent checks against absent
+fields):
+
+  github  issue responses: YES (`node_id` / GraphQL `id`)
+          comment responses: NO (REST comment has `issue_url`, not parent node_id)
+  gitlab  issue responses: YES (`id` = global issue id)
+          note responses: YES (`noteable_id` = global issue id)
+  linear  issue responses: YES (`id` UUID)
+          comment responses: YES when the selection set includes `issue { id }`
+  jira    issue responses: YES (`id`)
+          comment responses: NO (comment object carries no parent issue id)
+
+Transport routing matches spec A: github/gitlab via CLI argv (`gh api` /
+`glab api`), linear via GraphQL HTTP, jira via REST HTTP. Every request goes
+through the injected `execute` callable.
+
+Per-provider verb bodies live in `wire/{github,gitlab,linear,jira}.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+from urllib.parse import urlparse
+
+from .. import envelope
+from ..executor import execute as default_execute
+from ..question_claim import (
+    claim_question,
+    question_claim_path,
+    release_question_claim,
+)
+from ..types import (ErrorClass, Request, Response, TrackerError,
+                     gitlab_cli_hostname)
+
+#: Jira project / issue-key grammars from jira.md (listOpenIssues JQL safety).
+#: Underscores and keys longer than Cloud's 10-char alnum cap are intentional:
+#: Data Center admins can configure them. Cloud cannot reproduce that shape.
+#: UNVERIFIED on live Jira Data Center (Cloud cannot reproduce custom keys - fn-140 R17); verified against prose only.
+_JIRA_PROJECT_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+$")
+_JIRA_ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+-[1-9][0-9]*$")
+
+#: Verbs this module owns. `attach` / `attach-get` delegate to attach/ (fn-140.4).
+WIRE_VERBS = (
+    "read", "update", "comment-add", "comment-list", "comment-update",
+    "comment-delete", "label", "assign", "list-open", "relation-list",
+    "question", "attach", "attach-get",
+)
+WRITE_VERBS = frozenset({
+    "update", "comment-add", "comment-update", "comment-delete", "label", "assign",
+    "question", "attach",
+})
+#: Verbs that require a parent locator. attach-get and list-open are context-free.
+LOCATOR_VERBS = frozenset(v for v in WIRE_VERBS if v not in ("list-open", "attach-get"))
+
+_ACTIVE = frozenset({"github", "gitlab", "linear", "jira"})
+LINEAR_GQL = "https://api.linear.app/graphql"
+
+Result = Union[dict, TrackerError]
+Execute = Callable[[Request], Union[Response, TrackerError]]
+
+
+def _created_at(comment: dict) -> Optional[datetime]:
+    """Parse one normalized immutable comment timestamp."""
+    raw = comment.get("created_at")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    value = raw.strip()
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Config / locator
+# ---------------------------------------------------------------------------
+
+def _dict(value: Any) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _tracker_type(config: dict) -> Optional[str]:
+    t = _dict(config.get("tracker")).get("type")
+    return t if t in _ACTIVE else None
+
+
+def _destination(config: dict) -> Union[dict, TrackerError]:
+    dest = _dict(_dict(_dict(config.get("tracker")).get("resolved")).get("destination"))
+    if not dest:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "no resolved destination; run `flowctl tracker resolve` first",
+                            subtype="destination")
+    return dest
+
+
+def _ready_state(config: dict) -> Optional[str]:
+    value = _dict(config.get("tracker")).get("readyState")
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def parse_locator(raw: Any) -> Union[dict, TrackerError]:
+    """Accept a dict or a JSON string → `{durable, display}` both non-empty str."""
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            return TrackerError(ErrorClass.INVALID_INPUT,
+                                f"locator is not valid JSON: {exc}", subtype="locator")
+    if not isinstance(raw, dict):
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "locator must be an object {durable, display}",
+                            subtype="locator")
+    durable = raw.get("durable")
+    display = raw.get("display")
+    if not isinstance(durable, str) or not durable.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "locator.durable must be a non-empty string",
+                            subtype="locator")
+    if not isinstance(display, str) or not display.strip():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "locator.display must be a non-empty string",
+                            subtype="locator")
+    return {"durable": durable.strip(), "display": display.strip()}
+
+
+def _github_number(display: str) -> Union[int, TrackerError]:
+    s = display.strip().lstrip("#")
+    if not s.isdigit():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"github display must be #N, got {display!r}",
+                            subtype="display")
+    return int(s)
+
+
+def _gitlab_iid(display: str) -> Union[int, TrackerError]:
+    part = display.rsplit("#", 1)[-1].strip()
+    if not part.isdigit():
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"gitlab display must be <project>#<iid>, got {display!r}",
+                            subtype="display")
+    return int(part)
+
+
+def _jira_issue_key(display: str) -> Union[str, TrackerError]:
+    """Parse a Jira issue display key (PROJ-1 or DC custom MY_LONG_PROJECT_KEY-7).
+
+    UNVERIFIED on live Jira Data Center (Cloud cannot reproduce custom keys - fn-140 R17); verified against prose only.
+    """
+    s = (display or "").strip()
+    if not _JIRA_ISSUE_KEY_RE.fullmatch(s):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"jira display must be KEY-N (A-Z / digits / underscore), got {display!r}",
+            subtype="display",
+        )
+    return s
+
+
+def _jira_project_key(key: str) -> Union[str, TrackerError]:
+    """Validate a Jira projectKey before JQL interpolation (injection-safe).
+
+    UNVERIFIED on live Jira Data Center (Cloud cannot reproduce custom keys - fn-140 R17); verified against prose only.
+    """
+    s = (key or "").strip() if isinstance(key, str) else ""
+    if not _JIRA_PROJECT_KEY_RE.fullmatch(s):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"jira projectKey {key!r} is not a Jira key (expected ^[A-Z][A-Z0-9_]+$)",
+            subtype="project_key",
+        )
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Transport helpers
+# ---------------------------------------------------------------------------
+
+def _json_loads(resp: Response, *, what: str) -> Union[Any, TrackerError]:
+    try:
+        return json.loads(resp.body or b"null")
+    except (ValueError, TypeError) as exc:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"malformed {what}: {exc}", subtype="malformed_body")
+
+
+def _cli_argv(provider: str, config: dict, method: str, endpoint: str,
+              *, body: Optional[bytes] = None) -> list:
+    if provider == "github":
+        argv = ["gh", "api"]
+    else:
+        argv = ["glab", "api"]
+        host = _dict(_dict(config.get("tracker")).get("perTracker")).get("host")
+        if host:
+            argv += ["--hostname", gitlab_cli_hostname(str(host))]
+    if method.upper() != "GET":
+        argv += ["--method", method.upper()]
+    argv.append(endpoint)
+    if body is not None:
+        if provider != "github":
+            # glab api sends NO Content-Type with --input (measured live:
+            # GitLab replies 415 "provided content-type '' is not supported"
+            # on every JSON mutation); gh api defaults to JSON already.
+            argv += ["-H", "Content-Type: application/json"]
+        argv += ["--input", "-"]
+    return argv
+
+
+def _cli(execute: Execute, provider: str, config: dict, op: str, method: str,
+         endpoint: str, *, body: Optional[dict] = None,
+         idempotent: bool = False) -> Union[Any, TrackerError]:
+    raw = None if body is None else json.dumps(body).encode()
+    result = execute(Request(
+        provider=provider, op=op, method=method.upper(),
+        url_or_argv=_cli_argv(provider, config, method, endpoint, body=raw),
+        body=raw, idempotent=idempotent,
+    ))
+    if isinstance(result, TrackerError):
+        return result
+    # DELETE often returns empty body (204).
+    if not (result.body or b"").strip():
+        return None
+    return _json_loads(result, what=f"{provider} {op}")
+
+
+def _gql(execute: Execute, op: str, query: str, variables: dict, *,
+         idempotent: bool = False) -> Union[dict, TrackerError]:
+    result = execute(Request(
+        provider="linear", op=op, method="POST", url_or_argv=LINEAR_GQL,
+        headers={"Content-Type": "application/json"},
+        body=json.dumps({"query": query, "variables": variables}).encode(),
+        idempotent=idempotent,
+    ))
+    if isinstance(result, TrackerError):
+        return result
+    payload = _json_loads(result, what="linear graphql")
+    if isinstance(payload, TrackerError):
+        return payload
+    if not isinstance(payload, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "GraphQL payload is not an object",
+                            subtype="malformed_body")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "GraphQL response carries no data",
+                            subtype="malformed_body")
+    return data
+
+
+def _jira_base(config: dict, dest: dict) -> Union[str, TrackerError]:
+    # Prefer the resolved pin; fall back to the provider helper's env/perTracker
+    # precedence so a runtime JIRA_BASE_URL override still works.
+    from ..providers import jira as jira_mod  # noqa: PLC0415 - keep providers lazy
+    base = dest.get("baseUrl") or jira_mod.base_url(config)
+    if not base:
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "jira baseUrl is not resolved", subtype="destination")
+    return str(base).rstrip("/")
+
+
+def _jira(execute: Execute, op: str, method: str, url: str, *,
+          body: Optional[dict] = None, idempotent: bool = False
+          ) -> Union[Any, TrackerError]:
+    raw = None if body is None else json.dumps(body).encode()
+    headers = {"Content-Type": "application/json", "Accept": "application/json"} if raw else {
+        "Accept": "application/json",
+    }
+    result = execute(Request(
+        provider="jira", op=op, method=method.upper(), url_or_argv=url,
+        headers=headers, body=raw, idempotent=idempotent,
+    ))
+    if isinstance(result, TrackerError):
+        return result
+    if not (result.body or b"").strip():
+        return None
+    return _json_loads(result, what=f"jira {op}")
+
+
+# ---------------------------------------------------------------------------
+# Pagination (no silent caps: drain up to _MAX_PAGES, then say so)
+# ---------------------------------------------------------------------------
+
+_PAGE_SIZE = 100
+_MAX_PAGES = 20  # 2000 items; a ceiling with an honest `truncated` flag, not a silent cap
+
+
+def _rest_drain(fetch_page: Callable[[int], Union[list, TrackerError]]
+                ) -> Union[tuple, TrackerError]:
+    """Drain page=1.. until a short page. Returns (items, truncated)."""
+    items: list = []
+    for page in range(1, _MAX_PAGES + 1):
+        data = fetch_page(page)
+        if isinstance(data, TrackerError):
+            return data
+        if not isinstance(data, list):
+            return TrackerError(ErrorClass.TRANSPORT, "page is not a list",
+                                subtype="malformed_body")
+        items.extend(data)
+        if len(data) < _PAGE_SIZE:
+            return items, False
+    return items, True
+
+
+def _gql_connection_drain(execute: Execute, op: str, query: str,
+                          base_vars: dict, pluck: Callable[[dict], Union[dict, TrackerError]]
+                          ) -> Union[tuple, TrackerError]:
+    """Drain one GraphQL connection ({nodes, pageInfo}). Returns (nodes, truncated)."""
+    nodes: list = []
+    cursor = None
+    seen: set = set()
+    for _ in range(_MAX_PAGES):
+        data = _gql(execute, op, query, {**base_vars, "after": cursor}, idempotent=True)
+        if isinstance(data, TrackerError):
+            return data
+        conn = pluck(data)
+        if isinstance(conn, TrackerError):
+            return conn
+        page_nodes = conn.get("nodes")
+        if not isinstance(page_nodes, list):
+            return TrackerError(ErrorClass.TRANSPORT, "connection carries no nodes",
+                                subtype="malformed_body")
+        nodes.extend(n for n in page_nodes if isinstance(n, dict))
+        info = conn.get("pageInfo") or {}
+        if not info.get("hasNextPage"):
+            return nodes, False
+        cursor = info.get("endCursor")
+        if not cursor or cursor in seen:
+            return TrackerError(ErrorClass.TRANSPORT,
+                                "pagination made no progress", subtype="malformed_body")
+        seen.add(cursor)
+    return nodes, True
+
+
+# ---------------------------------------------------------------------------
+# Durable extraction + conflict
+# ---------------------------------------------------------------------------
+
+def _conflict(expected: str, got: Any) -> TrackerError:
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"locator.durable {expected!r} does not match parent durable {got!r}",
+        subtype="durable_mismatch",
+        details={"normalized": "durable", "candidates": [
+            {"durable": expected, "role": "locator"},
+            {"durable": got, "role": "parent"},
+        ]},
+    )
+
+
+def _comment_parent_mismatch(comment_id: str, detail: str) -> TrackerError:
+    return TrackerError(
+        ErrorClass.CONFLICT,
+        f"comment {comment_id!r} does not belong to locator parent ({detail})",
+        subtype="comment_parent_mismatch",
+    )
+
+
+def _github_durable(issue: dict) -> Optional[str]:
+    # REST via `gh api` returns `node_id`; `gh issue view --json id` also uses
+    # the node id under `id`. Accept either.
+    for key in ("node_id", "id"):
+        v = issue.get(key)
+        if isinstance(v, str) and v.startswith(("I_", "MDE")):
+            return v
+        if isinstance(v, str) and key == "node_id" and v:
+            return v
+    # Numeric `id` is the DB id, NOT the durable key - never treat it as durable.
+    v = issue.get("node_id")
+    return v if isinstance(v, str) and v else None
+
+
+def _gitlab_durable(issue: dict) -> Optional[str]:
+    v = issue.get("id")
+    return str(v) if isinstance(v, int) or (isinstance(v, str) and v.isdigit()) else None
+
+
+def _linear_durable(issue: dict) -> Optional[str]:
+    v = issue.get("id")
+    return v if isinstance(v, str) and v else None
+
+
+def _jira_durable(issue: dict) -> Optional[str]:
+    v = issue.get("id")
+    return str(v) if v is not None and str(v) else None
+
+
+_DURABLE_OF = {
+    "github": _github_durable,
+    "gitlab": _gitlab_durable,
+    "linear": _linear_durable,
+    "jira": _jira_durable,
+}
+
+
+def _check_durable(provider: str, locator: dict, entity: dict
+                   ) -> Optional[TrackerError]:
+    got = _DURABLE_OF[provider](entity)
+    if got is None:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"{provider} response carries no durable id",
+                            subtype="malformed_body")
+    if str(got) != str(locator["durable"]):
+        return _conflict(locator["durable"], got)
+    return None
+
+
+def _gh_repo(dest: dict) -> Union[str, TrackerError]:
+    owner, repo = dest.get("owner"), dest.get("repo")
+    if not isinstance(owner, str) or not isinstance(repo, str):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "github destination missing owner/repo",
+                            subtype="destination")
+    return f"{owner}/{repo}"
+
+
+def _gl_project(dest: dict) -> Union[int, TrackerError]:
+    pid = dest.get("projectId")
+    if not isinstance(pid, int):
+        return TrackerError(ErrorClass.UNRESOLVED,
+                            "gitlab destination missing numeric projectId",
+                            subtype="destination")
+    return pid
+
+
+# Provider modules imported after helpers so `from . import _cli` works mid-load.
+from . import github, gitlab, jira, linear  # noqa: E402
+
+_PROVIDERS = {
+    "github": github,
+    "gitlab": gitlab,
+    "linear": linear,
+    "jira": jira,
+}
+
+
+def parent_read(provider: str, config: dict, locator: dict, execute: Execute, *,
+                op: str = "wire-parent-read") -> Union[dict, TrackerError]:
+    """One parent fetch addressed by display. Returns the raw provider issue
+    object (already durable-checked against the locator)."""
+    mod = _PROVIDERS.get(provider)
+    if mod is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+    return mod.parent_read(config, locator, execute, op=op)
+
+
+def validate_pr_url(url: Any) -> Optional[TrackerError]:
+    """Reject malformed link content before a facade claim or provider read."""
+    if not isinstance(url, str):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "PR URL must be an absolute http(s) URL up to 2048 characters",
+            subtype="pr_url",
+        )
+    value = url.strip()
+    parsed = urlparse(value)
+    if (parsed.scheme not in ("http", "https") or not parsed.netloc
+            or any(ch.isspace() or ord(ch) < 0x20 or ord(ch) == 0x7f
+                   for ch in value)
+            or len(url) > 2048):
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            "PR URL must be an absolute http(s) URL up to 2048 characters",
+            subtype="pr_url",
+        )
+    return None
+
+
+def link_pr(provider: str, config: dict, locator: dict, execute: Execute, *,
+            url: str) -> Result:
+    """Project one PR URL through the provider's native non-closing link."""
+    invalid = validate_pr_url(url)
+    if invalid is not None:
+        return invalid
+    mod = _PROVIDERS.get(provider)
+    if mod is None:
+        return TrackerError(
+            ErrorClass.INVALID_INPUT,
+            f"unknown tracker type {provider!r}",
+            subtype="provider",
+        )
+    return mod.pr_link(config, locator, execute, url=url.strip())
+
+
+def _dispatch_question(*, mod: Any, provider: str, config: dict,
+                       locator: dict, execute: Execute, body: str,
+                       question_id: str) -> Result:
+    """Read the current semantic round and post only when no round is open."""
+    marker = f"<!-- flow-next:question id={question_id} status=open -->"
+    listed = mod.comment_list(config, locator, execute)
+    if isinstance(listed, TrackerError):
+        return listed
+    comments = listed.get("comments")
+    if not isinstance(comments, list):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "question comment list is malformed",
+            subtype="malformed_body")
+    if listed.get("truncated"):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "question comment pages truncated; latest round is unproven",
+            subtype="truncated")
+    question_pattern = re.compile(
+        rf"<!--\s*flow-next:question\s+id={re.escape(question_id)}"
+        r"(?:\s+status=[A-Za-z0-9_-]+)?\s*-->")
+    answer_pattern = re.compile(
+        rf"<!--\s*flow-next:answer\s+id={re.escape(question_id)}\s*-->")
+    questions = []
+    answers = []
+    for comment in comments:
+        comment_body = comment.get("body") if isinstance(comment, dict) else None
+        if not isinstance(comment_body, str):
+            continue
+        if question_pattern.search(comment_body):
+            questions.append(comment)
+        if answer_pattern.search(comment_body):
+            answers.append(comment)
+
+    current_question = questions[-1] if questions else None
+    reopen = False
+    if questions and answers:
+        timed_questions = [(_created_at(c), c) for c in questions]
+        timed_answers = [(_created_at(c), c) for c in answers]
+        if (any(stamp is None for stamp, _ in timed_questions)
+                or any(stamp is None for stamp, _ in timed_answers)):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "question and answer markers need immutable created_at "
+                "timestamps to determine the latest round",
+                subtype="malformed_body")
+        latest_question = max(timed_questions, key=lambda row: row[0])
+        latest_answer = max(timed_answers, key=lambda row: row[0])
+        if latest_question[0] == latest_answer[0]:
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "question and answer chronology is ambiguous",
+                subtype="malformed_body")
+        current_question = latest_question[1]
+        reopen = latest_answer[0] > latest_question[0]
+
+    if current_question is not None and not reopen:
+        # GitHub and GitLab comment-list routes address the parent by
+        # display number/IID. Accept a dedup match only after durable
+        # identity is proven, either by the comment payload itself or
+        # by an explicit display-addressed parent read.
+        if (provider in ("github", "gitlab")
+                and current_question.get("parent_identity") != "validated"):
+            parent = mod.parent_read(
+                config, locator, execute,
+                op="wire-question-parent-read")
+            if isinstance(parent, TrackerError):
+                return parent
+        return {
+            "posted": False,
+            "question_id": question_id,
+            "comment": current_question,
+        }
+    rendered = f"{marker}\n\n{body.lstrip()}"
+    added = mod.comment_add(
+        config, locator, execute, body=rendered)
+    if isinstance(added, TrackerError):
+        return added
+    return {
+        "posted": True,
+        "reopened": reopen,
+        "question_id": question_id,
+        "comment": added,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + CLI entry
+# ---------------------------------------------------------------------------
+
+def dispatch(verb: str, config: dict, *, locator: Any = None,
+             title: Optional[str] = None, body: Optional[str] = None,
+             comment_id: Optional[str] = None,
+             subject_id: Optional[str] = None,
+             blocked_stage: Optional[str] = None,
+             reason_code: Optional[str] = None,
+             question_slug: Optional[str] = None,
+             add: Optional[list] = None, remove: Optional[list] = None,
+             file_path: Optional[str] = None,
+             attachment_id: Optional[str] = None,
+             out_path: Optional[str] = None,
+             flow_dir: Optional[Path] = None,
+             execute: Execute = default_execute) -> Result:
+    """Run one wire verb. Returns data dict or TrackerError — never raises."""
+    if verb not in WIRE_VERBS:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            f"unknown wire verb {verb!r}", subtype="verb")
+    provider = _tracker_type(config)
+    if provider is None:
+        return TrackerError(ErrorClass.INACTIVE, "tracker bridge is inactive")
+
+    # attach / attach-get live in the attach package (capability gates, R9).
+    if verb in ("attach", "attach-get"):
+        from .. import attach as attach_mod  # noqa: PLC0415
+        if verb == "attach":
+            if not file_path:
+                return TrackerError(ErrorClass.INVALID_INPUT,
+                                    "attach requires --file", subtype="file")
+            return attach_mod.attach(config, locator, file_path=file_path,
+                                     execute=execute)
+        return attach_mod.attach_get(config, attachment_id=attachment_id or "",
+                                     out_path=out_path or "", execute=execute)
+
+    add = list(add or [])
+    remove = list(remove or [])
+
+    parsed: Optional[dict] = None
+    if verb in LOCATOR_VERBS:
+        parsed_or_err = parse_locator(locator)
+        if isinstance(parsed_or_err, TrackerError):
+            return parsed_or_err
+        parsed = parsed_or_err
+
+    if verb in ("comment-update", "comment-delete"):
+        if not comment_id:
+            return TrackerError(ErrorClass.INVALID_INPUT,
+                                f"{verb} requires <comment-id> and the parent locator",
+                                subtype="comment_id")
+        if parsed is None:
+            return TrackerError(ErrorClass.INVALID_INPUT,
+                                f"{verb} requires the parent locator",
+                                subtype="locator")
+
+    mod = _PROVIDERS[provider]
+    if verb == "read":
+        return mod.read(config, parsed, execute)  # type: ignore[arg-type]
+    if verb == "update":
+        return mod.update(config, parsed, execute, title=title, body=body)  # type: ignore[arg-type]
+    if verb == "comment-add":
+        if body is None:
+            return TrackerError(ErrorClass.INVALID_INPUT,
+                                "comment-add requires --body-file", subtype="body")
+        return mod.comment_add(config, parsed, execute, body=body)  # type: ignore[arg-type]
+    if verb == "comment-list":
+        return mod.comment_list(config, parsed, execute)  # type: ignore[arg-type]
+    if verb == "comment-update":
+        if body is None:
+            return TrackerError(ErrorClass.INVALID_INPUT,
+                                "comment-update requires --body-file", subtype="body")
+        return mod.comment_update(config, parsed, execute,  # type: ignore[arg-type]
+                                  comment_id=str(comment_id), body=body)
+    if verb == "comment-delete":
+        return mod.comment_delete(config, parsed, execute,  # type: ignore[arg-type]
+                                  comment_id=str(comment_id))
+    if verb == "label":
+        return mod.label(config, parsed, execute, add=add, remove=remove)  # type: ignore[arg-type]
+    if verb == "assign":
+        return mod.assign(config, parsed, execute, add=add, remove=remove)  # type: ignore[arg-type]
+    if verb == "list-open":
+        return mod.list_open(config, execute)
+    if verb == "relation-list":
+        from ..relate import listing as relation_listing  # noqa: PLC0415
+        return relation_listing.list_relations(
+            provider, config, execute, locator=parsed)  # type: ignore[arg-type]
+    if verb == "question":
+        if body is None:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                "question requires --body-file",
+                subtype="body")
+        identity = {
+            "subject-id": subject_id,
+            "blocked-stage": blocked_stage,
+            "reason-code": reason_code,
+            "question-slug": question_slug,
+        }
+        for name, value in identity.items():
+            if (not isinstance(value, str) or not value.strip()
+                    or "\0" in value or len(value) > 256):
+                return TrackerError(
+                    ErrorClass.INVALID_INPUT,
+                    f"question requires --{name} (1-256 non-NUL characters)",
+                    subtype=name.replace("-", "_"))
+        stable = "\0".join(str(value).strip() for value in identity.values())
+        question_id = hashlib.sha256(stable.encode()).hexdigest()[:16]
+        if flow_dir is None:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                "question requires the .flow directory for concurrency-safe "
+                "deduplication",
+                subtype="flow_dir")
+        if parsed is None:
+            return TrackerError(
+                ErrorClass.INVALID_INPUT,
+                "question requires the parent locator",
+                subtype="locator")
+        rec_path = question_claim_path(
+            Path(flow_dir), provider=provider,
+            durable=str(parsed["durable"]), question_id=question_id)
+        claimed = claim_question(
+            Path(flow_dir), rec_path, provider=provider,
+            durable=str(parsed["durable"]), question_id=question_id,
+            subject_id=str(subject_id))
+        if claimed is not None:
+            return claimed
+        try:
+            return _dispatch_question(
+                mod=mod, provider=provider, config=config, locator=parsed,
+                execute=execute, body=body, question_id=question_id)
+        finally:
+            release_question_claim(rec_path)
+    return TrackerError(ErrorClass.INVALID_INPUT, f"unhandled verb {verb!r}", subtype="verb")
+
+
+def _read_config(flow_dir) -> dict:
+    try:
+        data = json.loads((Path(flow_dir) / "config.json").read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def run(flow_dir, verb: str, *, locator: Any = None, title: Optional[str] = None,
+        body_file: Optional[str] = None, comment_id: Optional[str] = None,
+        subject_id: Optional[str] = None, blocked_stage: Optional[str] = None,
+        reason_code: Optional[str] = None, question_slug: Optional[str] = None,
+        add: Optional[list] = None, remove: Optional[list] = None,
+        file_path: Optional[str] = None, attachment_id: Optional[str] = None,
+        out_path: Optional[str] = None,
+        execute: Execute = default_execute) -> tuple[str, int]:
+    """CLI entry: return (stdout payload, exit code) — the single result envelope."""
+    config = _read_config(flow_dir)
+    if _tracker_type(config) is None and _dict(config.get("tracker")).get("type") not in _ACTIVE:
+        # Distinguish malformed vs inactive: a missing/off type is inactive.
+        t = _dict(config.get("tracker")).get("type")
+        if t is not None and t not in _ACTIVE:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"unknown tracker type {t!r}", subtype="provider"))
+        return envelope.inactive()
+
+    body = None
+    if body_file is not None:
+        try:
+            body = Path(body_file).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return envelope.failure(TrackerError(
+                ErrorClass.INVALID_INPUT, f"cannot read --body-file: {exc}",
+                subtype="body_file"))
+
+    # Bind transport policy for the real executor; injected fakes pass through.
+    from ..resolve_verb import bound_executor  # noqa: PLC0415
+    ex = bound_executor(config, execute)
+    body_claim = None
+    if verb == "update" and body is not None:
+        claimed_locator = parse_locator(locator)
+        if isinstance(claimed_locator, TrackerError):
+            return envelope.failure(claimed_locator)
+        from ..lifecycle.verbs import (  # noqa: PLC0415
+            _claim_body_mutation, _release_claim,
+        )
+        body_claim = _claim_body_mutation(
+            Path(flow_dir), _tracker_type(config) or "", claimed_locator,
+            operation="wire-update")
+        if isinstance(body_claim, TrackerError):
+            return envelope.failure(body_claim)
+    # Never-raises boundary: a provider that returns syntactically valid JSON
+    # with an unexpected field shape (e.g. gitlab `labels: 1`) can raise deep
+    # inside an adapter (`list(raw.get("labels"))` -> TypeError). The promise
+    # of this entry point is the structured envelope, never a traceback.
+    try:
+        try:
+            out = dispatch(verb, config, locator=locator, title=title, body=body,
+                           comment_id=comment_id, subject_id=subject_id,
+                           blocked_stage=blocked_stage,
+                           reason_code=reason_code, question_slug=question_slug,
+                           add=add, remove=remove,
+                           file_path=file_path, attachment_id=attachment_id,
+                           out_path=out_path, flow_dir=Path(flow_dir),
+                           execute=ex)
+        except Exception as exc:  # noqa: BLE001 - envelope boundary
+            out = TrackerError(
+                ErrorClass.TRANSPORT,
+                f"provider adapter failed on malformed response shape: "
+                f"{type(exc).__name__}: {exc}",
+                subtype="malformed_body",
+                details={"subtype": "malformed_body", "verb": verb})
+    finally:
+        if body_claim is not None:
+            _release_claim(body_claim)
+    if isinstance(out, TrackerError):
+        if out.cls is ErrorClass.INACTIVE:
+            return envelope.inactive()
+        return envelope.failure(out)
+    return envelope.success(out)

--- a/.flow/bin/flowctl_tracker/wire/github.py
+++ b/.flow/bin/flowctl_tracker/wire/github.py
@@ -1,0 +1,349 @@
+"""GitHub wire verb implementations."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from urllib.parse import quote, urlencode
+
+from ..types import ErrorClass, TrackerError
+from . import (
+    Execute,
+    Result,
+    _github_durable,
+    _check_durable,
+    _cli,
+    _comment_parent_mismatch,
+    _destination,
+    _gh_repo,
+    _github_number,
+    _PAGE_SIZE,
+    _ready_state,
+    _rest_drain,
+)
+
+
+
+def _issue_out(raw: dict, *, parent_identity: str = "validated") -> dict:
+    labels = raw.get("labels") or []
+    label_names = [x.get("name") if isinstance(x, dict) else x for x in labels]
+    return {
+        "id": _github_durable(raw),
+        "identifier": f"#{raw.get('number')}",
+        "title": raw.get("title"),
+        "body": raw.get("body"),
+        "url": raw.get("html_url") or raw.get("url"),
+        "labels": label_names,
+        "raw": raw,
+        "parent_identity": parent_identity,
+    }
+
+
+def _comment_out(raw: dict, *, parent_identity: str) -> dict:
+    return {"id": raw.get("id"), "body": raw.get("body"),
+            "url": raw.get("html_url") or raw.get("url"),
+            "created_at": raw.get("created_at"),
+            "raw": raw, "parent_identity": parent_identity}
+
+def parent_read(config: dict, locator: dict, execute: Execute, *,
+                op: str = "wire-parent-read") -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    number = _github_number(locator["display"])
+    if isinstance(number, TrackerError):
+        return number
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    data = _cli(execute, "github", config, op, "GET",
+                f"repos/{repo}/issues/{number}", idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "github issue is not an object",
+                            subtype="malformed_body")
+    err = _check_durable("github", locator, data)
+    return err if err else data
+
+
+def _require_parent(config: dict, locator: dict, execute: Execute) -> Result:
+    return parent_read(config, locator, execute, op="wire-parent-read")
+
+
+def _comment_belongs(config: dict, locator: dict, dest: dict, execute: Execute, *,
+                     comment_id: str) -> Optional[TrackerError]:
+    """Verify the comment's issue_url matches the locator display number.
+
+    GitHub comment-update/delete address by comment_id alone; without this
+    pre-fetch a valid-but-unrelated parent locator could mutate another issue's
+    comment.
+    """
+    number = _github_number(locator["display"])
+    if isinstance(number, TrackerError):
+        return number
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    data = _cli(execute, "github", config, "wire-comment-belong", "GET",
+                f"repos/{repo}/issues/comments/{comment_id}", idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "github comment is not an object",
+                            subtype="malformed_body")
+    issue_url = data.get("issue_url")
+    if not isinstance(issue_url, str) or not issue_url.endswith(f"/issues/{number}"):
+        return _comment_parent_mismatch(
+            comment_id, f"issue_url {issue_url!r} vs expected /issues/{number}")
+    return None
+
+
+def read(config: dict, locator: dict, execute: Execute) -> Result:
+    parent = parent_read(config, locator, execute, op="wire-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    return _issue_out(parent, parent_identity="validated")
+
+
+def pr_link(config: dict, locator: dict, execute: Execute, *, url: str) -> Result:
+    """GitHub linkage already lives in the PR body's non-closing `Refs #N`."""
+    parent = parent_read(config, locator, execute, op="wire-pr-link-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    return {
+        "linked": False,
+        "deduped": True,
+        "kind": "native-pr-body-ref",
+        "url": url,
+    }
+
+
+def update(config: dict, locator: dict, execute: Execute, *,
+           title: Optional[str], body: Optional[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    number = _github_number(locator["display"])
+    repo = _gh_repo(dest)
+    if isinstance(number, TrackerError):
+        return number
+    if isinstance(repo, TrackerError):
+        return repo
+    payload: dict = {}
+    if title is not None:
+        payload["title"] = title
+    if body is not None:
+        payload["body"] = body
+    if not payload:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "update requires --title and/or --body-file",
+                            subtype="update")
+    data = _cli(execute, "github", config, "wire-update", "PATCH",
+                f"repos/{repo}/issues/{number}", body=payload)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "github update returned no object",
+                            subtype="malformed_body")
+    err = _check_durable("github", locator, data)
+    if err:
+        return err
+    return _issue_out(data)
+
+
+def comment_add(config: dict, locator: dict, execute: Execute, *, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    number = _github_number(locator["display"])
+    repo = _gh_repo(dest)
+    if isinstance(number, TrackerError):
+        return number
+    if isinstance(repo, TrackerError):
+        return repo
+    data = _cli(execute, "github", config, "wire-comment-add", "POST",
+                f"repos/{repo}/issues/{number}/comments", body={"body": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "github comment-add returned no object",
+                            subtype="malformed_body")
+    # REST comment has issue_url, not parent node_id — do not fake a check.
+    return _comment_out(data, parent_identity="not_available")
+
+
+def comment_list(config: dict, locator: dict, execute: Execute) -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    number = _github_number(locator["display"])
+    if isinstance(number, TrackerError):
+        return number
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    drained = _rest_drain(lambda page: _cli(
+        execute, "github", config, "wire-comment-list", "GET",
+        f"repos/{repo}/issues/{number}/comments"
+        f"?per_page={_PAGE_SIZE}&page={page}", idempotent=True))
+    if isinstance(drained, TrackerError):
+        return drained
+    data, truncated = drained
+    # Comment list items carry no parent node_id.
+    return {"comments": [_comment_out(c, parent_identity="not_available")
+                         for c in data if isinstance(c, dict)],
+            "truncated": truncated,
+            "parent_identity": "not_available"}
+
+
+def comment_update(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    belong = _comment_belongs(config, locator, dest, execute, comment_id=comment_id)
+    if belong is not None:
+        return belong
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    # Path takes the comment id alone, but the contract still requires the
+    # parent locator (pre-mutation gate + belong check above). Response has no
+    # parent node_id.
+    data = _cli(execute, "github", config, "wire-comment-update", "PATCH",
+                f"repos/{repo}/issues/comments/{comment_id}", body={"body": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "github comment-update returned no object",
+                            subtype="malformed_body")
+    return _comment_out(data, parent_identity="not_available")
+
+
+def comment_delete(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    belong = _comment_belongs(config, locator, dest, execute, comment_id=comment_id)
+    if belong is not None:
+        return belong
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    data = _cli(execute, "github", config, "wire-comment-delete", "DELETE",
+                f"repos/{repo}/issues/comments/{comment_id}")
+    if isinstance(data, TrackerError):
+        return data
+    return {"deleted": comment_id, "parent_identity": "not_available"}
+
+
+def label(config: dict, locator: dict, execute: Execute, *,
+          add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "label requires --add and/or --remove", subtype="label")
+    number = _github_number(locator["display"])
+    repo = _gh_repo(dest)
+    if isinstance(number, TrackerError):
+        return number
+    if isinstance(repo, TrackerError):
+        return repo
+    data: Any = parent
+    if add:
+        data = _cli(execute, "github", config, "wire-label", "POST",
+                    f"repos/{repo}/issues/{number}/labels", body={"labels": add})
+        if isinstance(data, TrackerError):
+            return data
+    for name in remove:
+        data = _cli(execute, "github", config, "wire-label", "DELETE",
+                    f"repos/{repo}/issues/{number}/labels/{quote(name, safe='')}")
+        if isinstance(data, TrackerError):
+            return data
+    # Re-read so the durable check lands on an issue-shaped response.
+    refreshed = parent_read(config, locator, execute, op="wire-label-readback")
+    if isinstance(refreshed, TrackerError):
+        return refreshed
+    return _issue_out(refreshed)
+
+
+def assign(config: dict, locator: dict, execute: Execute, *,
+           add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "assign requires --add and/or --remove", subtype="assign")
+    number = _github_number(locator["display"])
+    repo = _gh_repo(dest)
+    if isinstance(number, TrackerError):
+        return number
+    if isinstance(repo, TrackerError):
+        return repo
+    if add:
+        data = _cli(execute, "github", config, "wire-assign", "POST",
+                    f"repos/{repo}/issues/{number}/assignees",
+                    body={"assignees": add})
+        if isinstance(data, TrackerError):
+            return data
+    if remove:
+        data = _cli(execute, "github", config, "wire-assign", "DELETE",
+                    f"repos/{repo}/issues/{number}/assignees",
+                    body={"assignees": remove})
+        if isinstance(data, TrackerError):
+            return data
+    refreshed = parent_read(config, locator, execute, op="wire-assign-readback")
+    if isinstance(refreshed, TrackerError):
+        return refreshed
+    return _issue_out(refreshed)
+
+
+def list_open(config: dict, execute: Execute) -> Result:
+    ready_state = _ready_state(config)
+    if ready_state is None:
+        return {"issues": [], "truncated": False}
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    repo = _gh_repo(dest)
+    if isinstance(repo, TrackerError):
+        return repo
+    qs = urlencode({
+        "state": "open",
+        "labels": ready_state,
+        "per_page": _PAGE_SIZE,
+    })
+    drained = _rest_drain(lambda page: _cli(
+        execute, "github", config, "wire-list-open", "GET",
+        f"repos/{repo}/issues?{qs}&page={page}",
+        idempotent=True))
+    if isinstance(drained, TrackerError):
+        return drained
+    data, truncated = drained
+    # MEASURED: GET /issues returns pull requests too - filter on pull_request.
+    issues = [i for i in data if isinstance(i, dict) and "pull_request" not in i]
+    return {"issues": [_issue_out(i, parent_identity="not_available")
+                       for i in issues],
+            "truncated": truncated}

--- a/.flow/bin/flowctl_tracker/wire/gitlab.py
+++ b/.flow/bin/flowctl_tracker/wire/gitlab.py
@@ -1,0 +1,384 @@
+"""GitLab wire verb implementations."""
+
+from __future__ import annotations
+
+from typing import Optional
+from urllib.parse import urlencode
+
+from ..types import ErrorClass, TrackerError
+from . import (
+    Execute,
+    Result,
+    _gitlab_durable,
+    _check_durable,
+    _cli,
+    _conflict,
+    _destination,
+    _gl_project,
+    _gitlab_iid,
+    _PAGE_SIZE,
+    _ready_state,
+    _rest_drain,
+)
+
+
+
+def _issue_out(raw: dict, *, parent_identity: str = "validated") -> dict:
+    path = raw.get("references", {})
+    refs = path.get("full") if isinstance(path, dict) else None
+    ident = refs or f"#{raw.get('iid')}"
+    return {
+        "id": _gitlab_durable(raw),
+        "identifier": ident if isinstance(ident, str) else f"#{raw.get('iid')}",
+        "title": raw.get("title"),
+        "body": raw.get("description"),
+        "url": raw.get("web_url"),
+        "labels": list(raw.get("labels") or []),
+        "raw": raw,
+        "parent_identity": parent_identity,
+    }
+
+
+def _comment_out(raw: dict, *, parent_identity: str) -> dict:
+    return {"id": raw.get("id"), "body": raw.get("body"),
+            "url": raw.get("web_url"),
+            "created_at": raw.get("created_at"),
+            "raw": raw, "parent_identity": parent_identity}
+
+def parent_read(config: dict, locator: dict, execute: Execute, *,
+                op: str = "wire-parent-read") -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    if isinstance(iid, TrackerError):
+        return iid
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    data = _cli(execute, "gitlab", config, op, "GET",
+                f"projects/{pid}/issues/{iid}", idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab issue is not an object",
+                            subtype="malformed_body")
+    err = _check_durable("gitlab", locator, data)
+    return err if err else data
+
+
+def _require_parent(config: dict, locator: dict, execute: Execute) -> Result:
+    return parent_read(config, locator, execute, op="wire-parent-read")
+
+
+def read(config: dict, locator: dict, execute: Execute) -> Result:
+    parent = parent_read(config, locator, execute, op="wire-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    return _issue_out(parent, parent_identity="validated")
+
+
+def pr_link(config: dict, locator: dict, execute: Execute, *, url: str) -> Result:
+    """Post one non-closing PR URL note, deduplicated by the exact URL."""
+    parent = parent_read(config, locator, execute, op="wire-pr-link-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    listed = comment_list(config, locator, execute)
+    if isinstance(listed, TrackerError):
+        return listed
+    comments = listed.get("comments")
+    if not isinstance(comments, list):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab PR-link comment list is malformed",
+            subtype="malformed_body",
+        )
+    expected = f"Flow-Next PR: {url}"
+    for comment in comments:
+        body = comment.get("body") if isinstance(comment, dict) else None
+        if isinstance(body, str) and body.strip() == expected:
+            return {
+                "linked": False,
+                "deduped": True,
+                "kind": "note",
+                "url": url,
+                "comment": comment,
+            }
+    if listed.get("truncated"):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "gitlab PR-link dedup scan truncated; refusing to post",
+            subtype="dedup_truncated",
+        )
+    added = comment_add(config, locator, execute, body=expected)
+    if isinstance(added, TrackerError):
+        return added
+    return {
+        "linked": True,
+        "deduped": False,
+        "kind": "note",
+        "url": url,
+        "comment": added,
+    }
+
+
+def update(config: dict, locator: dict, execute: Execute, *,
+           title: Optional[str], body: Optional[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    payload: dict = {}
+    if title is not None:
+        payload["title"] = title
+    if body is not None:
+        payload["description"] = body
+    if not payload:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "update requires --title and/or --body-file",
+                            subtype="update")
+    data = _cli(execute, "gitlab", config, "wire-update", "PUT",
+                f"projects/{pid}/issues/{iid}", body=payload)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab update returned no object",
+                            subtype="malformed_body")
+    err = _check_durable("gitlab", locator, data)
+    if err:
+        return err
+    return _issue_out(data)
+
+
+def comment_add(config: dict, locator: dict, execute: Execute, *, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    data = _cli(execute, "gitlab", config, "wire-comment-add", "POST",
+                f"projects/{pid}/issues/{iid}/notes", body={"body": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab comment-add returned no object",
+                            subtype="malformed_body")
+    # noteable_id IS the global issue id — validate when present.
+    noteable = data.get("noteable_id")
+    if noteable is not None and str(noteable) != str(locator["durable"]):
+        return _conflict(locator["durable"], noteable)
+    identity = "validated" if noteable is not None else "not_available"
+    return _comment_out(data, parent_identity=identity)
+
+
+def comment_list(config: dict, locator: dict, execute: Execute) -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    if isinstance(iid, TrackerError):
+        return iid
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    drained = _rest_drain(lambda page: _cli(
+        execute, "gitlab", config, "wire-comment-list", "GET",
+        f"projects/{pid}/issues/{iid}/notes"
+        f"?per_page={_PAGE_SIZE}&page={page}", idempotent=True))
+    if isinstance(drained, TrackerError):
+        return drained
+    data, truncated = drained
+    # MUST filter system notes (measured: label/state events are system:true).
+    human = [n for n in data if isinstance(n, dict) and not n.get("system")]
+    out = []
+    for n in human:
+        noteable = n.get("noteable_id")
+        if noteable is not None and str(noteable) != str(locator["durable"]):
+            return _conflict(locator["durable"], noteable)
+        identity = "validated" if noteable is not None else "not_available"
+        out.append(_comment_out(n, parent_identity=identity))
+    # Aggregate: "validated" only when ≥1 human note AND every one had
+    # noteable_id checked; empty list or any missing noteable_id → not_available.
+    if human and all(n.get("noteable_id") is not None for n in human):
+        aggregate = "validated"
+    else:
+        aggregate = "not_available"
+    return {"comments": out, "truncated": truncated, "parent_identity": aggregate}
+
+
+def comment_update(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    # Intrinsically parent-scoped: issue iid is in the path, so no comment
+    # pre-fetch is required (unlike GitHub/Linear which address by comment id alone).
+    data = _cli(execute, "gitlab", config, "wire-comment-update", "PUT",
+                f"projects/{pid}/issues/{iid}/notes/{comment_id}",
+                body={"body": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab comment-update returned no object",
+                            subtype="malformed_body")
+    noteable = data.get("noteable_id")
+    if noteable is not None and str(noteable) != str(locator["durable"]):
+        return _conflict(locator["durable"], noteable)
+    identity = "validated" if noteable is not None else "not_available"
+    return _comment_out(data, parent_identity=identity)
+
+
+def comment_delete(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    # Intrinsically parent-scoped: issue iid is in the path, so no comment
+    # pre-fetch is required (unlike GitHub/Linear which address by comment id alone).
+    data = _cli(execute, "gitlab", config, "wire-comment-delete", "DELETE",
+                f"projects/{pid}/issues/{iid}/notes/{comment_id}")
+    if isinstance(data, TrackerError):
+        return data
+    return {"deleted": comment_id, "parent_identity": "not_available"}
+
+
+def label(config: dict, locator: dict, execute: Execute, *,
+          add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "label requires --add and/or --remove", subtype="label")
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    payload: dict = {}
+    if add:
+        payload["add_labels"] = ",".join(add)
+    if remove:
+        payload["remove_labels"] = ",".join(remove)
+    data = _cli(execute, "gitlab", config, "wire-label", "PUT",
+                f"projects/{pid}/issues/{iid}", body=payload)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab label returned no object",
+                            subtype="malformed_body")
+    err = _check_durable("gitlab", locator, data)
+    if err:
+        return err
+    return _issue_out(data)
+
+
+def assign(config: dict, locator: dict, execute: Execute, *,
+           add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "assign requires --add and/or --remove", subtype="assign")
+    iid = _gitlab_iid(locator["display"])
+    pid = _gl_project(dest)
+    if isinstance(iid, TrackerError):
+        return iid
+    if isinstance(pid, TrackerError):
+        return pid
+    # GitLab takes numeric user ids. Callers pass ids as strings.
+    current = []
+    for a in (parent.get("assignees") or []):
+        if isinstance(a, dict) and a.get("id") is not None:
+            current.append(int(a["id"]))
+    cur = set(current)
+    for u in add:
+        if not str(u).isdigit():
+            return TrackerError(ErrorClass.INVALID_INPUT,
+                                f"gitlab assignee must be a numeric user id, got {u!r}",
+                                subtype="assign")
+        cur.add(int(u))
+    for u in remove:
+        if str(u).isdigit():
+            cur.discard(int(u))
+    data = _cli(execute, "gitlab", config, "wire-assign", "PUT",
+                f"projects/{pid}/issues/{iid}",
+                body={"assignee_ids": sorted(cur)})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "gitlab assign returned no object",
+                            subtype="malformed_body")
+    err = _check_durable("gitlab", locator, data)
+    if err:
+        return err
+    return _issue_out(data)
+
+
+def list_open(config: dict, execute: Execute) -> Result:
+    ready_state = _ready_state(config)
+    if ready_state is None:
+        return {"issues": [], "truncated": False}
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    pid = _gl_project(dest)
+    if isinstance(pid, TrackerError):
+        return pid
+    # GitLab states are opened/closed (not open/closed).
+    qs = urlencode({
+        "state": "opened",
+        "labels": ready_state,
+        "per_page": _PAGE_SIZE,
+    })
+    drained = _rest_drain(lambda page: _cli(
+        execute, "gitlab", config, "wire-list-open", "GET",
+        f"projects/{pid}/issues?{qs}&page={page}",
+        idempotent=True))
+    if isinstance(drained, TrackerError):
+        return drained
+    data, truncated = drained
+    return {"issues": [_issue_out(i, parent_identity="not_available")
+                       for i in data if isinstance(i, dict)],
+            "truncated": truncated}

--- a/.flow/bin/flowctl_tracker/wire/jira.py
+++ b/.flow/bin/flowctl_tracker/wire/jira.py
@@ -1,0 +1,503 @@
+"""Jira wire verb implementations."""
+
+from __future__ import annotations
+
+from typing import Optional
+from urllib.parse import quote, urlencode
+
+from ..types import ErrorClass, TrackerError
+from . import (
+    Execute,
+    Result,
+    _check_durable,
+    _destination,
+    _dict,
+    _jira,
+    _jira_base,
+    _jira_issue_key,
+    _jira_project_key,
+    _MAX_PAGES,
+    _PAGE_SIZE,
+    _ready_state,
+)
+
+
+
+def _issue_out(raw: dict, *, parent_identity: str = "not_available") -> dict:
+    fields = raw.get("fields") if isinstance(raw.get("fields"), dict) else {}
+    return {
+        "id": str(raw.get("id")),
+        "identifier": raw.get("key"),
+        "title": fields.get("summary"),
+        "body": fields.get("description"),
+        "url": None,
+        "labels": list(fields.get("labels") or []),
+        "status": (
+            {"raw": fields["status"].get("name"),
+             "type": (
+                 fields["status"].get("statusCategory", {}).get("key")
+                 if isinstance(fields["status"].get("statusCategory"), dict)
+                 else None
+             )}
+            if isinstance(fields.get("status"), dict) else None
+        ),
+        "raw": raw,
+        "parent_identity": parent_identity,
+    }
+
+
+def _comment_out(raw: dict, *, parent_identity: str) -> dict:
+    return {"id": raw.get("id"), "body": raw.get("body"),
+            "url": None, "created_at": raw.get("created"),
+            "raw": raw, "parent_identity": parent_identity}
+
+def parent_read(config: dict, locator: dict, execute: Execute, *,
+                op: str = "wire-parent-read") -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    # jira - the PARENT READ addresses by the DISPLAY key and compares the
+    # returned immutable id to locator.durable. The key is the mutable half
+    # (project moves renumber it), so key->id comparison is the check that
+    # actually catches a move; reading by durable would compare durable to
+    # itself and always pass. Mutations still address by durable (immutable).
+    #
+    # Display grammar accepts DC custom keys (underscores, >10 chars), e.g.
+    # MY_LONG_PROJECT_KEY-7. UNVERIFIED on live Jira Data Center (Cloud cannot
+    # reproduce custom keys - fn-140 R17); verified against prose only.
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    key = _jira_issue_key(locator["display"])
+    if isinstance(key, TrackerError):
+        return key
+    data = _jira(execute, op, "GET",
+                 f"{base}/rest/api/2/issue/{quote(str(key), safe='')}"
+                 f"?fields=summary,description,status,priority,labels,assignee,updated",
+                 idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "jira issue is not an object",
+                            subtype="malformed_body")
+    err = _check_durable("jira", locator, data)
+    return err if err else data
+
+
+def _require_parent(config: dict, locator: dict, execute: Execute) -> Result:
+    return parent_read(config, locator, execute, op="wire-parent-read")
+
+
+def read(config: dict, locator: dict, execute: Execute) -> Result:
+    parent = parent_read(config, locator, execute, op="wire-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    return _issue_out(parent, parent_identity="validated")
+
+
+def pr_link(config: dict, locator: dict, execute: Execute, *, url: str) -> Result:
+    """Upsert a Jira remote link, falling back to a deduplicated URL comment."""
+    parent = parent_read(config, locator, execute, op="wire-pr-link-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    endpoint = (
+        f"{base}/rest/api/2/issue/"
+        f"{quote(str(locator['durable']), safe='')}/remotelink"
+    )
+    linked = _jira(
+        execute,
+        "wire-pr-link",
+        "POST",
+        endpoint,
+        body={
+            "globalId": f"flow-next:pr:{url}",
+            "object": {
+                "url": url,
+                "title": "Flow-Next pull request",
+            },
+        },
+        idempotent=True,
+    )
+    if not isinstance(linked, TrackerError):
+        return {
+            "linked": True,
+            "deduped": False,
+            "kind": "remote-link",
+            "url": url,
+        }
+
+    listed = comment_list(config, locator, execute)
+    if isinstance(listed, TrackerError):
+        return linked
+    comments = listed.get("comments")
+    if not isinstance(comments, list):
+        return linked
+    expected = f"Flow-Next PR: {url}"
+    for comment in comments:
+        body = comment.get("body") if isinstance(comment, dict) else None
+        if isinstance(body, str) and body.strip() == expected:
+            return {
+                "linked": False,
+                "deduped": True,
+                "kind": "comment-fallback",
+                "url": url,
+                "comment": comment,
+                "degraded": {
+                    "capability": "remote-link",
+                    "reason": linked.message,
+                },
+            }
+    if listed.get("truncated"):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "jira PR-link fallback dedup scan truncated; refusing to post",
+            subtype="dedup_truncated",
+            details={"remote_link_error": linked.message},
+        )
+    added = comment_add(config, locator, execute, body=expected)
+    if isinstance(added, TrackerError):
+        return linked
+    return {
+        "linked": True,
+        "deduped": False,
+        "kind": "comment-fallback",
+        "url": url,
+        "comment": added,
+        "degraded": {
+            "capability": "remote-link",
+            "reason": linked.message,
+        },
+    }
+
+
+def update(config: dict, locator: dict, execute: Execute, *,
+           title: Optional[str], body: Optional[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    fields: dict = {}
+    if title is not None:
+        fields["summary"] = title
+    if body is not None:
+        fields["description"] = body
+    if not fields:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "update requires --title and/or --body-file",
+                            subtype="update")
+    key = locator["durable"]
+    data = _jira(execute, "wire-update", "PUT",
+                 f"{base}/rest/api/2/issue/{quote(str(key), safe='')}",
+                 body={"fields": fields})
+    if isinstance(data, TrackerError):
+        return data
+    # PUT returns 204 (no body), so response-side parent identity is not
+    # available on the write itself - the pre-mutation gate already checked.
+    # Fold the applied fields into the parent snapshot so the caller sees the
+    # POST-update state, not the stale pre-update body.
+    prior = parent.get("fields") if isinstance(parent.get("fields"), dict) else {}
+    parent["fields"] = {**prior, **fields}
+    # 204 carries no body: response-side parent identity is NOT available on
+    # this synthesized post-state - the pre-mutation gate is the protection.
+    return _issue_out(parent, parent_identity="not_available")
+
+
+def comment_add(config: dict, locator: dict, execute: Execute, *, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    data = _jira(execute, "wire-comment-add", "POST",
+                 f"{base}/rest/api/2/issue/{quote(str(locator['durable']), safe='')}/comment",
+                 body={"body": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "jira comment-add returned no object",
+                            subtype="malformed_body")
+    return _comment_out(data, parent_identity="not_available")
+
+
+def comment_list(config: dict, locator: dict, execute: Execute) -> Result:
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    collected: list = []
+    truncated = False
+    start_at = 0
+    for _ in range(_MAX_PAGES):
+        data = _jira(execute, "wire-comment-list", "GET",
+                     f"{base}/rest/api/2/issue/{quote(str(locator['durable']), safe='')}"
+                     f"/comment?startAt={start_at}&maxResults={_PAGE_SIZE}",
+                     idempotent=True)
+        if isinstance(data, TrackerError):
+            return data
+        if not isinstance(data, dict):
+            return TrackerError(ErrorClass.TRANSPORT, "jira comment list is not an object",
+                                subtype="malformed_body")
+        comments = data.get("comments") or []
+        if not isinstance(comments, list):
+            return TrackerError(ErrorClass.TRANSPORT, "jira comments is not a list",
+                                subtype="malformed_body")
+        collected.extend(c for c in comments if isinstance(c, dict))
+        total = data.get("total")
+        start_at += len(comments)
+        if not comments or not isinstance(total, int) or start_at >= total:
+            break
+    else:
+        truncated = True
+    return {"comments": [_comment_out(c, parent_identity="not_available")
+                         for c in collected],
+            "truncated": truncated, "parent_identity": "not_available"}
+
+
+def comment_update(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    # Intrinsically parent-scoped: issue key/id is in the path, so no comment
+    # pre-fetch is required (unlike GitHub/Linear which address by comment id alone).
+    data = _jira(execute, "wire-comment-update", "PUT",
+                 f"{base}/rest/api/2/issue/{quote(str(locator['durable']), safe='')}"
+                 f"/comment/{quote(str(comment_id), safe='')}",
+                 body={"body": body})
+    if isinstance(data, TrackerError):
+        return data
+    if not isinstance(data, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "jira comment-update returned no object",
+                            subtype="malformed_body")
+    return _comment_out(data, parent_identity="not_available")
+
+
+def comment_delete(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    # Intrinsically parent-scoped: issue key/id is in the path, so no comment
+    # pre-fetch is required (unlike GitHub/Linear which address by comment id alone).
+    data = _jira(execute, "wire-comment-delete", "DELETE",
+                 f"{base}/rest/api/2/issue/{quote(str(locator['durable']), safe='')}"
+                 f"/comment/{quote(str(comment_id), safe='')}")
+    if isinstance(data, TrackerError):
+        return data
+    return {"deleted": comment_id, "parent_identity": "not_available"}
+
+
+def label(config: dict, locator: dict, execute: Execute, *,
+          add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "label requires --add and/or --remove", subtype="label")
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    fields = parent.get("fields") if isinstance(parent.get("fields"), dict) else {}
+    current_labels = list(fields.get("labels") or [])
+    for name in add:
+        if name not in current_labels:
+            current_labels.append(name)
+    for name in remove:
+        current_labels = [x for x in current_labels if x != name]
+    data = _jira(execute, "wire-label", "PUT",
+                 f"{base}/rest/api/2/issue/{quote(str(locator['durable']), safe='')}",
+                 body={"fields": {"labels": current_labels}})
+    if isinstance(data, TrackerError):
+        return data
+    parent["fields"] = {**fields, "labels": current_labels}
+    return _issue_out(parent)
+
+
+def assign(config: dict, locator: dict, execute: Execute, *,
+           add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "assign requires --add and/or --remove", subtype="assign")
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    fields = parent.get("fields") if isinstance(parent.get("fields"), dict) else {}
+    prior = fields.get("assignee") if isinstance(fields.get("assignee"), dict) else None
+    previous = None
+    if prior:
+        previous = prior.get("accountId") or prior.get("name")
+    # Single-assignee: last --add REPLACES; report prior in degraded (R15).
+    if add:
+        # Cloud assigns by accountId; DC/Server assigns by name. Select the
+        # field from the PERSISTED deployment shape (perTracker.authScheme,
+        # decided once at the discovery ceremony) - never from the shape of
+        # the identifier itself, which misclassifies valid DC usernames like
+        # `john-doe`. Absent authScheme means cloud-basic, matching how
+        # credentials.resolve() treats every non-"bearer-pat" value.
+        scheme = _dict(_dict(config.get("tracker")).get("perTracker")).get("authScheme")
+        user = add[-1]
+        assignee = {"name": user} if scheme == "bearer-pat" else {"accountId": user}
+        applied = user
+    else:
+        # Remove-only: clear the single assignee ONLY when the current identity
+        # matches a requested removal (accountId on Cloud; name/key on DC).
+        # Otherwise preserve the unrelated assignee and no-op.
+        current_ids = set()
+        if prior:
+            for k in ("accountId", "name", "key"):
+                v = prior.get(k)
+                if isinstance(v, str) and v:
+                    current_ids.add(v)
+        if not current_ids.intersection(remove):
+            out = _issue_out(parent)
+            out["degraded"] = {
+                "kind": "assignee_remove_skipped",
+                "requested": list(remove),
+                "current": previous,
+            }
+            return out
+        assignee = None
+        applied = None
+    data = _jira(execute, "wire-assign", "PUT",
+                 f"{base}/rest/api/2/issue/{quote(str(locator['durable']), safe='')}",
+                 body={"fields": {"assignee": assignee}})
+    if isinstance(data, TrackerError):
+        return data
+    parent["fields"] = {**fields, "assignee": assignee}
+    out = _issue_out(parent)
+    if add and previous is not None and previous != applied:
+        out["degraded"] = {
+            "kind": "assignee_replaced",
+            "previous": previous,
+            "applied": applied,
+        }
+    return out
+
+
+def list_open(config: dict, execute: Execute) -> Result:
+    ready_state = _ready_state(config)
+    if ready_state is None:
+        return {"issues": [], "truncated": False}
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    base = _jira_base(config, dest)
+    if isinstance(base, TrackerError):
+        return base
+    raw_key = dest.get("projectKey") or _dict(_dict(config.get("tracker")).get("perTracker")).get("projectKey")
+    if not raw_key:
+        return TrackerError(ErrorClass.UNRESOLVED, "jira projectKey is not resolved",
+                            subtype="destination")
+    # Sanitize before JQL interpolation. Grammar allows DC underscores / long
+    # keys (^[A-Z][A-Z0-9_]+$). UNVERIFIED on live Jira Data Center (Cloud cannot
+    # reproduce custom keys - fn-140 R17); verified against prose only.
+    key = _jira_project_key(str(raw_key))
+    if isinstance(key, TrackerError):
+        return key
+    escaped_state = ready_state.replace("\\", "\\\\").replace('"', '\\"')
+    jql = f'project = {key} AND status = "{escaped_state}"'
+
+    collected: list = []
+    truncated = False
+    fields = ["summary", "description", "status", "priority", "labels", "updated"]
+    if str(dest.get("apiVersion")) == "3":
+        next_page = None
+        seen = set()
+        for _ in range(_MAX_PAGES):
+            body = {"jql": jql, "maxResults": _PAGE_SIZE, "fields": fields}
+            if next_page is not None:
+                body["nextPageToken"] = next_page
+            data = _jira(execute, "wire-list-open", "POST",
+                         f"{base}/rest/api/3/search/jql", body=body,
+                         idempotent=True)
+            if isinstance(data, TrackerError):
+                return data
+            if not isinstance(data, dict):
+                return TrackerError(ErrorClass.TRANSPORT, "jira search is not an object",
+                                    subtype="malformed_body")
+            issues = data.get("issues") or []
+            if not isinstance(issues, list):
+                return TrackerError(ErrorClass.TRANSPORT,
+                                    "jira search.issues is not a list",
+                                    subtype="malformed_body")
+            collected.extend(i for i in issues if isinstance(i, dict))
+            if data.get("isLast") is not False:
+                break
+            token = data.get("nextPageToken")
+            if not isinstance(token, str) or not token or token in seen:
+                return TrackerError(ErrorClass.TRANSPORT,
+                                    "jira search cursor made no progress",
+                                    subtype="malformed_body")
+            seen.add(token)
+            next_page = token
+        else:
+            truncated = True
+        return {"issues": [_issue_out(i, parent_identity="not_available")
+                           for i in collected],
+                "truncated": truncated}
+
+    # Data Center / Server v2 retains classic offset pagination.
+    start_at = 0
+    for _ in range(_MAX_PAGES):
+        qs = urlencode({"jql": jql, "startAt": start_at, "maxResults": _PAGE_SIZE,
+                        "fields": ",".join(fields)})
+        data = _jira(execute, "wire-list-open", "GET",
+                     f"{base}/rest/api/2/search?{qs}", idempotent=True)
+        if isinstance(data, TrackerError):
+            return data
+        if not isinstance(data, dict):
+            return TrackerError(ErrorClass.TRANSPORT, "jira search is not an object",
+                                subtype="malformed_body")
+        issues = data.get("issues") or []
+        if not isinstance(issues, list):
+            return TrackerError(ErrorClass.TRANSPORT, "jira search.issues is not a list",
+                                subtype="malformed_body")
+        collected.extend(i for i in issues if isinstance(i, dict))
+        total = data.get("total")
+        start_at += len(issues)
+        if not issues or not isinstance(total, int) or start_at >= total:
+            break
+    else:
+        truncated = True
+    return {"issues": [_issue_out(i, parent_identity="not_available")
+                       for i in collected],
+            "truncated": truncated}

--- a/.flow/bin/flowctl_tracker/wire/linear.py
+++ b/.flow/bin/flowctl_tracker/wire/linear.py
@@ -1,0 +1,604 @@
+"""Linear wire verb implementations."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from ..types import ErrorClass, TrackerError
+from . import (
+    Execute,
+    Result,
+    _check_durable,
+    _comment_parent_mismatch,
+    _destination,
+    _dict,
+    _gql,
+    _gql_connection_drain,
+    _PAGE_SIZE,
+    _ready_state,
+)
+
+
+def _require_success(data: dict, field: str) -> Union[dict, TrackerError]:
+    """Linear mutations that carry `success` must report success is True."""
+    payload = data.get(field)
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return TrackerError(ErrorClass.TRANSPORT,
+                            f"linear {field} reported failure",
+                            subtype="mutation_failed")
+    return payload
+
+
+
+def _issue_out(raw: dict, *, parent_identity: str = "validated") -> dict:
+    labels = ((((raw.get("labels") or {}).get("nodes"))
+               if isinstance(raw.get("labels"), dict) else raw.get("labels")) or [])
+    names = [n.get("name") for n in labels if isinstance(n, dict)]
+    return {
+        "id": raw.get("id"),
+        "identifier": raw.get("identifier"),
+        "title": raw.get("title"),
+        "body": raw.get("description"),
+        "url": raw.get("url"),
+        "labels": names,
+        "status": (
+            {"raw": raw["state"].get("name"),
+             "type": raw["state"].get("type")}
+            if isinstance(raw.get("state"), dict) else None
+        ),
+        "raw": raw,
+        "parent_identity": parent_identity,
+    }
+
+
+def _comment_out(raw: dict, *, parent_identity: str) -> dict:
+    return {"id": raw.get("id"), "body": raw.get("body"),
+            "url": raw.get("url"),
+            "created_at": raw.get("createdAt"),
+            "raw": raw, "parent_identity": parent_identity}
+
+def parent_read(config: dict, locator: dict, execute: Execute, *,
+                op: str = "wire-parent-read") -> Result:
+    # Address by DISPLAY identifier (issue(id:) accepts both) and compare
+    # the returned UUID to locator.durable. Reading by durable would make
+    # the check vacuous - durable compared to itself always passes, and a
+    # moved/renumbered identifier would go unnoticed.
+    data = _gql(execute, op,
+                "query($id: String!) { issue(id: $id) { id identifier title "
+                "description url updatedAt "
+                "state { id name type } "
+                "labels { nodes { id name } } "
+                "assignee { id name } } }",
+                {"id": locator["display"]}, idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    issue = data.get("issue")
+    if issue is None:
+        return TrackerError(ErrorClass.NOT_FOUND, "linear issue not found",
+                            subtype="parent")
+    if not isinstance(issue, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear issue is not an object",
+                            subtype="malformed_body")
+    err = _check_durable("linear", locator, issue)
+    return err if err else issue
+
+
+def _require_parent(config: dict, locator: dict, execute: Execute) -> Result:
+    return parent_read(config, locator, execute, op="wire-parent-read")
+
+
+def _comment_belongs(locator: dict, execute: Execute, *,
+                     comment_id: str) -> Optional[TrackerError]:
+    """Verify comment.issue.id matches locator.durable before mutating.
+
+    Linear comment-update/delete address by comment_id alone; without this
+    pre-fetch a valid-but-unrelated parent locator could mutate another issue's
+    comment.
+    """
+    data = _gql(execute, "wire-comment-belong",
+                "query($id: String!) { comment(id: $id) { id issue { id } } }",
+                {"id": comment_id}, idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    comment = data.get("comment")
+    if comment is None:
+        return TrackerError(ErrorClass.NOT_FOUND, "linear comment not found",
+                            subtype="comment")
+    if not isinstance(comment, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear comment is not an object",
+                            subtype="malformed_body")
+    issue = comment.get("issue") if isinstance(comment.get("issue"), dict) else None
+    issue_id = issue.get("id") if issue else None
+    if issue_id is None or str(issue_id) != str(locator["durable"]):
+        return _comment_parent_mismatch(
+            comment_id, f"issue.id {issue_id!r} vs locator.durable {locator['durable']!r}")
+    return None
+
+
+def read(config: dict, locator: dict, execute: Execute) -> Result:
+    parent = parent_read(config, locator, execute, op="wire-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    return _issue_out(parent, parent_identity="validated")
+
+
+def _pr_attachments(locator: dict, execute: Execute) -> Result:
+    """Drain the PR-link dedup surface; absence is valid only when complete."""
+    def pluck(data: dict) -> Union[dict, TrackerError]:
+        issue = data.get("issue")
+        conn = issue.get("attachments") if isinstance(issue, dict) else None
+        if not isinstance(conn, dict):
+            return TrackerError(
+                ErrorClass.TRANSPORT,
+                "linear attachments connection is malformed",
+                subtype="malformed_body",
+            )
+        return conn
+
+    drained = _gql_connection_drain(
+        execute,
+        "wire-pr-link-list",
+        "query($id: String!, $after: String) { issue(id: $id) { "
+        f"attachments(first: {_PAGE_SIZE}, after: $after) "
+        "{ nodes { id url } pageInfo { hasNextPage endCursor } } } }",
+        {"id": locator["durable"]},
+        pluck,
+    )
+    if isinstance(drained, TrackerError):
+        return drained
+    nodes, truncated = drained
+    return {"attachments": nodes, "truncated": truncated}
+
+
+def _matching_pr_attachment(listed: dict, url: str) -> Optional[dict]:
+    attachments = listed.get("attachments")
+    if not isinstance(attachments, list):
+        return None
+    return next(
+        (
+            attachment
+            for attachment in attachments
+            if isinstance(attachment, dict) and attachment.get("url") == url
+        ),
+        None,
+    )
+
+
+def pr_link(config: dict, locator: dict, execute: Execute, *, url: str) -> Result:
+    """Create Linear's rich URL attachment for PR status/diff integration."""
+    parent = parent_read(config, locator, execute, op="wire-pr-link-parent-read")
+    if isinstance(parent, TrackerError):
+        return parent
+    listed = _pr_attachments(locator, execute)
+    if isinstance(listed, TrackerError):
+        return listed
+    existing = _matching_pr_attachment(listed, url)
+    if existing is not None:
+        return {
+            "linked": False,
+            "deduped": True,
+            "kind": "rich-attachment",
+            "url": url,
+            "attachment": existing,
+        }
+    if listed.get("truncated"):
+        return TrackerError(
+            ErrorClass.TRANSPORT,
+            "linear PR-link dedup scan truncated; refusing to attach",
+            subtype="dedup_truncated",
+        )
+    data = _gql(
+        execute,
+        "wire-pr-link",
+        "mutation($issueId: String!, $url: String!) { "
+        "attachmentLinkURL(issueId: $issueId, url: $url) { "
+        "success attachment { id url } } }",
+        {"issueId": locator["durable"], "url": url},
+    )
+    if isinstance(data, TrackerError):
+        # Another make-pr process may have attached the same URL after our
+        # complete absence scan. Re-read once before surfacing the mutation
+        # error so that the race remains idempotent without hiding other errors.
+        raced = _pr_attachments(locator, execute)
+        if not isinstance(raced, TrackerError):
+            existing = _matching_pr_attachment(raced, url)
+            if existing is not None:
+                return {
+                    "linked": False,
+                    "deduped": True,
+                    "kind": "rich-attachment",
+                    "url": url,
+                    "attachment": existing,
+                }
+        return data
+    payload = _require_success(data, "attachmentLinkURL")
+    if isinstance(payload, TrackerError):
+        return payload
+    return {
+        "linked": True,
+        "deduped": False,
+        "kind": "rich-attachment",
+        "url": url,
+        "attachment": payload.get("attachment"),
+    }
+
+
+def update(config: dict, locator: dict, execute: Execute, *,
+           title: Optional[str], body: Optional[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    inp: dict = {}
+    if title is not None:
+        inp["title"] = title
+    if body is not None:
+        inp["description"] = body
+    if not inp:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "update requires --title and/or --body-file",
+                            subtype="update")
+    data = _gql(execute, "wire-update",
+                "mutation($id: String!, $input: IssueUpdateInput!) { "
+                "issueUpdate(id: $id, input: $input) { success "
+                "issue { id identifier title description url } } }",
+                {"id": locator["durable"], "input": inp})
+    if isinstance(data, TrackerError):
+        return data
+    mut = _require_success(data, "issueUpdate")
+    if isinstance(mut, TrackerError):
+        return mut
+    issue = mut.get("issue")
+    if not isinstance(issue, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear update returned no issue",
+                            subtype="malformed_body")
+    err = _check_durable("linear", locator, issue)
+    if err:
+        return err
+    return _issue_out(issue)
+
+
+def comment_add(config: dict, locator: dict, execute: Execute, *, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    data = _gql(execute, "wire-comment-add",
+                "mutation($input: CommentCreateInput!) { "
+                "commentCreate(input: $input) { success "
+                "comment { id body url createdAt issue { id } } } }",
+                {"input": {"issueId": locator["durable"], "body": body}})
+    if isinstance(data, TrackerError):
+        return data
+    mut = _require_success(data, "commentCreate")
+    if isinstance(mut, TrackerError):
+        return mut
+    comment = mut.get("comment")
+    if not isinstance(comment, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear comment-add returned no comment",
+                            subtype="malformed_body")
+    issue = comment.get("issue") if isinstance(comment.get("issue"), dict) else None
+    if issue is not None:
+        err = _check_durable("linear", locator, issue)
+        if err:
+            return err
+        return _comment_out(comment, parent_identity="validated")
+    return _comment_out(comment, parent_identity="not_available")
+
+
+def comment_list(config: dict, locator: dict, execute: Execute) -> Result:
+    """Display-addressed (real durable validation) + fully drained connection."""
+    probe = _gql(execute, "wire-comment-list",
+                 "query($id: String!) { issue(id: $id) { id } }",
+                 {"id": locator["display"]}, idempotent=True)
+    if isinstance(probe, TrackerError):
+        return probe
+    issue = probe.get("issue")
+    if issue is None:
+        return TrackerError(ErrorClass.NOT_FOUND, "linear issue not found",
+                            subtype="parent")
+    if not isinstance(issue, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear issue is not an object",
+                            subtype="malformed_body")
+    err = _check_durable("linear", locator, issue)
+    if err:
+        return err
+
+    def pluck(data: dict) -> Union[dict, TrackerError]:
+        iss = data.get("issue")
+        conn = (iss.get("comments") if isinstance(iss, dict) else None)
+        if not isinstance(conn, dict):
+            return TrackerError(ErrorClass.TRANSPORT,
+                                "linear comments connection is malformed",
+                                subtype="malformed_body")
+        return conn
+
+    drained = _gql_connection_drain(
+        execute, "wire-comment-list",
+        "query($id: String!, $after: String) { issue(id: $id) { "
+        f"comments(first: {_PAGE_SIZE}, after: $after) "
+        "{ nodes { id body url createdAt } "
+        "pageInfo { hasNextPage endCursor } } } }",
+        {"id": locator["display"]}, pluck)
+    if isinstance(drained, TrackerError):
+        return drained
+    nodes, truncated = drained
+    return {"comments": [_comment_out(c, parent_identity="validated")
+                         for c in nodes],
+            "truncated": truncated, "parent_identity": "validated"}
+
+
+def comment_update(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str, body: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    belong = _comment_belongs(locator, execute, comment_id=comment_id)
+    if belong is not None:
+        return belong
+    data = _gql(execute, "wire-comment-update",
+                "mutation($id: String!, $input: CommentUpdateInput!) { "
+                "commentUpdate(id: $id, input: $input) { success "
+                "comment { id body url createdAt issue { id } } } }",
+                {"id": comment_id, "input": {"body": body}})
+    if isinstance(data, TrackerError):
+        return data
+    mut = _require_success(data, "commentUpdate")
+    if isinstance(mut, TrackerError):
+        return mut
+    comment = mut.get("comment")
+    if not isinstance(comment, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear comment-update returned no comment",
+                            subtype="malformed_body")
+    issue = comment.get("issue") if isinstance(comment.get("issue"), dict) else None
+    if issue is not None:
+        err = _check_durable("linear", locator, issue)
+        if err:
+            return err
+        return _comment_out(comment, parent_identity="validated")
+    return _comment_out(comment, parent_identity="not_available")
+
+
+def comment_delete(config: dict, locator: dict, execute: Execute, *,
+                   comment_id: str) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    belong = _comment_belongs(locator, execute, comment_id=comment_id)
+    if belong is not None:
+        return belong
+    data = _gql(execute, "wire-comment-delete",
+                "mutation($id: String!) { commentDelete(id: $id) { success } }",
+                {"id": comment_id})
+    if isinstance(data, TrackerError):
+        return data
+    mut = _require_success(data, "commentDelete")
+    if isinstance(mut, TrackerError):
+        return mut
+    return {"deleted": comment_id, "parent_identity": "not_available"}
+
+
+def _team_label_lookup(execute: Execute, team_id: str, name: str
+                       ) -> Union[Optional[str], TrackerError]:
+    """Resolve `name` against the team's LIVE label connection.
+
+    A label auto-created while updating a DIFFERENT issue exists on the team
+    but appears in neither the pinned config labelIds nor this issue's parent
+    read; creating again would fail (name already exists) or duplicate. The
+    server-side name filter (`eqIgnoreCase` - label names are case-insensitively
+    unique per team) avoids pagination entirely, but the connection shape is
+    still validated: unproven absence is never absence, so a malformed or
+    truncated listing returns a TrackerError instead of falling through to
+    issueLabelCreate.
+    """
+    data = _gql(execute, "wire-label-team-lookup",
+                "query($teamId: String!, $name: String!) { team(id: $teamId) { "
+                "labels(filter: { name: { eqIgnoreCase: $name } }, first: 50) "
+                "{ nodes { id name } pageInfo { hasNextPage endCursor } } } }",
+                {"teamId": team_id, "name": name}, idempotent=True)
+    if isinstance(data, TrackerError):
+        return data
+    team = data.get("team")
+    conn = team.get("labels") if isinstance(team, dict) else None
+    nodes = conn.get("nodes") if isinstance(conn, dict) else None
+    if not isinstance(nodes, list):
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "linear team labels connection is malformed",
+                            subtype="malformed_body")
+    for n in nodes:
+        if (isinstance(n, dict) and isinstance(n.get("id"), str) and n["id"]
+                and isinstance(n.get("name"), str)
+                and n["name"].lower() == name.lower()):
+            return n["id"]
+    if _dict(conn.get("pageInfo")).get("hasNextPage"):
+        # Name-filtered yet truncated: the match could sit on an unread page,
+        # so absence is unproven and auto-create must not proceed.
+        return TrackerError(ErrorClass.TRANSPORT,
+                            "linear team labels listing is truncated; "
+                            "cannot prove label absence before create",
+                            subtype="truncated")
+    return None
+
+
+def label(config: dict, locator: dict, execute: Execute, *,
+          add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "label requires --add and/or --remove", subtype="label")
+    label_ids = dict(_dict(dest.get("labelIds")))
+    team_id = dest.get("teamId")
+    current = []
+    labels = parent.get("labels")
+    nodes = (labels.get("nodes") if isinstance(labels, dict) else labels) or []
+    # Label names are case-insensitively unique per Linear team; the resolved
+    # labelIds map is keyed lowercased (providers/linear.py). Fold the labels
+    # the parent read just returned into the lookup so a label auto-created by
+    # an earlier invocation (present on the issue but absent from the pinned
+    # config) resolves to its live id instead of a second issueLabelCreate.
+    for n in nodes:
+        if isinstance(n, dict) and n.get("id"):
+            current.append(n["id"])
+            if isinstance(n.get("name"), str) and n["name"]:
+                label_ids.setdefault(n["name"].lower(), n["id"])
+    current_set = set(current)
+    created: list[str] = []
+    for name in add:
+        key = str(name).lower()
+        lid = label_ids.get(key)
+        if not lid:
+            # R15: unknown Linear label AUTO-CREATES (matches GitHub/GitLab
+            # create-on-demand). issueLabelCreate then attach via labelIds.
+            if not team_id:
+                return TrackerError(ErrorClass.UNRESOLVED,
+                                    "linear teamId required to auto-create label",
+                                    subtype="destination")
+            # The parent-read fold above only covers labels already on THIS
+            # issue; a label auto-created via another issue is still unknown
+            # here. Prove absence against the team's live labels first.
+            found = _team_label_lookup(execute, team_id, str(name))
+            if isinstance(found, TrackerError):
+                return found
+            if found:
+                label_ids[key] = found
+                current_set.add(found)
+                continue
+            created_data = _gql(
+                execute, "wire-label-create",
+                "mutation($input: IssueLabelCreateInput!) { "
+                "issueLabelCreate(input: $input) { success "
+                "issueLabel { id name } } }",
+                {"input": {"name": str(name), "teamId": team_id}},
+            )
+            if isinstance(created_data, TrackerError):
+                return created_data
+            payload = created_data.get("issueLabelCreate")
+            if not isinstance(payload, dict) or payload.get("success") is not True:
+                return TrackerError(ErrorClass.TRANSPORT,
+                                    "linear issueLabelCreate failed",
+                                    subtype="mutation_failed")
+            lab = payload.get("issueLabel") if isinstance(payload.get("issueLabel"), dict) else {}
+            lid = lab.get("id")
+            if not isinstance(lid, str) or not lid:
+                return TrackerError(ErrorClass.TRANSPORT,
+                                    "linear issueLabelCreate returned no id",
+                                    subtype="malformed_body")
+            label_ids[key] = lid
+            created.append(str(name))
+        current_set.add(lid)
+    for name in remove:
+        lid = label_ids.get(str(name).lower())
+        if lid:
+            current_set.discard(lid)
+    data = _gql(execute, "wire-label",
+                "mutation($id: String!, $input: IssueUpdateInput!) { "
+                "issueUpdate(id: $id, input: $input) { success "
+                "issue { id identifier title description url "
+                "labels { nodes { id name } } } } }",
+                {"id": locator["durable"],
+                 "input": {"labelIds": sorted(current_set)}})
+    if isinstance(data, TrackerError):
+        return data
+    mut = _require_success(data, "issueUpdate")
+    if isinstance(mut, TrackerError):
+        return mut
+    issue = mut.get("issue")
+    if not isinstance(issue, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear label returned no issue",
+                            subtype="malformed_body")
+    err = _check_durable("linear", locator, issue)
+    if err:
+        return err
+    out = _issue_out(issue)
+    if created:
+        out["labels_created"] = created
+    return out
+
+
+def assign(config: dict, locator: dict, execute: Execute, *,
+           add: list[str], remove: list[str]) -> Result:
+    parent = _require_parent(config, locator, execute)
+    if isinstance(parent, TrackerError):
+        return parent
+    if not add and not remove:
+        return TrackerError(ErrorClass.INVALID_INPUT,
+                            "assign requires --add and/or --remove", subtype="assign")
+    # Single-assignee: last --add REPLACES; report prior in degraded (R15).
+    previous = None
+    current = parent.get("assignee") if isinstance(parent.get("assignee"), dict) else None
+    current_id = current.get("id") if current else None
+    assignee_id = None
+    if add:
+        assignee_id = add[-1]
+        if current_id and current_id != assignee_id:
+            previous = current_id
+    elif remove:
+        if current_id in remove:
+            assignee_id = None
+            previous = current_id
+        else:
+            assignee_id = current_id
+    data = _gql(execute, "wire-assign",
+                "mutation($id: String!, $input: IssueUpdateInput!) { "
+                "issueUpdate(id: $id, input: $input) { success "
+                "issue { id identifier title description url assignee { id name } } } }",
+                {"id": locator["durable"],
+                 "input": {"assigneeId": assignee_id}})
+    if isinstance(data, TrackerError):
+        return data
+    mut = _require_success(data, "issueUpdate")
+    if isinstance(mut, TrackerError):
+        return mut
+    issue = mut.get("issue")
+    if not isinstance(issue, dict):
+        return TrackerError(ErrorClass.TRANSPORT, "linear assign returned no issue",
+                            subtype="malformed_body")
+    err = _check_durable("linear", locator, issue)
+    if err:
+        return err
+    out = _issue_out(issue)
+    if previous is not None and add:
+        out["degraded"] = {
+            "kind": "assignee_replaced",
+            "previous": previous,
+            "applied": assignee_id,
+        }
+    return out
+
+
+def list_open(config: dict, execute: Execute) -> Result:
+    ready_state = _ready_state(config)
+    if ready_state is None:
+        return {"issues": [], "truncated": False}
+    dest = _destination(config)
+    if isinstance(dest, TrackerError):
+        return dest
+    team_id = dest.get("teamId")
+    filt: dict = {"state": {"name": {"eqIgnoreCase": ready_state}}}
+    if team_id:
+        filt["team"] = {"id": {"eq": team_id}}
+
+    def pluck(data: dict) -> Union[dict, TrackerError]:
+        conn = data.get("issues")
+        if not isinstance(conn, dict):
+            return TrackerError(ErrorClass.TRANSPORT,
+                                "linear issues connection is malformed",
+                                subtype="malformed_body")
+        return conn
+
+    drained = _gql_connection_drain(
+        execute, "wire-list-open",
+        "query($filter: IssueFilter!, $after: String) { "
+        f"issues(first: {_PAGE_SIZE}, filter: $filter, after: $after) "
+        "{ nodes { id identifier title description url } "
+        "pageInfo { hasNextPage endCursor } } }",
+        {"filter": filt}, pluck)
+    if isinstance(drained, TrackerError):
+        return drained
+    nodes, truncated = drained
+    return {"issues": [_issue_out(i, parent_identity="not_available")
+                       for i in nodes],
+            "truncated": truncated}

--- a/.flow/config.json
+++ b/.flow/config.json
@@ -1,8 +1,13 @@
 {
+  "$schema": "https://flow-next.dev/schema/flow-config.schema.json",
   "artifacts": {
     "html": {
       "enabled": false
     }
+  },
+  "chart": {
+    "claimStaleAfter": 24,
+    "maxDecisions": 12
   },
   "land": {
     "automatedReviewers": "",
@@ -53,6 +58,7 @@
     "github": false
   },
   "tracker": {
+    "charts": "off",
     "conflictTiebreak": "always-ask",
     "enabled": true,
     "perEvent": {

--- a/.flow/meta.json
+++ b/.flow/meta.json
@@ -6,7 +6,7 @@
       "AGENTS.md": "de6b082414e956b3b8e2c02b2f7823bcabc1b18b96f56b3095191265d4e06d07"
     }
   },
-  "setup_date": "2026-07-26T11:57:11Z",
+  "setup_date": "2026-08-03T12:21:00Z",
   "setup_mode": "copy",
-  "setup_version": "3.5.0"
+  "setup_version": "3.13.1"
 }

--- a/.flow/specs/fn-114-reliable-watcher-reconciliation-for.json
+++ b/.flow/specs/fn-114-reliable-watcher-reconciliation-for.json
@@ -1,0 +1,24 @@
+{
+  "branch_name": "fix/atomic-write-watcher-sync",
+  "created_at": "2026-08-03T11:53:54.875025Z",
+  "depends_on_epics": [],
+  "id": "fn-114-reliable-watcher-reconciliation-for",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-114-reliable-watcher-reconciliation-for.md",
+  "status": "open",
+  "title": "Reliable watcher reconciliation for atomic writes and deletions",
+  "tracker": {
+    "baseHashFlow": null,
+    "baseHashTracker": null,
+    "depRelations": [],
+    "id": null,
+    "identifier": null,
+    "lastSyncedAt": null,
+    "mergeBaseFlow": null,
+    "mergeBaseTracker": null,
+    "url": null
+  },
+  "updated_at": "2026-08-03T11:56:36.026071Z"
+}

--- a/.flow/specs/fn-114-reliable-watcher-reconciliation-for.md
+++ b/.flow/specs/fn-114-reliable-watcher-reconciliation-for.md
@@ -1,0 +1,271 @@
+# Reliable watcher reconciliation for atomic writes and deletions
+
+## Goal
+
+Make continuous indexing reliable when the filesystem watcher reports an ambiguous or temporary path rather than the final eligible document path, while preserving GNO's incremental sync, collection filters, debounce behavior, and embedding/event semantics.
+
+## Scope decision
+
+This is a watcher-correctness bug fix. It is not a second indexing daemon, timer fallback, or broad ingestion rewrite.
+
+The implementation should treat filesystem events as **hints about a changed area**, not authoritative proof that the reported path is the final document path. Exact eligible-path events remain incremental. Ambiguous events may trigger a bounded reconciliation of the smallest affected directory.
+
+## Verified production evidence
+
+Environment: GNO 1.30.1, Bun on Linux, `gno serve` running continuously.
+
+1. The status endpoint reported the configured collections as actively watched.
+2. The process had active inotify descriptors and recursive watches.
+3. A normal `cp` of an eligible Markdown file into a watched collection became retrievable without `gno update` in approximately 2.5 seconds.
+4. An atomic writer created `.hermes-tmp.<id>` in the destination directory and renamed it to `final.md`.
+5. A standalone recursive Bun `fs.watch` observed only the temporary path for that write sequence; it did not report the final Markdown path.
+6. GNO did not index the resulting eligible Markdown file within repeated 45-second probes, including after restarting `gno serve`.
+7. Deleting an indexed eligible probe advanced watcher sync state, but the document remained retrievable until a full `gno update` marked it inactive.
+8. `gno update` successfully reconciled both missed additions and stale deletions, proving that full collection ingestion is correct enough to repair the index.
+
+The hidden-file probe is not evidence of a defect by itself: dotfiles may intentionally be excluded. The ordinary Markdown and copy probes establish the relevant contrast.
+
+## Current implementation and root-cause boundary
+
+### Proven atomic-write failure
+
+`src/serve/watch-service.ts` currently:
+
+1. receives `eventType` and `filename` from recursive `node:fs.watch`;
+2. converts `filename` to a collection-relative path;
+3. immediately applies `matchesWalkPath` using the current collection configuration;
+4. returns without queueing when the reported path is ineligible;
+5. calls `syncPaths` only for queued eligible paths.
+
+For an atomic save where Bun reports only `.hermes-tmp.<id>`, the callback rejects that path because it does not match the collection's eligible document rules. The final `*.md` path is never presented to `syncPaths`, so the document cannot be discovered.
+
+This is a generic mismatch between event shape and final filesystem state. The fix must not special-case Hermes or a particular temporary filename.
+
+### Deletion root cause is not yet proven
+
+`src/ingestion/sync.ts::syncPaths` already handles a known missing eligible path by marking active documents inactive, and `test/serve/watch-service.test.ts` contains green deletion coverage. Therefore the observed live deletion failure must not be attributed to `markInactive` without a failing reproduction.
+
+Likely causes include Linux event shape, path normalization, event coalescing, directory-level rename semantics, or a difference between the existing fake-watcher test and real Bun behavior. Task 1 must capture the real event sequence and produce a RED regression before product code changes.
+
+## Design decision
+
+### Exact-path fast path
+
+When the reported relative path is eligible under the **current** collection configuration:
+
+- preserve the existing debounce and `syncPaths` path;
+- preserve suppression semantics;
+- do not scan the directory;
+- emit/schedule only when ingestion reports a material add or update.
+
+### Bounded reconciliation path
+
+When an event cannot safely identify the final eligible path, queue the smallest trustworthy area—normally the reported path's parent directory—as dirty.
+
+At flush time, reconcile the direct eligible children of that directory against the active indexed documents whose relative paths are direct children of the same directory. Feed the deduplicated union of those relative paths through existing ingestion behavior.
+
+This provides both sides required for reconciliation:
+
+- eligible files now present on disk, including an atomic writer's unreported final path;
+- active indexed files no longer present, enabling normal missing-path deactivation.
+
+The implementation may choose an equivalent existing seam if inspection proves it smaller or safer. It must not perform an unbounded full-collection sync for every irrelevant event.
+
+### Noise control
+
+An ineligible event is not permission to index the ineligible file. Directory reconciliation must continue to use current collection include/exclude/pattern/reserved-path rules.
+
+The implementation must coalesce repeated events by collection and directory. Unchanged files must continue to short-circuit through ingestion, and a reconciliation batch must not cause duplicate `document-changed` events or redundant embedding work.
+
+## Requirements
+
+### R1 — Preserve incremental eligible-path sync
+
+Exact eligible create, update, and delete events continue through the existing per-path debounce/sync flow without widening to a directory scan.
+
+### R2 — Reconcile ambiguous atomic-write events
+
+When a filesystem event reports an ineligible or otherwise ambiguous path inside a watched collection, GNO can discover an eligible final file created by an atomic save in the same directory without manual `gno update`.
+
+Reconciliation is bounded to the smallest affected directory and does not hard-code Hermes, editor, or temporary-file naming conventions.
+
+### R3 — Deactivate deleted eligible documents
+
+A watched eligible file deleted after watcher readiness becomes inactive and is no longer retrievable without a full collection update.
+
+The implementation is based on a deterministic failing reproduction of the real event/path condition, not an assumed ingestion defect.
+
+### R4 — Preserve collection eligibility and safety rules
+
+Reconciliation consults the current collection configuration and preserves:
+
+- `pattern`, `include`, and `exclude` behavior;
+- dotfile, temporary, and reserved-path exclusions;
+- path normalization and collection-root containment;
+- configured limits and content-type behavior supplied through existing sync options;
+- suppression of known application-originated writes.
+
+Ineligible files remain unindexed even when their event causes directory reconciliation.
+
+### R5 — Coalesce work and emit only material changes
+
+Repeated or coalesced filesystem events for the same collection/directory result in one bounded reconciliation batch per debounce window.
+
+Unchanged files do not produce duplicate document-change notifications or redundant embedding scheduling. Adds and updates retain existing event/scheduler behavior. Deletions do not falsely announce content updates.
+
+### R6 — Respect live collection generations
+
+Queued work is evaluated against the current collection path, filters, sync options, and generation. A collection update, removal, root change, or service disposal cannot flush stale reconciliation work into the wrong configuration.
+
+### R7 — Expose enough diagnostics to distinguish event receipt from successful reconciliation
+
+Existing callbacks/state/logging, or a minimal compatible extension, must make it possible to determine:
+
+- that an ambiguous event was received;
+- which collection and bounded directory were reconciled;
+- whether reconciliation completed or failed;
+- that the watcher remains armed.
+
+Do not expand the public status schema unless necessary. Any schema change requires matching contract tests and documentation.
+
+### R8 — Deterministic regression coverage and Linux smoke proof
+
+Tests cover exact-path and ambiguous-event paths deterministically without fixed sleeps. A real temporary-directory smoke test on Linux captures Bun's event shape and proves the completed watch-to-index lifecycle where CI/runtime support allows it.
+
+## Non-goals
+
+- A cron, systemd timer, polling loop, or second watcher implementation
+- A full collection sync for every event
+- Special handling for `.hermes-tmp`, Vim, Emacs, Obsidian, or any named editor
+- Frontend changes
+- Reworking the embedding scheduler
+- Config-file hot reload beyond existing `updateCollections` semantics
+- Guaranteeing recursive discovery for an entire newly moved directory tree in this bug-fix slice
+- Solving platform/runtime defects that provide neither a filename nor a trustworthy affected directory; such cases must be diagnosed and specified separately
+
+## Implementation boundaries
+
+Primary files to inspect and likely modify:
+
+- `src/serve/watch-service.ts`
+- `test/serve/watch-service.test.ts`
+
+Only if no existing bounded query is adequate:
+
+- the store port/interface that exposes active document paths;
+- `src/store/sqlite/adapter.ts` or the narrow backing query;
+- focused store tests.
+
+Potential status/diagnostic contract files are in scope only when required by R7.
+
+Do not modify web UI code, unrelated ingestion pipelines, model code, or packaging.
+
+## Data and control flow
+
+```text
+fs.watch event
+  |
+  +-- exact eligible path --------------------+
+  |                                           |
+  +-- ambiguous/ineligible reported path      |
+        -> mark parent directory dirty        |
+        -> coalesce by collection+directory   |
+        -> enumerate direct eligible disk children
+        -> obtain active indexed direct children
+        -> union + dedupe --------------------+
+                                              |
+                                              v
+                                    existing syncPaths behavior
+                                              |
+                           +------------------+------------------+
+                           |                                     |
+                    add/update material                     missing path
+                           |                                     |
+                 event + embed scheduling                 mark inactive
+```
+
+## Test strategy
+
+### RED evidence gate
+
+Before product code changes:
+
+1. Record the exact Bun/Linux event sequence for:
+   - direct create/write;
+   - atomic temp-write plus rename;
+   - eligible file deletion;
+   - atomic replacement of an existing eligible file.
+2. Add a deterministic watcher test that injects the observed ambiguous event sequence and fails because the final eligible file is not synced.
+3. Add or adapt deletion coverage to reproduce the live stale-active condition; if the existing fake-watcher test cannot reproduce it, document the event-shape gap and add the smallest integration seam needed.
+4. Preserve the RED command/output as task evidence; do not weaken expectations to make the baseline pass.
+
+### Required automated cases
+
+- eligible file added after watcher readiness through an exact event;
+- eligible file updated through an exact event;
+- atomic create where only a temporary/ineligible event path is reported;
+- atomic replacement of an existing eligible file;
+- deletion of an indexed eligible file;
+- excluded dotfile/temp/reserved file remains unindexed;
+- unrelated excluded-path noise does not cause unbounded collection work;
+- repeated/coalesced events perform one reconciliation batch;
+- unchanged eligible neighbors produce no duplicate document events or embedding work;
+- collection filters changed before flush are honored;
+- collection removal/root change/disposal drops stale queued reconciliation safely;
+- reconciliation errors reach existing error/health diagnostics.
+
+Use explicit watcher-readiness and `onSettled`/callback synchronization rather than arbitrary sleeps.
+
+### Verification commands
+
+The implementation task must determine canonical package scripts from `package.json`, then run at minimum:
+
+```bash
+bun test test/serve/watch-service.test.ts
+bun test test/ingestion/ test/store/
+bunx tsc --noEmit
+git diff --check
+```
+
+Also run the repository's canonical lint/check command and the full relevant suite. Run a real Linux temporary-directory smoke test when supported, with deterministic cleanup and a hard timeout.
+
+## Risks and mitigations
+
+### Reconciliation amplification
+
+Risk: noisy temporary-file activity repeatedly scans directories.
+
+Mitigation: coalesce by collection+directory, enumerate only direct children, preserve debounce, and measure/assert batch counts.
+
+### Large directories
+
+Risk: one directory may contain many documents.
+
+Mitigation: remain directory-bounded, reuse eligibility filters, avoid content reads before `syncPaths`, and document/test acceptable behavior for a large fixture.
+
+### Path escape or stale config
+
+Risk: malformed relative paths or config mutation could reconcile outside the intended root.
+
+Mitigation: normalize and prove root containment; resolve work against current collection generation; discard stale queued work.
+
+### Duplicate events and embedding
+
+Risk: the exact path and ambiguous parent event both arrive for one save.
+
+Mitigation: deduplicate exact paths with reconciliation candidates in a single batch and rely on material sync results for notifications/scheduling.
+
+### Cross-platform differences
+
+Risk: macOS, Linux, and Windows report different event types and names.
+
+Mitigation: keep correctness independent of event type/name conventions, inject event sequences in deterministic tests, and keep one real Bun/Linux smoke proof for the reproduced defect.
+
+## Task order
+
+1. Capture watcher event shapes and establish RED regression coverage.
+2. Add the smallest bounded directory reconciliation/store seam.
+3. Integrate reconciliation into the watcher with config, lifecycle, dedupe, and diagnostics guarantees.
+4. Run integrated verification and document any contract-level behavior change.
+
+Implementation begins only after the Flow plan is reviewed and approved. This spec intentionally leaves `plan_review_status` as `unknown` and `ready` as `false` for Daniel's local implementation workflow.

--- a/.flow/templates/spec.md
+++ b/.flow/templates/spec.md
@@ -49,6 +49,16 @@ Discovery cascade (first match wins):
   2. <repo_root>/spec.md           (lowercase honored when uppercase absent)
   3. .flow/templates/spec.md       (project-local copy from /flow-next:setup)
   4. bundled ${PLUGIN_ROOT}/templates/spec.md  (this file — canonical source of truth)
+
+Customizing: adding sections and rewriting the guidance prose under any heading is
+free. Renaming or removing `## Acceptance Criteria`, `## Boundaries`,
+`## Goal & Context` or `## Decision Context` does NOT error - it silently degrades
+the features that parse them (R-ID coverage, PR "Not in this PR", interview scope
+routing, Decision Context shape detection).
+
+Full guide, incl. the known limitation for custom sections under an interview pass:
+flow-next docs, "Customizing the scaffold for your project"
+(plugins/flow-next/docs/spec-template.md - https://flow-next.dev/docs/spec-template/).
 -->
 
 # <spec-id> <Title>

--- a/.flow/usage.md
+++ b/.flow/usage.md
@@ -15,9 +15,14 @@ Task tracking for AI agents. All state lives in `.flow/`.
 
 - Specs: `fn-N-slug` where slug is derived from title (e.g., fn-1-add-oauth, fn-2-fix-login-bug)
 - Tasks: `fn-N-slug.M` (e.g., fn-1-add-oauth.1, fn-2-fix-login-bug.2)
+- Charts share the native `fn-N` domain with specs (never the same id)
 - Tracker-keyed ids coexist and resolve (`wor-17-slug`, `gh-123-slug`, `gl-456-slug`). Default: `config set tracker.specIds tracker`.
 
 **Backwards compatibility**: Legacy formats `fn-N`, `fn-N-xxx`, `fn-N.M`, and `fn-N-xxx.M` still work.
+
+## Chart (optional pre-capture discovery)
+
+One oversized/unclear idea whose **destination is nameable but route is not** (a direction like "make X more Y" is refused - narrow it or run prospect); one decision (`<chart-id>.D<n>`) per invocation; never a pilot stage. `chart frontier` is the sole work-mode selection input; `chart claim` then `chart resolve --answer-file` close it; every work invocation ends with one greppable `CHART_VERDICT=...` line. Chart never writes specs; capture ingests the briefing.
 
 ## Common Commands
 
@@ -67,7 +72,7 @@ claude -p "<self-contained prompt>" --output-format text --allowedTools "Read,Ba
 # the prompt, so `grok -p --always-approve "..."` misparses (live-verified failure mode).
 # Model + effort are separate flags: `-m grok-4.5 --reasoning-effort high` (NOT `-m grok-4.5-high`).
 grok -m grok-4.5 --reasoning-effort high -p "<self-contained prompt>" </dev/null             # read-only one-shot
-grok --permission-mode acceptEdits -m grok-4.5 --reasoning-effort high -p "<self-contained prompt>" </dev/null  # WRITE mode (edits files - run inside a trusted git dir; --always-approve = blanket). Extras: --check, --best-of-n N, --json-schema. Grok 4.5 = fast + cheap first-draft; route to bulk/implementation, not UI or final taste-critical work.
+grok --always-approve --no-plan -m grok-4.5 --reasoning-effort high -p "<self-contained prompt>" </dev/null  # WRITE mode (blanket; trusted git dir ONLY - acceptEdits skips Bash and silently truncates shell-using tasks). Extras: --check, --best-of-n N, --json-schema. Grok 4.5 = fast cheap first-draft; bulk/implementation, never taste-critical work.
 ```
 
 The codex bridge also works FROM a Codex host (same-family self-bridge): `codex exec -m gpt-5.6-terra -c model_reasoning_effort=medium "<prompt>"` steers a different GPT tier reliably even where `spawn_agent`/Multi-Agent-V2 per-spawn model steering is broken (openai/codex#33268 and friends, Jul 2026). Keep the child prompt flat - no nested subagents.


### PR DESCRIPTION
Refreshes the repo-local Flow-Next copy install from 3.5.0 to 3.13.1.

Mechanical: re-copies `flowctl` and its tracker package into `.flow/bin/`, refreshes `.flow/templates/spec.md` and `.flow/usage.md`, and stamps `setup_version` in `.flow/meta.json`. Generated by `/flow-next:setup` in copy mode; no hand edits.

Kept as-is: the curated model-routing block in AGENTS.md, and the existing FLOW-NEXT doc block (already current — `setup-block apply` reported `unchanged`). Note `CLAUDE.md` is a symlink to `AGENTS.md`, so the helper correctly refused it and wrote through the real file.

Split out of #183 to keep that review readable — it was 36,886 of its 43,920 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)