### PR TITLE
Bound local generation contextSize (issue #189)

### DIFF
--- a/.flow/specs/fn-117-bound-local-generation-contextsize.json
+++ b/.flow/specs/fn-117-bound-local-generation-contextsize.json
@@ -1,0 +1,24 @@
+{
+  "branch_name": "fn-117-bound-local-generation-contextsize",
+  "created_at": "2026-08-07T20:24:32.132845Z",
+  "depends_on_epics": [],
+  "id": "fn-117-bound-local-generation-contextsize",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-117-bound-local-generation-contextsize.md",
+  "status": "open",
+  "title": "Bound local generation contextSize (issue #189)",
+  "tracker": {
+    "baseHashFlow": null,
+    "baseHashTracker": null,
+    "depRelations": [],
+    "id": null,
+    "identifier": null,
+    "lastSyncedAt": null,
+    "mergeBaseFlow": null,
+    "mergeBaseTracker": null,
+    "url": null
+  },
+  "updated_at": "2026-08-07T20:25:02.367016Z"
+}

--- a/.flow/specs/fn-117-bound-local-generation-contextsize.json
+++ b/.flow/specs/fn-117-bound-local-generation-contextsize.json
@@ -20,5 +20,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-08-07T20:25:02.367016Z"
+  "updated_at": "2026-08-07T20:26:45.585485Z"
 }

--- a/.flow/specs/fn-117-bound-local-generation-contextsize.md
+++ b/.flow/specs/fn-117-bound-local-generation-contextsize.md
@@ -1,6 +1,6 @@
-# Bound local generation contextSize (issue #189)
+# fn-117 Bound local generation contextSize (issue #189)
 
-## Problem
+## Goal & Context
 
 Local GGUF generation (node-llama-cpp backend) never passes `contextSize` to
 `createContext`. node-llama-cpp defaults to `contextSize: "auto"`, which grows
@@ -10,47 +10,62 @@ cache (~2.5 GB) exceeds its weights (~2.4 GB) and peak usage hits ~7.8/8 GB —
 OOM risk with nothing else running.
 
 Reported in https://github.com/gmickel/gno/issues/189 by @fightp86 with VRAM
-measurements. Verified against HEAD:
+measurements. Verified against HEAD: `src/llm/nodeLlamaCpp/generation.ts`
+passed `undefined` to `createContext` when no `contextSize` param was
+supplied; `src/pipeline/answer.ts` (grounded answers) passes no `contextSize`;
+`src/pipeline/claim-verifier.ts` (missed by the reporter) also passes none —
+a second unbounded call site. Expansion (`expandContextSize`, default 2048)
+and embedding (`embeddingContextSize`) already bound their contexts;
+generation was the only unbounded family.
 
-- `src/llm/nodeLlamaCpp/generation.ts` passed `undefined` to `createContext`
-  when no `contextSize` param was supplied.
-- `src/pipeline/answer.ts` (grounded answers) passes no `contextSize`.
-- `src/pipeline/claim-verifier.ts` (missed by the reporter) also passes none —
-  second unbounded call site.
-- Expansion (`expandContextSize`, default 2048) and embedding
-  (`embeddingContextSize`) already bound their contexts; generation was the
-  only unbounded family.
+## Architecture & Data Models
 
-## Requirements
+Adapter-level dynamic bound in `NodeLlamaCppGeneration.generate`
+(`src/llm/nodeLlamaCpp/generation.ts`): a pure exported helper
+`resolveGenContextSize({promptTokenCount, maxTokens, trainContextSize})`
+computes prompt tokens + output budget + 512-token margin, floored at 1024
+and capped at the model's trained context size when known. Prompt tokens come
+from `llamaModel.tokenize(prompt).length`. Fixes all callers (answer,
+claim-verifier) without config plumbing. A `genContextSize` config knob was
+considered and deferred as YAGNI — dynamic prompt-sized contexts are already
+minimal.
 
