### PR TITLE
feat: add --query-file for search and query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gno search` and `gno query` accept `--query-file <path>` (`-` reads stdin) so
+  desktop callers can keep the query off argv.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `gno search` and `gno query` accept `--query-file <path>` (`-` reads stdin) so
-  desktop callers can keep the query off argv.
-
 ### Changed
 
 ### Fixed
+
+## [1.39.2] - 2026-09-02
+
+### Added
+
+- `gno search` and `gno query` accept `--query-file <path>` (`-` reads stdin) so
+  desktop callers can keep the query off argv.
 
 ## [1.39.1] - 2026-09-02
 
@@ -2325,7 +2329,8 @@ Re-release of 1.0.2 with a CHANGELOG formatting fix so the Publish workflow's
 | 0.4.0   | 2026-01-01 | Web UI and REST API                        |
 | 0.1.0   | 2025-12-30 | Initial release with full search pipeline  |
 
-[Unreleased]: https://github.com/gmickel/gno/compare/v1.39.1...HEAD
+[Unreleased]: https://github.com/gmickel/gno/compare/v1.39.2...HEAD
+[1.39.2]: https://github.com/gmickel/gno/compare/v1.39.1...v1.39.2
 [1.39.1]: https://github.com/gmickel/gno/compare/v1.39.0...v1.39.1
 [1.39.0]: https://github.com/gmickel/gno/compare/v1.38.0...v1.39.0
 [1.38.0]: https://github.com/gmickel/gno/compare/v1.37.1...v1.38.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [1.39.2] - 2026-09-02
+## [1.39.2] - 2026-09-03
 
 ### Added
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -227,6 +227,8 @@ gno search "project deadlines"
 gno search "error handling" -n 5
 gno search "auth" --json
 gno search "meeting" --files
+gno search --query-file /run/user/1000/gno-recall/q.XXXX --json
+printf '%s' "auth" | gno search --query-file - --json
 ```
 
 **Document-level indexing**: Finds documents where terms appear anywhere, even across sections. "authentication JWT" matches docs with those terms in different parts.
@@ -245,6 +247,7 @@ gno search "meeting" --files
 
 Options:
 
+- `--query-file <path>` - Read the query from a file (`-` reads stdin). Keeps the query off argv. Do not also pass a positional query.
 - `-n, --limit <n>` - Limit results (default: 5; 20 with --json/--files)
 - `--min-score <n>` - Minimum score threshold (0-1)
 - `--full` - Show full document content (not just snippet)
@@ -308,6 +311,7 @@ Hybrid search combining BM25 and vector results. This is the recommended search 
 
 ```bash
 gno query "database optimization"
+gno query --query-file /run/user/1000/gno-recall/q.XXXX --json
 gno query "API design patterns" --explain
 gno query "auth" --fast              # Fastest: ~0.7s
 gno query "auth" --thorough          # Full pipeline: ~5-8s
@@ -339,6 +343,7 @@ gno query $'auth flow\nterm: "refresh token"\nintent: token rotation'
 
 Additional options:
 
+- `--query-file <path>` - Same as `gno search`. Invalid with a positional query and invalid on `query diagnose`.
 - `--fast` - Skip query expansion and reranking (fastest, ~0.7s)
 - `--thorough` - Use the widest retrieval/rerank budget (slower, best recall)
 - `--no-expand` - Disable query expansion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmickel/gno",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "description": "Local semantic search for your documents. Index Markdown, PDF, and Office files with hybrid BM25 + vector search.",
   "keywords": [
     "embeddings",

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -1346,6 +1346,7 @@ gno query diagnose <query> --target <doc> [-n <num>] [--min-score <num>] [-c <co
 **Additional Options:**
 | Option | Type | Description |
 |--------|------|-------------|
+| `--query-file` | string | Same as `gno search`: read the query from a file (`-` is stdin). Invalid with a positional query and invalid on `query diagnose`. |
 | `--no-expand` | boolean | Disable query expansion |
 | `--no-rerank` | boolean | Disable cross-encoder reranking |
 | `--graph` | boolean | Explicitly enable the default bounded one-hop graph neighbor expansion |
@@ -1358,7 +1359,7 @@ gno query diagnose <query> --target <doc> [-n <num>] [--min-score <num>] [-c <co
 | `--target` | ref | Required for `query diagnose`; target document to diagnose |
 
 `query diagnose` accepts the same `--project-root` and
-`--no-project-affinity` controls as `query`.
+`--no-project-affinity` controls as `query`. It rejects `--query-file`.
 
 **Compatibility / Migration:**
 

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -1194,7 +1194,7 @@ BM25 keyword search over indexed documents.
 **Synopsis:**
 
 ```bash
