### PR TITLE
fix(skill): honor the global --json flag for skill install/uninstall/paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gno skill install|uninstall|paths --json` printed human-readable text when
+  the global `--json` flag was consumed by the root program; the subcommands
+  now fall back to the global flag like every other command.
+
 ## [1.39.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `gno skill install|uninstall|paths --json` printed human-readable text when
-  the global `--json` flag was consumed by the root program; the subcommands
-  now fall back to the global flag like every other command.
+- `gno skill install --json`, `gno skill uninstall --json`, and
+  `gno skill paths --json` printed human-readable text when the global
+  `--json` flag was consumed by the root program; the subcommands now fall
+  back to the global flag like every other command.
 
 ## [1.39.0] - 2026-09-02
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -3201,7 +3201,9 @@ function wireSkillCommands(program: Command): void {
           | "hermes"
           | "all",
         force: Boolean(cmdOpts.force),
-        json: Boolean(cmdOpts.json),
+        // The root program also defines a global --json and may consume the
+        // flag; leave undefined here so the runner falls back to globals.
+        json: cmdOpts.json === true ? true : undefined,
       });
     });
 
@@ -3252,7 +3254,7 @@ function wireSkillCommands(program: Command): void {
           | "openclaw"
           | "hermes"
           | "all",
-        json: Boolean(cmdOpts.json),
+        json: cmdOpts.json === true ? true : undefined,
       });
     });
 
@@ -3316,7 +3318,7 @@ function wireSkillCommands(program: Command): void {
           | "openclaw"
           | "hermes"
           | "all",
-        json: Boolean(cmdOpts.json),
+        json: cmdOpts.json === true ? true : undefined,
       });
     });
 }


### PR DESCRIPTION
`gno skill install --json` (and `uninstall`, `paths`) printed human-readable text: the subcommands passed `json: Boolean(cmdOpts.json)`, and when the root program consumed the global `--json` flag the subcommand saw `undefined` → `false`, overriding the global. Every other command uses `cmdOpts.json === true ? true : undefined` so the runner falls back to globals; this aligns the three skill sites.

Verified live:

```
bun src/index.ts skill paths --json      → {"paths":[...]}
bun src/index.ts skill install --scope user --target hermes --force --json → {"installed":[...]}
bun src/index.ts skill uninstall --scope project --target hermes --json → {"error":{"code":"VALIDATION",...}}
```

`bun test test/cli/skill.test.ts` 34/34, lint clean. Found while installing the 1.39.0 skills.