-- R1: When no explicit `contextSize` is supplied, local generation must size
-  the context to actual need — prompt tokens + output budget + margin — never
-  node-llama-cpp "auto".
-- R2: The computed size is floored (1024) and capped at the model's trained
-  context size when known.
+## Edge Cases & Constraints
+
+- A flat default (e.g. 8192) is NOT acceptable — claim-verifier prompts may
+  reach `MAX_PROMPT_BYTES` (256 KB ≈ ~65K tokens); sizing must be dynamic per
+  prompt.
+- Unknown or non-positive `trainContextSize` → use the uncapped dynamic size.
+- Explicit `contextSize` params (expansion path) keep prior behavior.
+
+## Acceptance Criteria
+
+- R1: When no explicit `contextSize` is supplied, local generation sizes the
+  context to actual need (prompt tokens + output budget + margin) — never
+  node-llama-cpp "auto"; `createContext` always receives an explicit bounded
+  `contextSize`.
+- R2: The computed size is floored at 1024 tokens and capped at the model's
+  trained context size when known; unknown/non-positive trained size falls
+  back to the uncapped dynamic value.
 - R3: Explicit `contextSize` params (expansion path) keep prior behavior.
-- R4: A flat default (e.g. 8192) is NOT acceptable — claim-verifier prompts
-  may reach `MAX_PROMPT_BYTES` (256 KB ≈ ~65K tokens); sizing must be dynamic
-  per prompt.
-- R5: Regression test covering the sizing resolver (margin math, floor, cap,
-  unknown/non-positive trained size).
+- R4: Regression tests cover the sizing resolver: margin math, floor, cap,
+  unknown and non-positive trained size.
+- R5: CHANGELOG [Unreleased] entry credits @fightp86 and links issue #189;
+  `bun test` and `bun run lint:check` green.
 
-## Approach
+## Boundaries
 
-Adapter-level dynamic bound in `NodeLlamaCppGeneration.generate`: extract a
-pure `resolveGenContextSize({promptTokenCount, maxTokens, trainContextSize})`
-helper; compute prompt tokens via `llamaModel.tokenize(prompt).length`. Fixes
-all callers (answer, claim-verifier) without config plumbing. A
-`genContextSize` config knob was considered and deferred as YAGNI — dynamic
-prompt-sized contexts are already minimal.
+- No `genContextSize` config knob in this change — deferred as YAGNI; dynamic
+  prompt-sized contexts are already minimal. Revisit only if users need a hard
+  ceiling below prompt size.
+- No changes to the expansion or embedding context sizing paths — they are
+  already bounded.
+- No HTTP/remote generation changes — remote backends manage their own
+  context.
 
-## Acceptance criteria
+## Decision Context
 
-- `createContext` always receives an explicit bounded `contextSize`.
-- `bun test` green; `bun run lint:check` clean.
-- CHANGELOG entry crediting @fightp86.
-
-## Tasks
-
-1. Implement bounded context sizing in generation adapter + regression test +
-   changelog. (satisfies: R1, R2, R3, R4, R5)
+Chose adapter-level dynamic sizing over the issue's suggested flat 8192
+default because claim-verifier prompts can reach ~65K tokens — a flat cap
+would break large verifier runs, while per-prompt sizing bounds VRAM without
+regressing capability.

--- a/.flow/specs/fn-117-bound-local-generation-contextsize.md
+++ b/.flow/specs/fn-117-bound-local-generation-contextsize.md
@@ -40,17 +40,17 @@ minimal.
 
 ## Acceptance Criteria
 
-- R1: When no explicit `contextSize` is supplied, local generation sizes the
+- **R1:** When no explicit `contextSize` is supplied, local generation sizes the
   context to actual need (prompt tokens + output budget + margin) — never
   node-llama-cpp "auto"; `createContext` always receives an explicit bounded
   `contextSize`.