-gno search <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--json|--files|--csv|--md|--xml]
+gno search [query] [--query-file <path>] [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--json|--files|--csv|--md|--xml]
 ```
 
 **Arguments:**
@@ -1204,24 +1204,25 @@ gno search <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <da
 
 **Options:**
 
-| Option                  | Type     | Default                   | Description                                                                                   |
-| ----------------------- | -------- | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `-n`                    | integer  | 5 (20 for --json/--files) | Max results                                                                                   |
-| `--min-score`           | number   | 0                         | Minimum score threshold                                                                       |
-| `-c, --collection`      | string   | all                       | Filter to collection                                                                          |
-| `--since`               | string   | none                      | Modified-at lower bound (ISO date/time or relative token)                                     |
-| `--until`               | string   | none                      | Modified-at upper bound (ISO date/time or relative token)                                     |
-| `--category`            | string   | none                      | Filter to docs with matching category/content type (comma-separated)                          |
-| `--author`              | string   | none                      | Filter to docs where author contains value (case-insensitive)                                 |
-| `--intent`              | string   | none                      | Disambiguating context for ambiguous queries; steers snippets without being searched directly |
-| `--exclude`             | string   | none                      | Hard-prune docs containing any comma-separated term in title/path/body                        |
-| `--tags-all`            | string   | none                      | Filter to docs with ALL tags (comma-separated)                                                |
-| `--tags-any`            | string   | none                      | Filter to docs with ANY tag (comma-separated)                                                 |
-| `--project-root`        | string[] | cwd                       | Trusted project root; repeatable, replaces default cwd/repository affinity                    |
-| `--no-project-affinity` | boolean  | false                     | Disable project-aware soft ranking; invalid with `--project-root`                             |
-| `--full`                | boolean  | false                     | Include full mirror content instead of snippet                                                |
-| `--line-numbers`        | boolean  | false                     | Include line numbers in output                                                                |
-| `--lang`                | string   | auto                      | Language filter/hint (BCP-47)                                                                 |
+| Option                  | Type     | Default                   | Description                                                                                                          |
+| ----------------------- | -------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--query-file`          | string   | none                      | Read the query from a file; `-` reads stdin so the query never appears on argv. Do not also pass a positional query. |
+| `-n`                    | integer  | 5 (20 for --json/--files) | Max results                                                                                                          |
+| `--min-score`           | number   | 0                         | Minimum score threshold                                                                                              |
+| `-c, --collection`      | string   | all                       | Filter to collection                                                                                                 |
+| `--since`               | string   | none                      | Modified-at lower bound (ISO date/time or relative token)                                                            |
+| `--until`               | string   | none                      | Modified-at upper bound (ISO date/time or relative token)                                                            |
+| `--category`            | string   | none                      | Filter to docs with matching category/content type (comma-separated)                                                 |
+| `--author`              | string   | none                      | Filter to docs where author contains value (case-insensitive)                                                        |
+| `--intent`              | string   | none                      | Disambiguating context for ambiguous queries; steers snippets without being searched directly                        |
+| `--exclude`             | string   | none                      | Hard-prune docs containing any comma-separated term in title/path/body                                               |
+| `--tags-all`            | string   | none                      | Filter to docs with ALL tags (comma-separated)                                                                       |
+| `--tags-any`            | string   | none                      | Filter to docs with ANY tag (comma-separated)                                                                        |
+| `--project-root`        | string[] | cwd                       | Trusted project root; repeatable, replaces default cwd/repository affinity                                           |
+| `--no-project-affinity` | boolean  | false                     | Disable project-aware soft ranking; invalid with `--project-root`                                                    |
+| `--full`                | boolean  | false                     | Include full mirror content instead of snippet                                                                       |
+| `--line-numbers`        | boolean  | false                     | Include line numbers in output                                                                                       |
+| `--lang`                | string   | auto                      | Language filter/hint (BCP-47)                                                                                        |
 
 **Scoring:**
 
@@ -1336,7 +1337,7 @@ Hybrid search combining BM25 and vector retrieval with optional expansion and re
 **Synopsis:**
 
 ```bash
-gno query <query> [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--no-expand] [--no-rerank] [--graph] [--no-graph] [--query-mode <mode:text>]... [--explain] [--json|--files|--csv|--md|--xml]
+gno query [query...] [--query-file <path>] [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--no-expand] [--no-rerank] [--graph] [--no-graph] [--query-mode <mode:text>]... [--explain] [--json|--files|--csv|--md|--xml]
 gno query diagnose <query> --target <doc> [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--lang <bcp47>] [--no-expand] [--no-rerank] [--graph] [--no-graph] [--json]
 ```
 

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -1198,9 +1198,10 @@ gno search [query] [--query-file <path>] [-n <num>] [--min-score <num>] [-c <col
 ```
 
 **Arguments:**
-| Arg | Type | Description |
-|-----|------|-------------|
-| `<query>` | string | Search query |
+
+| Arg       | Type   | Description                                                          |
+| --------- | ------ | -------------------------------------------------------------------- |
+| `[query]` | string | Search query. Optional when `--query-file` is set. Do not pass both. |
 
 **Options:**
 
@@ -1340,6 +1341,8 @@ Hybrid search combining BM25 and vector retrieval with optional expansion and re
 gno query [query...] [--query-file <path>] [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--full] [--line-numbers] [--lang <bcp47>] [--no-expand] [--no-rerank] [--graph] [--no-graph] [--query-mode <mode:text>]... [--explain] [--json|--files|--csv|--md|--xml]
 gno query diagnose <query> --target <doc> [-n <num>] [--min-score <num>] [-c <collection>] [--since <date>] [--until <date>] [--category <values>] [--author <text>] [--intent <text>] [--exclude <values>] [-C <num>] [--tags-all <tags>] [--tags-any <tags>] [--lang <bcp47>] [--no-expand] [--no-rerank] [--graph] [--no-graph] [--json]
 ```
+
+The positional query is optional when `--query-file` is set. Do not pass both. `--query-file` is invalid on `query diagnose`.
 
 **Options:** Same as `gno search`, plus:
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -46,6 +46,7 @@ import {
   parseOptionalFloat,
   parsePositiveInt,
 } from "./options";
+import { resolveCliQueryText } from "./query-text";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Global State (set by preAction hook)
@@ -625,8 +626,12 @@ function wireTraceCommands(program: Command): void {
 function wireSearchCommands(program: Command): void {
   // search - BM25 keyword search
   program
-    .command("search <query>")
+    .command("search [query]")
     .description("BM25 keyword search")
+    .option(
+      "--query-file <path>",
+      "read query from file; use - for stdin (keeps the query off argv)"
+    )
     .option("-n, --limit <num>", "max results")
     .option("--min-score <num>", "minimum score threshold")
     .option("-c, --collection <name>", "filter by collection")
@@ -662,95 +667,104 @@ function wireSearchCommands(program: Command): void {
     .option("--csv", "CSV output")
     .option("--xml", "XML output")
     .option("--files", "file paths only")
-    .action(async (queryText: string, cmdOpts: Record<string, unknown>) => {
-      const format = getFormat(cmdOpts);
-      assertFormatSupported(CMD.search, format);
-      const globals = getGlobals();
+    .action(
+      async (
+        queryText: string | undefined,
+        cmdOpts: Record<string, unknown>
+      ) => {
+        const format = getFormat(cmdOpts);
+        assertFormatSupported(CMD.search, format);
+        const globals = getGlobals();
+        queryText = await resolveCliQueryText(queryText, cmdOpts.queryFile);
 
-      // Validate empty query
-      if (!queryText.trim()) {
-        throw new CliError("VALIDATION", "Query cannot be empty");
+        // Validate empty query
+        if (!queryText.trim()) {
+          throw new CliError("VALIDATION", "Query cannot be empty");
+        }
+
+        // Validate minScore range
+        const minScore = parseOptionalFloat("min-score", cmdOpts.minScore);
+        if (minScore !== undefined && (minScore < 0 || minScore > 1)) {
+          throw new CliError(
+            "VALIDATION",
+            "--min-score must be between 0 and 1"
+          );
+        }
+
+        // Parse and validate tag filters
+        let tagsAll: string[] | undefined;
+        let tagsAny: string[] | undefined;
+        try {
+          tagsAll = cmdOpts.tagsAll
+            ? parseAndValidateTagFilter(cmdOpts.tagsAll as string)
+            : undefined;
+          tagsAny = cmdOpts.tagsAny
+            ? parseAndValidateTagFilter(cmdOpts.tagsAny as string)
+            : undefined;
+        } catch (error) {
+          throw new CliError(
+            "VALIDATION",
+            error instanceof Error ? error.message : "Invalid tag filter"
+          );
+        }
+
+        const limit = cmdOpts.limit
+          ? parsePositiveInt("limit", cmdOpts.limit)
+          : cmdOpts.verify
+            ? 5
+            : getDefaultLimit(format);
+        const categories = parseCsvValues(cmdOpts.category);
+        const exclude = parseCsvValues(cmdOpts.exclude);
+        const projectAffinity = parseCliProjectAffinityOptions(cmdOpts);
+
+        const { search, formatSearch } = await import("./commands/search");
+        const result = await search(queryText, {
+          configPath: globals.config,
+          indexName: globals.index,
+          limit,
+          minScore,
+          collection: cmdOpts.collection as string | undefined,
+          lang: cmdOpts.lang as string | undefined,
+          since: cmdOpts.since as string | undefined,
+          until: cmdOpts.until as string | undefined,
+          categories,
+          author: cmdOpts.author as string | undefined,
+          intent: cmdOpts.intent as string | undefined,
+          exclude,
+          tagsAll,
+          tagsAny,
+          ...projectAffinity,
+          full: Boolean(cmdOpts.full),
+          lineNumbers: Boolean(cmdOpts.lineNumbers),
+          json: format === "json",
+          md: format === "md",
+          csv: format === "csv",
+          xml: format === "xml",
+          files: format === "files",
+        });
+
+        // Check success before printing - stdout is for successful outputs only
+        if (!result.success) {
+          // Map validation errors to exit code 1
+          throw new CliError(
+            result.isValidation ? "VALIDATION" : "RUNTIME",
+            result.error
+          );
+        }
+        const output = formatSearch(result, {
+          json: format === "json",
+          md: format === "md",
+          csv: format === "csv",
+          xml: format === "xml",
+          files: format === "files",
+          full: Boolean(cmdOpts.full),
+          lineNumbers: Boolean(cmdOpts.lineNumbers),
+          terminalLinks: await resolveTerminalLinkPolicy(format),
+        });
+        await writeOutput(output, format);
+        writeRetrievalTraceReceipt(result.metadata);
       }
-
-      // Validate minScore range
-      const minScore = parseOptionalFloat("min-score", cmdOpts.minScore);
-      if (minScore !== undefined && (minScore < 0 || minScore > 1)) {
-        throw new CliError("VALIDATION", "--min-score must be between 0 and 1");
-      }
-
-      // Parse and validate tag filters
-      let tagsAll: string[] | undefined;
-      let tagsAny: string[] | undefined;
-      try {
-        tagsAll = cmdOpts.tagsAll
-          ? parseAndValidateTagFilter(cmdOpts.tagsAll as string)
-          : undefined;
-        tagsAny = cmdOpts.tagsAny
-          ? parseAndValidateTagFilter(cmdOpts.tagsAny as string)
-          : undefined;
-      } catch (error) {
-        throw new CliError(
-          "VALIDATION",
-          error instanceof Error ? error.message : "Invalid tag filter"
-        );
-      }
-
-      const limit = cmdOpts.limit
-        ? parsePositiveInt("limit", cmdOpts.limit)
-        : cmdOpts.verify
-          ? 5
-          : getDefaultLimit(format);
-      const categories = parseCsvValues(cmdOpts.category);
-      const exclude = parseCsvValues(cmdOpts.exclude);
-      const projectAffinity = parseCliProjectAffinityOptions(cmdOpts);
-
-      const { search, formatSearch } = await import("./commands/search");
-      const result = await search(queryText, {
-        configPath: globals.config,
-        indexName: globals.index,
-        limit,
-        minScore,
-        collection: cmdOpts.collection as string | undefined,
-        lang: cmdOpts.lang as string | undefined,
-        since: cmdOpts.since as string | undefined,
-        until: cmdOpts.until as string | undefined,
-        categories,
-        author: cmdOpts.author as string | undefined,
-        intent: cmdOpts.intent as string | undefined,
-        exclude,
-        tagsAll,
-        tagsAny,
-        ...projectAffinity,
-        full: Boolean(cmdOpts.full),
-        lineNumbers: Boolean(cmdOpts.lineNumbers),
-        json: format === "json",
-        md: format === "md",
-        csv: format === "csv",
-        xml: format === "xml",
-        files: format === "files",
-      });
-
-      // Check success before printing - stdout is for successful outputs only
-      if (!result.success) {
-        // Map validation errors to exit code 1
-        throw new CliError(
-          result.isValidation ? "VALIDATION" : "RUNTIME",
-          result.error
-        );
-      }
-      const output = formatSearch(result, {
-        json: format === "json",
-        md: format === "md",
-        csv: format === "csv",
-        xml: format === "xml",
-        files: format === "files",
-        full: Boolean(cmdOpts.full),
-        lineNumbers: Boolean(cmdOpts.lineNumbers),
-        terminalLinks: await resolveTerminalLinkPolicy(format),
-      });
-      await writeOutput(output, format);
-      writeRetrievalTraceReceipt(result.metadata);
-    });
+    );
 
   // vsearch - Vector similarity search
   program
@@ -876,8 +890,12 @@ function wireSearchCommands(program: Command): void {
 
   // query - Hybrid search with expansion and reranking
   program
-    .command("query <query...>")
+    .command("query [query...]")
     .description("Hybrid search with expansion and reranking")
+    .option(
+      "--query-file <path>",
+      "read query from file; use - for stdin (keeps the query off argv)"
+    )
     .option("-n, --limit <num>", "max results")
     .option("--min-score <num>", "minimum score threshold")
     .option("-c, --collection <name>", "filter by collection")
@@ -931,103 +949,158 @@ function wireSearchCommands(program: Command): void {
     .option("--csv", "CSV output")
     .option("--xml", "XML output")
     .option("--files", "file paths only")
-    .action(async (queryParts: string[], cmdOpts: Record<string, unknown>) => {
-      const format = getFormat(cmdOpts);
-      const isDiagnose =
-        queryParts[0] === "diagnose" && Boolean(cmdOpts.target);
-      assertFormatSupported(isDiagnose ? CMD.queryDiagnose : CMD.query, format);
-      const diagnoseFormat = format === "json" ? "json" : "terminal";
-      const globals = getGlobals();
-      let queryText = isDiagnose
-        ? queryParts.slice(1).join(" ")
-        : queryParts.join(" ");
-
-      // Validate empty query
-      if (!queryText.trim()) {
-        throw new CliError("VALIDATION", "Query cannot be empty");
-      }
-
-      // Validate minScore range
-      const minScore = parseOptionalFloat("min-score", cmdOpts.minScore);
-      if (minScore !== undefined && (minScore < 0 || minScore > 1)) {
-        throw new CliError("VALIDATION", "--min-score must be between 0 and 1");
-      }
-
-      // Parse optional structured query modes
-      let queryModes: import("../pipeline/types").QueryModeInput[] | undefined;
-      if (Array.isArray(cmdOpts.queryMode) && cmdOpts.queryMode.length > 0) {
-        const { parseQueryModeSpecs } = await import("../pipeline/query-modes");
-        const parsed = parseQueryModeSpecs(cmdOpts.queryMode as string[]);
-        if (!parsed.ok) {
-          throw new CliError("VALIDATION", parsed.error.message);
-        }
-        queryModes = parsed.value;
-      }
-
-      const { normalizeStructuredQueryInput } =
-        await import("../core/structured-query");
-      const normalizedInput = normalizeStructuredQueryInput(
-        queryText,
-        queryModes ?? []
-      );
-      if (!normalizedInput.ok) {
-        throw new CliError("VALIDATION", normalizedInput.error.message);
-      }
-      queryText = normalizedInput.value.query;
-      queryModes =
-        normalizedInput.value.queryModes.length > 0
-          ? normalizedInput.value.queryModes
-          : undefined;
-
-      // Parse and validate tag filters
-      let tagsAll: string[] | undefined;
-      let tagsAny: string[] | undefined;
-      try {
-        tagsAll = cmdOpts.tagsAll
-          ? parseAndValidateTagFilter(cmdOpts.tagsAll as string)
-          : undefined;
-        tagsAny = cmdOpts.tagsAny
-          ? parseAndValidateTagFilter(cmdOpts.tagsAny as string)
-          : undefined;
-      } catch (error) {
-        throw new CliError(
-          "VALIDATION",
-          error instanceof Error ? error.message : "Invalid tag filter"
+    .action(
+      async (
+        queryParts: string[] | undefined,
+        cmdOpts: Record<string, unknown>
+      ) => {
+        const parts = queryParts ?? [];
+        const format = getFormat(cmdOpts);
+        const isDiagnose = parts[0] === "diagnose" && Boolean(cmdOpts.target);
+        assertFormatSupported(
+          isDiagnose ? CMD.queryDiagnose : CMD.query,
+          format
         );
-      }
+        const diagnoseFormat = format === "json" ? "json" : "terminal";
+        const globals = getGlobals();
+        if (isDiagnose && cmdOpts.queryFile) {
+          throw new CliError(
+            "VALIDATION",
+            "query diagnose does not accept --query-file"
+          );
+        }
+        let queryText = isDiagnose
+          ? parts.slice(1).join(" ")
+          : await resolveCliQueryText(parts.join(" "), cmdOpts.queryFile);
 
-      const limit = cmdOpts.limit
-        ? parsePositiveInt("limit", cmdOpts.limit)
-        : getDefaultLimit(format);
-      const { loadConfig } = await import("../config");
-      const { getActivePreset } = await import("../llm/registry");
-      const configResult = await loadConfig(globals.config);
-      const activePresetId = configResult.ok
-        ? getActivePreset(configResult.value).id
-        : "slim-tuned";
-      const candidateLimit = cmdOpts.candidateLimit
-        ? parsePositiveInt("candidate-limit", cmdOpts.candidateLimit)
-        : undefined;
-      const categories = parseCsvValues(cmdOpts.category);
-      const exclude = parseCsvValues(cmdOpts.exclude);
-      const projectAffinity = parseCliProjectAffinityOptions(cmdOpts);
+        // Validate empty query
+        if (!queryText.trim()) {
+          throw new CliError("VALIDATION", "Query cannot be empty");
+        }
 
-      const depthPolicy = resolveDepthPolicy({
-        presetId: activePresetId,
-        fast: Boolean(cmdOpts.fast),
-        thorough: Boolean(cmdOpts.thorough),
-        expand: cmdOpts.expand === false ? false : undefined,
-        rerank: cmdOpts.rerank === false ? false : undefined,
-        candidateLimit,
-      });
+        // Validate minScore range
+        const minScore = parseOptionalFloat("min-score", cmdOpts.minScore);
+        if (minScore !== undefined && (minScore < 0 || minScore > 1)) {
+          throw new CliError(
+            "VALIDATION",
+            "--min-score must be between 0 and 1"
+          );
+        }
 
-      if (isDiagnose) {
-        const { queryDiagnose, formatQueryDiagnose } =
-          await import("./commands/query");
-        const result = await queryDiagnose(queryText, {
+        // Parse optional structured query modes
+        let queryModes:
+          | import("../pipeline/types").QueryModeInput[]
+          | undefined;
+        if (Array.isArray(cmdOpts.queryMode) && cmdOpts.queryMode.length > 0) {
+          const { parseQueryModeSpecs } =
+            await import("../pipeline/query-modes");
+          const parsed = parseQueryModeSpecs(cmdOpts.queryMode as string[]);
+          if (!parsed.ok) {
+            throw new CliError("VALIDATION", parsed.error.message);
+          }
+          queryModes = parsed.value;
+        }
+
+        const { normalizeStructuredQueryInput } =
+          await import("../core/structured-query");
+        const normalizedInput = normalizeStructuredQueryInput(
+          queryText,
+          queryModes ?? []
+        );
+        if (!normalizedInput.ok) {
+          throw new CliError("VALIDATION", normalizedInput.error.message);
+        }
+        queryText = normalizedInput.value.query;
+        queryModes =
+          normalizedInput.value.queryModes.length > 0
+            ? normalizedInput.value.queryModes
+            : undefined;
+
+        // Parse and validate tag filters
+        let tagsAll: string[] | undefined;
+        let tagsAny: string[] | undefined;
+        try {
+          tagsAll = cmdOpts.tagsAll
+            ? parseAndValidateTagFilter(cmdOpts.tagsAll as string)
+            : undefined;
+          tagsAny = cmdOpts.tagsAny
+            ? parseAndValidateTagFilter(cmdOpts.tagsAny as string)
+            : undefined;
+        } catch (error) {
+          throw new CliError(
+            "VALIDATION",
+            error instanceof Error ? error.message : "Invalid tag filter"
+          );
+        }
+
+        const limit = cmdOpts.limit
+          ? parsePositiveInt("limit", cmdOpts.limit)
+          : getDefaultLimit(format);
+        const { loadConfig } = await import("../config");
+        const { getActivePreset } = await import("../llm/registry");
+        const configResult = await loadConfig(globals.config);
+        const activePresetId = configResult.ok
+          ? getActivePreset(configResult.value).id
+          : "slim-tuned";
+        const candidateLimit = cmdOpts.candidateLimit
+          ? parsePositiveInt("candidate-limit", cmdOpts.candidateLimit)
+          : undefined;
+        const categories = parseCsvValues(cmdOpts.category);
+        const exclude = parseCsvValues(cmdOpts.exclude);
+        const projectAffinity = parseCliProjectAffinityOptions(cmdOpts);
+
+        const depthPolicy = resolveDepthPolicy({
+          presetId: activePresetId,
+          fast: Boolean(cmdOpts.fast),
+          thorough: Boolean(cmdOpts.thorough),
+          expand: cmdOpts.expand === false ? false : undefined,
+          rerank: cmdOpts.rerank === false ? false : undefined,
+          candidateLimit,
+        });
+
+        if (isDiagnose) {
+          const { queryDiagnose, formatQueryDiagnose } =
+            await import("./commands/query");
+          const result = await queryDiagnose(queryText, {
+            configPath: globals.config,
+            indexName: globals.index,
+            target: cmdOpts.target as string,
+            limit,
+            minScore,
+            collection: cmdOpts.collection as string | undefined,
+            lang: cmdOpts.lang as string | undefined,
+            since: cmdOpts.since as string | undefined,
+            until: cmdOpts.until as string | undefined,
+            categories,
+            author: cmdOpts.author as string | undefined,
+            intent: cmdOpts.intent as string | undefined,
+            exclude,
+            tagsAll,
+            tagsAny,
+            ...projectAffinity,
+            noExpand: depthPolicy.noExpand,
+            noRerank: depthPolicy.noRerank,
+            graph: cmdOpts.graph !== false,
+            noGraph: Boolean(cmdOpts.fast) || cmdOpts.graph === false,
+            candidateLimit: depthPolicy.candidateLimit,
+            queryModes,
+            json: diagnoseFormat === "json",
+          });
+
+          if (!result.success) {
+            throw new CliError("RUNTIME", result.error);
+          }
+          await writeOutput(
+            formatQueryDiagnose(result, { format: diagnoseFormat }),
+            diagnoseFormat
+          );
+          return;
+        }
+
+        const { query, formatQuery } = await import("./commands/query");
+        const result = await query(queryText, {
           configPath: globals.config,
           indexName: globals.index,
-          target: cmdOpts.target as string,
           limit,
           minScore,
           collection: cmdOpts.collection as string | undefined,
@@ -1041,70 +1114,35 @@ function wireSearchCommands(program: Command): void {
           tagsAll,
           tagsAny,
           ...projectAffinity,
+          full: Boolean(cmdOpts.full),
+          lineNumbers: Boolean(cmdOpts.lineNumbers),
           noExpand: depthPolicy.noExpand,
           noRerank: depthPolicy.noRerank,
           graph: cmdOpts.graph !== false,
           noGraph: Boolean(cmdOpts.fast) || cmdOpts.graph === false,
           candidateLimit: depthPolicy.candidateLimit,
           queryModes,
-          json: diagnoseFormat === "json",
+          explain: Boolean(cmdOpts.explain),
+          json: format === "json",
+          md: format === "md",
+          csv: format === "csv",
+          xml: format === "xml",
+          files: format === "files",
         });
 
         if (!result.success) {
           throw new CliError("RUNTIME", result.error);
         }
-        await writeOutput(
-          formatQueryDiagnose(result, { format: diagnoseFormat }),
-          diagnoseFormat
-        );
-        return;
+        const output = formatQuery(result, {
+          format,
+          full: Boolean(cmdOpts.full),
+          lineNumbers: Boolean(cmdOpts.lineNumbers),
+          terminalLinks: await resolveTerminalLinkPolicy(format),
+        });
+        await writeOutput(output, format);
+        writeRetrievalTraceReceipt(result.metadata);
       }
-
-      const { query, formatQuery } = await import("./commands/query");
-      const result = await query(queryText, {
-        configPath: globals.config,
-        indexName: globals.index,
-        limit,
-        minScore,
-        collection: cmdOpts.collection as string | undefined,
-        lang: cmdOpts.lang as string | undefined,
-        since: cmdOpts.since as string | undefined,
-        until: cmdOpts.until as string | undefined,
-        categories,
-        author: cmdOpts.author as string | undefined,
-        intent: cmdOpts.intent as string | undefined,
-        exclude,
-        tagsAll,
-        tagsAny,
-        ...projectAffinity,
-        full: Boolean(cmdOpts.full),
-        lineNumbers: Boolean(cmdOpts.lineNumbers),
-        noExpand: depthPolicy.noExpand,
-        noRerank: depthPolicy.noRerank,
-        graph: cmdOpts.graph !== false,
-        noGraph: Boolean(cmdOpts.fast) || cmdOpts.graph === false,
-        candidateLimit: depthPolicy.candidateLimit,
-        queryModes,
-        explain: Boolean(cmdOpts.explain),
-        json: format === "json",
-        md: format === "md",
-        csv: format === "csv",
-        xml: format === "xml",
-        files: format === "files",
-      });
-
-      if (!result.success) {
-        throw new CliError("RUNTIME", result.error);
-      }
-      const output = formatQuery(result, {
-        format,
-        full: Boolean(cmdOpts.full),
-        lineNumbers: Boolean(cmdOpts.lineNumbers),
-        terminalLinks: await resolveTerminalLinkPolicy(format),
-      });
-      await writeOutput(output, format);
-      writeRetrievalTraceReceipt(result.metadata);
-    });
+    );
 
   // bench - Retrieval benchmark fixture runner
   program

--- a/src/cli/query-text.ts
+++ b/src/cli/query-text.ts
@@ -1,0 +1,41 @@
+/**
+ * Resolve a search/query string from a positional argument or --query-file.
+ * `--query-file -` reads stdin so callers can keep the query off argv.
+ *
+ * @module src/cli/query-text
+ */
+
+import { CliError } from "./errors";
+
+const readQueryFile = async (path: string): Promise<string> => {
+  if (path.includes("\0")) {
+    throw new CliError("VALIDATION", "--query-file path is invalid");
+  }
+  try {
+    const raw =
+      path === "-" ? await Bun.stdin.text() : await Bun.file(path).text();
+    return raw.replace(/\s+$/u, "");
+  } catch (error) {
+    throw new CliError(
+      "VALIDATION",
+      error instanceof Error
+        ? `Failed to read --query-file: ${error.message}`
+        : "Failed to read --query-file"
+    );
+  }
+};
+
+export const resolveCliQueryText = async (
+  positional: string | undefined,
+  queryFile: unknown
+): Promise<string> => {
+  const file = typeof queryFile === "string" ? queryFile.trim() : "";
+  const pos = positional ?? "";
+  if (file !== "" && pos.trim() !== "") {
+    throw new CliError("VALIDATION", "Pass a query or --query-file, not both");
+  }
+  if (file !== "") {
+    return await readQueryFile(file);
+  }
+  return pos;
+};

--- a/src/cli/query-text.ts
+++ b/src/cli/query-text.ts
@@ -29,7 +29,7 @@ export const resolveCliQueryText = async (
   positional: string | undefined,
   queryFile: unknown
 ): Promise<string> => {
-  const file = typeof queryFile === "string" ? queryFile.trim() : "";
+  const file = typeof queryFile === "string" ? queryFile : "";
   const pos = positional ?? "";
   if (file !== "" && pos.trim() !== "") {
     throw new CliError("VALIDATION", "Pass a query or --query-file, not both");

--- a/test/cli/query-text.test.ts
+++ b/test/cli/query-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,10 +12,9 @@ describe("resolveCliQueryText", () => {
   });
 
   test("reads a query file and strips a trailing newline", async () => {
-    const dir = join(tmpdir(), `gno-query-text-${Date.now()}`);
-    await mkdir(dir, { recursive: true });
+    const dir = await mkdtemp(join(tmpdir(), "gno-query-text-"));
     const path = join(dir, "q.txt");
-    await writeFile(path, "ramen bowl\n");
+    await writeFile(path, "ramen bowl\n", { flag: "wx" });
     try {
       expect(await resolveCliQueryText("", path)).toBe("ramen bowl");
     } finally {

--- a/test/cli/query-text.test.ts
+++ b/test/cli/query-text.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveCliQueryText } from "../../src/cli/query-text";
+import { safeRm } from "../helpers/cleanup";
+
+describe("resolveCliQueryText", () => {
+  test("returns the positional query when no file is set", async () => {
+    expect(await resolveCliQueryText("hello", undefined)).toBe("hello");
+  });
+
+  test("reads a query file and strips a trailing newline", async () => {
+    const dir = join(tmpdir(), `gno-query-text-${Date.now()}`);
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, "q.txt");
+    await writeFile(path, "ramen bowl\n");
+    try {
+      expect(await resolveCliQueryText("", path)).toBe("ramen bowl");
+    } finally {
+      await safeRm(dir);
+    }
+  });
+
+  test("rejects positional query plus --query-file", async () => {
+    await expect(resolveCliQueryText("a", "/tmp/q")).rejects.toThrow(
+      "Pass a query or --query-file, not both"
+    );
+  });
+});

--- a/test/cli/query-text.test.ts
+++ b/test/cli/query-text.test.ts
@@ -14,7 +14,7 @@ describe("resolveCliQueryText", () => {
   test("reads a query file and strips a trailing newline", async () => {
     const dir = await mkdtemp(join(tmpdir(), "gno-query-text-"));
     const path = join(dir, "q.txt");
-    await writeFile(path, "ramen bowl\n", { flag: "wx" });
+    await writeFile(path, "ramen bowl\n", { flag: "wx", mode: 0o600 });
     try {
       expect(await resolveCliQueryText("", path)).toBe("ramen bowl");
     } finally {

--- a/test/cli/search-smoke.test.ts
+++ b/test/cli/search-smoke.test.ts
@@ -7,7 +7,7 @@ import Ajv from "ajv";
 // oxlint-disable-next-line import/no-namespace -- ajv-formats requires namespace for .default
 import * as addFormatsModule from "ajv-formats";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -65,8 +65,9 @@ function restoreOutput() {
 const TEST_ROOT = join(tmpdir(), "gno-search-smoke");
 let testCounter = 0;
 
-function getTestDir(): string {
-  const dir = join(TEST_ROOT, `test-${Date.now()}-${testCounter}`);
+async function getTestDir(): Promise<string> {
+  await mkdir(TEST_ROOT, { recursive: true });
+  const dir = await mkdtemp(join(TEST_ROOT, `test-${testCounter}-`));
   testCounter += 1;
   return dir;
 }
@@ -98,7 +99,7 @@ async function cli(
 }
 
 async function setupTestWithContent(): Promise<string> {
-  const testDir = getTestDir();
+  const testDir = await getTestDir();
   await setupTestEnv(testDir);
 
   const docsDir = join(testDir, "docs");
@@ -146,7 +147,7 @@ describe("gno search smoke tests", () => {
 
   test("search --query-file reads the query from a file", async () => {
     const queryPath = join(testDir, "query.txt");
-    await writeFile(queryPath, "markdown\n", { flag: "wx" });
+    await writeFile(queryPath, "markdown\n", { flag: "wx", mode: 0o600 });
     const { code, stdout } = await cli(
       "search",
       "--query-file",
@@ -162,7 +163,7 @@ describe("gno search smoke tests", () => {
 
   test("search rejects a positional query together with --query-file", async () => {
     const queryPath = join(testDir, "query.txt");
-    await writeFile(queryPath, "markdown\n", { flag: "wx" });
+    await writeFile(queryPath, "markdown\n", { flag: "wx", mode: 0o600 });
     const { code, stderr } = await cli(
       "search",
       "markdown",
@@ -185,7 +186,7 @@ describe("gno search smoke tests", () => {
 
   test("search --query-file empty file exits 1", async () => {
     const queryPath = join(testDir, "empty-query.txt");
-    await writeFile(queryPath, "", { flag: "wx" });
+    await writeFile(queryPath, "", { flag: "wx", mode: 0o600 });
     const { code, stderr } = await cli("search", "--query-file", queryPath);
     expect(code).toBe(1);
     expect(stderr).toContain("Query cannot be empty");
@@ -193,7 +194,7 @@ describe("gno search smoke tests", () => {
 
   test("query diagnose rejects --query-file", async () => {
     const queryPath = join(testDir, "diag-query.txt");
-    await writeFile(queryPath, "markdown\n", { flag: "wx" });
+    await writeFile(queryPath, "markdown\n", { flag: "wx", mode: 0o600 });
     const { code, stderr } = await cli(
       "query",
       "diagnose",
@@ -404,7 +405,7 @@ describe("search on empty index", () => {
   let testDir: string;
 
   beforeEach(async () => {
-    testDir = getTestDir();
+    testDir = await getTestDir();
     await setupTestEnv(testDir);
     // Create empty docs dir and init with it
     const docsDir = join(testDir, "docs");

--- a/test/cli/search-smoke.test.ts
+++ b/test/cli/search-smoke.test.ts
@@ -146,7 +146,7 @@ describe("gno search smoke tests", () => {
 
   test("search --query-file reads the query from a file", async () => {
     const queryPath = join(testDir, "query.txt");
-    await writeFile(queryPath, "markdown\n");
+    await writeFile(queryPath, "markdown\n", { flag: "wx" });
     const { code, stdout } = await cli(
       "search",
       "--query-file",
@@ -162,7 +162,7 @@ describe("gno search smoke tests", () => {
 
   test("search rejects a positional query together with --query-file", async () => {
     const queryPath = join(testDir, "query.txt");
-    await writeFile(queryPath, "markdown\n");
+    await writeFile(queryPath, "markdown\n", { flag: "wx" });
     const { code, stderr } = await cli(
       "search",
       "markdown",
@@ -185,7 +185,7 @@ describe("gno search smoke tests", () => {
 
   test("search --query-file empty file exits 1", async () => {
     const queryPath = join(testDir, "empty-query.txt");
-    await writeFile(queryPath, "");
+    await writeFile(queryPath, "", { flag: "wx" });
     const { code, stderr } = await cli("search", "--query-file", queryPath);
     expect(code).toBe(1);
     expect(stderr).toContain("Query cannot be empty");
@@ -193,7 +193,7 @@ describe("gno search smoke tests", () => {
 
   test("query diagnose rejects --query-file", async () => {
     const queryPath = join(testDir, "diag-query.txt");
-    await writeFile(queryPath, "markdown\n");
+    await writeFile(queryPath, "markdown\n", { flag: "wx" });
     const { code, stderr } = await cli(
       "query",
       "diagnose",

--- a/test/cli/search-smoke.test.ts
+++ b/test/cli/search-smoke.test.ts
@@ -163,8 +163,82 @@ describe("gno search smoke tests", () => {
   test("search rejects a positional query together with --query-file", async () => {
     const queryPath = join(testDir, "query.txt");
     await writeFile(queryPath, "markdown\n");
-    const { code } = await cli("search", "markdown", "--query-file", queryPath);
-    expect(code).not.toBe(0);
+    const { code, stderr } = await cli(
+      "search",
+      "markdown",
+      "--query-file",
+      queryPath
+    );
+    expect(code).toBe(1);
+    expect(stderr).toContain("Pass a query or --query-file, not both");
+  });
+
+  test("search --query-file missing file exits 1", async () => {
+    const { code, stderr } = await cli(
+      "search",
+      "--query-file",
+      join(testDir, "missing-query.txt")
+    );
+    expect(code).toBe(1);
+    expect(stderr).toContain("Failed to read --query-file");
+  });
+
+  test("search --query-file empty file exits 1", async () => {
+    const queryPath = join(testDir, "empty-query.txt");
+    await writeFile(queryPath, "");
+    const { code, stderr } = await cli("search", "--query-file", queryPath);
+    expect(code).toBe(1);
+    expect(stderr).toContain("Query cannot be empty");
+  });
+
+  test("query diagnose rejects --query-file", async () => {
+    const queryPath = join(testDir, "diag-query.txt");
+    await writeFile(queryPath, "markdown\n");
+    const { code, stderr } = await cli(
+      "query",
+      "diagnose",
+      "--target",
+      "gno://docs/test.md",
+      "--query-file",
+      queryPath
+    );
+    expect(code).toBe(1);
+    expect(stderr).toContain("query diagnose does not accept --query-file");
+  });
+
+  test("search --query-file - reads stdin", async () => {
+    const repoRoot = join(import.meta.dir, "../..");
+    const proc = Bun.spawn(
+      [
+        "bun",
+        join(repoRoot, "src/index.ts"),
+        "search",
+        "--query-file",
+        "-",
+        "--json",
+      ],
+      {
+        cwd: repoRoot,
+        stdin: new Blob(["markdown\n"]),
+        env: {
+          ...process.env,
+          GNO_CONFIG_DIR: process.env.GNO_CONFIG_DIR,
+          GNO_DATA_DIR: process.env.GNO_DATA_DIR,
+          GNO_CACHE_DIR: process.env.GNO_CACHE_DIR,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    );
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    const parsed = JSON.parse(stdout);
+    expect(parsed.results?.length).toBeGreaterThan(0);
   });
 
   test("search --json validates against schema", async () => {

--- a/test/cli/search-smoke.test.ts
+++ b/test/cli/search-smoke.test.ts
@@ -144,6 +144,29 @@ describe("gno search smoke tests", () => {
     expect(stdout).toContain("result(s)");
   });
 
+  test("search --query-file reads the query from a file", async () => {
+    const queryPath = join(testDir, "query.txt");
+    await writeFile(queryPath, "markdown\n");
+    const { code, stdout } = await cli(
+      "search",
+      "--query-file",
+      queryPath,
+      "--json"
+    );
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(
+      parsed.results[0]?.uri || parsed.results[0]?.source?.relPath
+    ).toBeDefined();
+  });
+
+  test("search rejects a positional query together with --query-file", async () => {
+    const queryPath = join(testDir, "query.txt");
+    await writeFile(queryPath, "markdown\n");
+    const { code } = await cli("search", "markdown", "--query-file", queryPath);
+    expect(code).not.toBe(0);
+  });
+
   test("search --json validates against schema", async () => {
     const { code, stdout } = await cli("search", "markdown", "--json");
     expect(code).toBe(0);

--- a/test/cli/smoke.test.ts
+++ b/test/cli/smoke.test.ts
@@ -566,7 +566,7 @@ describe("CLI smoke tests", () => {
     test("search requires query", async () => {
       const { code, stderr } = await cli("search");
       expect(code).toBe(1);
-      expect(stderr).toContain("missing required argument");
+      expect(stderr).toContain("Query cannot be empty");
     });
 
     test("vsearch requires query", async () => {
@@ -578,7 +578,7 @@ describe("CLI smoke tests", () => {
     test("query requires query", async () => {
       const { code, stderr } = await cli("query");
       expect(code).toBe(1);
-      expect(stderr).toContain("missing required argument");
+      expect(stderr).toContain("Query cannot be empty");
     });
 
     test("ask requires query", async () => {


### PR DESCRIPTION
## Summary
- `gno search` and `gno query` accept `--query-file` (`-` = stdin) so desktop callers never put the query on argv.
- Fail-closed on missing/empty/conflict/diagnose; CLI + spec + tests included.
- Ships as **1.39.2** (already bumped on the branch; tag after merge, do not bump again).

## Test plan
- [x] `bun test test/cli/query-text.test.ts test/cli/search-smoke.test.ts`
- [x] Live `--query-file`, stdin, diagnose reject
- [ ] CI green
- [ ] Tag `v1.39.2` after merge (publish workflow)