-- R2: The computed size is floored at 1024 tokens and capped at the model's
+- **R2:** The computed size is floored at 1024 tokens and capped at the model's
   trained context size when known; unknown/non-positive trained size falls
   back to the uncapped dynamic value.
-- R3: Explicit `contextSize` params (expansion path) keep prior behavior.
-- R4: Regression tests cover the sizing resolver: margin math, floor, cap,
+- **R3:** Explicit `contextSize` params (expansion path) keep prior behavior.
+- **R4:** Regression tests cover the sizing resolver: margin math, floor, cap,
   unknown and non-positive trained size.
-- R5: CHANGELOG [Unreleased] entry credits @fightp86 and links issue #189;
+- **R5:** CHANGELOG [Unreleased] entry credits @fightp86 and links issue #189;
   `bun test` and `bun run lint:check` green.
 
 ## Boundaries

--- a/.flow/specs/fn-117-bound-local-generation-contextsize.md
+++ b/.flow/specs/fn-117-bound-local-generation-contextsize.md
@@ -1,0 +1,56 @@
+# Bound local generation contextSize (issue #189)
+
+## Problem
+
+Local GGUF generation (node-llama-cpp backend) never passes `contextSize` to
+`createContext`. node-llama-cpp defaults to `contextSize: "auto"`, which grows
+the context/KV cache to fill available VRAM up to the model's trained context
+length. On small GPUs (reporter: 8 GB RTX 5060 Laptop) the gen model's KV
+cache (~2.5 GB) exceeds its weights (~2.4 GB) and peak usage hits ~7.8/8 GB —
+OOM risk with nothing else running.
+
+Reported in https://github.com/gmickel/gno/issues/189 by @fightp86 with VRAM
+measurements. Verified against HEAD:
+
+- `src/llm/nodeLlamaCpp/generation.ts` passed `undefined` to `createContext`
+  when no `contextSize` param was supplied.
+- `src/pipeline/answer.ts` (grounded answers) passes no `contextSize`.
+- `src/pipeline/claim-verifier.ts` (missed by the reporter) also passes none —
+  second unbounded call site.
+- Expansion (`expandContextSize`, default 2048) and embedding
+  (`embeddingContextSize`) already bound their contexts; generation was the
+  only unbounded family.
+
+## Requirements
+
+- R1: When no explicit `contextSize` is supplied, local generation must size
+  the context to actual need — prompt tokens + output budget + margin — never
+  node-llama-cpp "auto".
+- R2: The computed size is floored (1024) and capped at the model's trained
+  context size when known.
+- R3: Explicit `contextSize` params (expansion path) keep prior behavior.
+- R4: A flat default (e.g. 8192) is NOT acceptable — claim-verifier prompts
+  may reach `MAX_PROMPT_BYTES` (256 KB ≈ ~65K tokens); sizing must be dynamic
+  per prompt.
+- R5: Regression test covering the sizing resolver (margin math, floor, cap,
+  unknown/non-positive trained size).
+
+## Approach
+
+Adapter-level dynamic bound in `NodeLlamaCppGeneration.generate`: extract a
+pure `resolveGenContextSize({promptTokenCount, maxTokens, trainContextSize})`
+helper; compute prompt tokens via `llamaModel.tokenize(prompt).length`. Fixes
+all callers (answer, claim-verifier) without config plumbing. A
+`genContextSize` config knob was considered and deferred as YAGNI — dynamic
+prompt-sized contexts are already minimal.
+
+## Acceptance criteria
+
+- `createContext` always receives an explicit bounded `contextSize`.
+- `bun test` green; `bun run lint:check` clean.
+- CHANGELOG entry crediting @fightp86.
+
+## Tasks
+
+1. Implement bounded context sizing in generation adapter + regression test +
+   changelog. (satisfies: R1, R2, R3, R4, R5)

--- a/.flow/tasks/fn-117-bound-local-generation-contextsize.1.json
+++ b/.flow/tasks/fn-117-bound-local-generation-contextsize.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-07T20:25:02.756591Z",
+  "depends_on": [],
+  "id": "fn-117-bound-local-generation-contextsize.1",
+  "priority": null,
+  "spec": "fn-117-bound-local-generation-contextsize",
+  "spec_path": ".flow/tasks/fn-117-bound-local-generation-contextsize.1.md",
+  "status": "todo",
+  "title": "Bound generation contextSize + regression test + changelog",
+  "updated_at": "2026-08-07T20:25:02.756591Z"
+}

--- a/.flow/tasks/fn-117-bound-local-generation-contextsize.1.json
+++ b/.flow/tasks/fn-117-bound-local-generation-contextsize.1.json
@@ -1,14 +1,14 @@
 {
-  "assignee": null,
+  "assignee": "gordon.mickel@gmail.com",
   "claim_note": "",
-  "claimed_at": null,
+  "claimed_at": "2026-08-07T20:25:15.476305Z",
   "created_at": "2026-08-07T20:25:02.756591Z",
   "depends_on": [],
   "id": "fn-117-bound-local-generation-contextsize.1",
   "priority": null,
   "spec": "fn-117-bound-local-generation-contextsize",
   "spec_path": ".flow/tasks/fn-117-bound-local-generation-contextsize.1.md",
-  "status": "todo",
+  "status": "done",
   "title": "Bound generation contextSize + regression test + changelog",
-  "updated_at": "2026-08-07T20:25:02.756591Z"
+  "updated_at": "2026-08-07T20:25:16.089470Z"
 }

--- a/.flow/tasks/fn-117-bound-local-generation-contextsize.1.md
+++ b/.flow/tasks/fn-117-bound-local-generation-contextsize.1.md
@@ -1,0 +1,24 @@
+# fn-117-bound-local-generation-contextsize.1 Bound generation contextSize + regression test + changelog
+
+## Description
+TBD
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+Implemented bounded context sizing for local GGUF generation (issue #189).
+
+- Added `resolveGenContextSize` in `src/llm/nodeLlamaCpp/generation.ts`:
+  prompt tokens + maxTokens + 512 margin, floor 1024, capped at the model's
+  trained context size. `generate()` now always passes an explicit
+  `contextSize` to `createContext` (explicit params keep prior behavior).
+- Regression test `test/llm/node-generation-context-size.test.ts` (5 cases:
+  margin math, floor, cap, unknown and non-positive trained size).
+- CHANGELOG [Unreleased] Fixed entry crediting @fightp86.
+
+Full suite green: 4034 pass / 0 fail; lint:check clean (type-aware).
+## Evidence
+- Commits: b578db56
+- Tests: bun test, bun run lint:check
+- PRs:

--- a/.flow/tasks/fn-117-bound-local-generation-contextsize.1.md
+++ b/.flow/tasks/fn-117-bound-local-generation-contextsize.1.md
@@ -1,10 +1,21 @@
+---
+satisfies: [R1, R2, R3, R4, R5]
+---
 # fn-117-bound-local-generation-contextsize.1 Bound generation contextSize + regression test + changelog
 
 ## Description
-TBD
+Add `resolveGenContextSize` to the node-llama-cpp generation adapter so
+`createContext` always receives an explicit bounded `contextSize` (prompt
+tokens + output budget + margin, floored at 1024, capped at trained context
+size), replacing the VRAM-hungry "auto" default. Add regression tests and a
+CHANGELOG entry crediting @fightp86 (issue #189).
 
 ## Acceptance
-- [ ] TBD
+- [x] `createContext` always receives an explicit bounded `contextSize`
+- [x] Resolver floors at 1024 and caps at trained context size
+- [x] Explicit `contextSize` params keep prior behavior
+- [x] Regression tests cover margin math, floor, cap, unknown/non-positive trained size
+- [x] CHANGELOG entry credits @fightp86; `bun test` + `bun run lint:check` green
 
 ## Done summary
 Implemented bounded context sizing for local GGUF generation (issue #189).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed local GGUF generation (answers and claim verification) consuming all
+  available VRAM: `contextSize` was never passed to node-llama-cpp, whose
+  `"auto"` default grows the KV cache up to the model's trained context
+  length. Generation contexts are now sized to the actual prompt plus output
+  budget, capped at the trained context size. Thanks @fightp86 for the
+  detailed report and VRAM measurements ([#189](https://github.com/gmickel/gno/issues/189)).
+
 ## [1.34.1] - 2026-08-07
 
 ### Added

--- a/src/llm/nodeLlamaCpp/generation.ts
+++ b/src/llm/nodeLlamaCpp/generation.ts
@@ -60,6 +60,29 @@ const DEFAULT_TEMPERATURE = 0;
 const DEFAULT_SEED = 42;
 const DEFAULT_MAX_TOKENS = 256;
 
+// Context sizing: without an explicit contextSize, node-llama-cpp defaults to
+// "auto", which grows the KV cache to fill available VRAM up to the model's
+// trained context length (OOM risk on small GPUs — see issue #189). Instead,
+// size the context to what the call actually needs: prompt tokens + output
+// budget + margin for chat-template wrapping and special tokens.
+const GEN_CONTEXT_MARGIN_TOKENS = 512;
+const GEN_CONTEXT_MIN_TOKENS = 1024;
+
+export const resolveGenContextSize = (input: {
+  promptTokenCount: number;
+  maxTokens: number;
+  trainContextSize?: number;
+}): number => {
+  const needed = Math.max(
+    GEN_CONTEXT_MIN_TOKENS,
+    input.promptTokenCount + input.maxTokens + GEN_CONTEXT_MARGIN_TOKENS
+  );
+  if (input.trainContextSize && input.trainContextSize > 0) {
+    return Math.min(needed, input.trainContextSize);
+  }
+  return needed;
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Implementation
 // ─────────────────────────────────────────────────────────────────────────────
@@ -97,9 +120,14 @@ export class NodeLlamaCppGeneration implements GenerationPort {
             await this.manager.getLlama()
           ).createGrammarForJsonSchema(params.jsonSchema as JsonGrammarSchema)
         : undefined;
-      context = await llamaModel.createContext(
-        params?.contextSize ? { contextSize: params.contextSize } : undefined
-      );
+      const contextSize =
+        params?.contextSize ??
+        resolveGenContextSize({
+          promptTokenCount: llamaModel.tokenize(prompt).length,
+          maxTokens: params?.maxTokens ?? DEFAULT_MAX_TOKENS,
+          trainContextSize: llamaModel.trainContextSize,
+        });
+      context = await llamaModel.createContext({ contextSize });
       // Import LlamaChatSession dynamically
       const { LlamaChatSession } = await import("node-llama-cpp");
       const session = new LlamaChatSession({

--- a/test/llm/node-generation-context-size.test.ts
+++ b/test/llm/node-generation-context-size.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveGenContextSize } from "../../src/llm/nodeLlamaCpp/generation";
+
+// Regression for issue #189: local generation never set contextSize, so
+// node-llama-cpp fell back to "auto" and grew the KV cache to fill all
+// available VRAM. The resolver must always produce a bounded size.
+describe("resolveGenContextSize", () => {
+  test("sizes the context to prompt + output + margin", () => {
+    expect(
+      resolveGenContextSize({
+        promptTokenCount: 3000,
+        maxTokens: 512,
+        trainContextSize: 262_144,
+      })
+    ).toBe(3000 + 512 + 512);
+  });
+
+  test("never returns less than the minimum context size", () => {
+    expect(
+      resolveGenContextSize({
+        promptTokenCount: 10,
+        maxTokens: 32,
+        trainContextSize: 262_144,
+      })
+    ).toBe(1024);
+  });
+
+  test("caps at the model's trained context size", () => {
+    expect(
+      resolveGenContextSize({
+        promptTokenCount: 70_000,
+        maxTokens: 512,
+        trainContextSize: 32_768,
+      })
+    ).toBe(32_768);
+  });
+
+  test("handles unknown trained context size", () => {
+    expect(
+      resolveGenContextSize({
+        promptTokenCount: 5000,
+        maxTokens: 256,
+      })
+    ).toBe(5000 + 256 + 512);
+  });
+
+  test("ignores non-positive trained context size", () => {
+    expect(
+      resolveGenContextSize({
+        promptTokenCount: 5000,
+        maxTokens: 256,
+        trainContextSize: 0,
+      })
+    ).toBe(5000 + 256 + 512);
+  });
+});


### PR DESCRIPTION
# Bound local generation contextSize (issue #189)

Local GGUF generation never passed `contextSize` to `createContext`, so node-llama-cpp's "auto" default grew the KV cache to fill available VRAM up to the model's trained context length — OOM risk on small GPUs (reported with VRAM measurements in #189).

> **Spec:** [fn-117-bound-local-generation-contextsize](https://github.com/gmickel/gno/blob/a82de898c593201f0be259dbd8da9f4f59583fee/.flow/specs/fn-117-bound-local-generation-contextsize.md)
> **Branch:** `fix/gen-context-size` → `main`
> **Tasks:** 1 completed
> **R-ID coverage:** 5/5 satisfied

## TL;DR

- Local generation (grounded answers and claim verification) now sizes its node-llama-cpp context to the actual prompt plus output budget instead of the VRAM-filling "auto" default.
- A new pure resolver computes prompt tokens + output budget + a 512-token margin, floored at 1024 and capped at the model's trained context size.
- Five regression tests pin the resolver's bounds; the CHANGELOG credits @fightp86 for the report and VRAM measurements.

## Not in this PR (by design)

- No `genContextSize` config knob in this change — deferred as YAGNI; dynamic prompt-sized contexts are already minimal. Revisit only if users need a hard…
- No changes to the expansion or embedding context sizing paths — they are already bounded.
- No HTTP/remote generation changes — remote backends manage their own context.

## The change, top to bottom

Local GGUF generation now sizes its node-llama-cpp context to the actual prompt plus output budget (capped at the trained context size) instead of the VRAM-filling &quot;auto&quot; default, fixing OOM on small GPUs (issue #189).

| Proof | Value | Sources |
|---|---|---|
| Artifact | `aid-fn-117-a82de898c593` | artifact identity |
| Base commit | `f9e4effd28e67239156eb863f18be938ec2cab4e` | artifact currentness |
| Head commit | `a82de898c593201f0be259dbd8da9f4f59583fee` | artifact identity |
| Human-review lines | 98 | deterministic file stats |
| Canonical files | 3 | deterministic membership |
| Total files | 7 | deterministic membership |
| Tests | bun test — 4034 pass / 0 fail | source:s-task1 |
| Lint | bun run lint:check clean (type-aware) | source:s-task1 |
| R-ID coverage | 5/5 acceptance criteria satisfied by fn-117-bound-local-generation-contextsize.1 | source:s-task1, source:s-r1, source:s-r2, source:s-r3, source:s-r4, source:s-r5 |

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `src/llm/nodeLlamaCpp/generation.ts` | Adds resolveGenContextSize and wires it into generate(); createContext no longer receives undefined. | +31/-3 | — | source:s-diff, source:s-r1, source:s-r2, source:s-r3, source:s-task1, R-ID:R1, R-ID:R2, R-ID:R3, task:fn-117-bound-local-generation-contextsize.1 |
| `NEW` | `CANONICAL` | `test/llm/node-generation-context-size.test.ts` | New unit suite covering resolveGenContextSize bounds. | +57/-0 | — | source:s-diff, source:s-r4, source:s-task1, R-ID:R4, task:fn-117-bound-local-generation-contextsize.1 |
| `MODIFIED` | `CANONICAL` | `CHANGELOG.md` | Fixed entry for the unbounded generation contextSize. | +7/-0 | — | source:s-diff, source:s-r5, source:s-task1, R-ID:R5, task:fn-117-bound-local-generation-contextsize.1 |

## Critical changes

- **High-churn:** [`test/llm/node-generation-context-size.test.ts`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-a492db88a9348b671d04e42d57ec2f1447def8b13d9c507c02fa1e26dc1bf83b) (+57/-0 lines)
- **High-churn:** [`src/llm/nodeLlamaCpp/generation.ts`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-eec4b55310a3aafa1d688529e284e13056503b033875053599034311fc7a63b4) (+31/-3 lines)
- **Cross-module:** test/llm imports src/llm (new)

## How to review this PR

The pipeline already verified this — you don't re-check it from scratch:
- **Tests / gates:** fn-117-bound-local-generation-contextsize.1 — `bun test` (4034 pass / 0 fail) · `bun run lint:check` (type-aware, clean)
- **R-ID coverage:** 5/5 acceptance criteria satisfied — see the walkthrough above
- **Cross-model review:** no cross-model review recorded on this PR

Your job — the calls the pipeline can't make:
- Line-review the **Must review** bucket below — the one file carrying real judgment risk.
- Spot-check the verified claims above; sample, don't re-run everything.
- Own what machines can't judge: is the 512-token margin + 1024 floor the right sizing policy?

## Review plan

### Must review (~15%)

- [ ] 🔴 [`src/llm/nodeLlamaCpp/generation.ts`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-eec4b55310a3aafa1d688529e284e13056503b033875053599034311fc7a63b4) — high-churn source file and the sole behavior change — Is prompt-token counting via `llamaModel.tokenize(prompt).length` plus the 512-token margin enough headroom for chat-template wrapping, and does the trained-context cap behave when the prompt alone exceeds it? — open `resolveGenContextSize` and the `generate()` wiring

### Spot-check

- [ ] 🟡 [`test/llm/node-generation-context-size.test.ts`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-a492db88a9348b671d04e42d57ec2f1447def8b13d9c507c02fa1e26dc1bf83b) — do the five cases actually pin the bounds you'd want (margin math, floor, cap, unknown/non-positive trained size)?
- [ ] 🟡 [`CHANGELOG.md`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) — entry accuracy and credit.

### Safe to skim (~60%)

- [ ] ⚪ 4 `.flow/` spec/task files — task-state, not hand-written code — skim

## Structural changes

The regression suite adds a new test module that imports the generation adapter directly: [`test/llm/node-generation-context-size.test.ts`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-a492db88a9348b671d04e42d57ec2f1447def8b13d9c507c02fa1e26dc1bf83b) imports `resolveGenContextSize` from [`src/llm/nodeLlamaCpp/generation.ts`](https://github.com/gmickel/gno/commit/b578db5661ba56f41eec6fbea725de17acb6be4e#diff-eec4b55310a3aafa1d688529e284e13056503b033875053599034311fc7a63b4). That export is new — the sizing logic was extracted into a pure helper precisely so the bounds could be tested without loading a GGUF model. No production module boundaries changed; the only new dependency edge is test-to-source.

```mermaid
flowchart LR
  tests["test/llm/node-generation-context-size.test.ts"] --> gen["src/llm/nodeLlamaCpp/generation.ts (resolveGenContextSize)"]
```

---

*Generated by `/flow-next:make-pr` from [fn-117-bound-local-generation-contextsize](https://github.com/gmickel/gno/blob/a82de898c593201f0be259dbd8da9f4f59583fee/.flow/specs/fn-117-bound-local-generation-contextsize.md) against `origin/main` on 2026-08-07.*
<!-- flow-next:make-pr spec=fn-117-bound-local-generation-contextsize base=origin/main -->
