### PR TITLE
Repair GNO 2.0 desktop release packaging

### DIFF
--- a/.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.json
+++ b/.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.json
@@ -1,0 +1,24 @@
+{
+  "branch_name": "fn-158-repair-gno-20-desktop-release-packaging",
+  "created_at": "2026-09-05T14:34:43.074353Z",
+  "depends_on_epics": [],
+  "id": "fn-158-repair-gno-20-desktop-release-packaging",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-158-repair-gno-20-desktop-release-packaging.md",
+  "status": "open",
+  "title": "Repair GNO 2.0 desktop release packaging",
+  "tracker": {
+    "baseHashFlow": null,
+    "baseHashTracker": null,
+    "depRelations": [],
+    "id": null,
+    "identifier": null,
+    "lastSyncedAt": null,
+    "mergeBaseFlow": null,
+    "mergeBaseTracker": null,
+    "url": null
+  },
+  "updated_at": "2026-09-05T14:34:43.077510Z"
+}

--- a/.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.md
+++ b/.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.md
@@ -1,0 +1,18 @@
+# Repair GNO 2.0 desktop release packaging
+
+## Problem
+The v2.0.0 npm release is published and all core platform tests and package smoke passed. Desktop packaging fails because Electrobun invokes its bundled Bun 1.3.9 for staging, which cannot read the root Bun 1.4 lockfile. The packaged runtime must also honor the repository Bun pin.
+
+## Requirements
+- R1: Stage using the verified pinned repository Bun; ship and verify that same Bun version. Reject mismatches before destructive staging changes.
+- R2: Validate the exact staging failure with the old hook runtime and focused regression tests, then build and verify actual platform artifacts.
+- R3: Recover desktop publication without retagging v2.0.0, republishing npm, or repeating already-passing core tests. Preserve signing/notarization and artifact provenance. Record the desktop packaging commit separately from the immutable npm tag.
+
+## Scope
+Desktop scripts/config, focused tests, release workflow recovery, desktop release documentation and evidence only. No retrieval/runtime product changes, dependencies, fn138/fn141 edits, or hosted website deployment.
+
+## Acceptance
+- Pinned Bun production staging works under the original old-Bun hook.
+- Focused tests and configured local gates pass.
+- Windows and signed/notarized macOS artifacts verify and attach to v2.0.0 release.
+- npm2.0.0 remains at98fd4eb11db9708a51915df7d2cb113515ed482f, unchanged.

--- a/.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.json
+++ b/.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-09-05T14:34:50.035046Z",
+  "depends_on": [],
+  "id": "fn-158-repair-gno-20-desktop-release-packaging.1",
+  "priority": null,
+  "spec": "fn-158-repair-gno-20-desktop-release-packaging",
+  "spec_path": ".flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.md",
+  "status": "todo",
+  "title": "Repair pinned desktop runtime and recover release artifacts",
+  "updated_at": "2026-09-05T14:34:50.035046Z"
+}

--- a/.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.md
+++ b/.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.md
@@ -1,0 +1,15 @@
+# fn-158-repair-gno-20-desktop-release-packaging.1 Repair pinned desktop runtime and recover release artifacts
+
+## Description
+TBD
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/desktop/electrobun-shell/README.md
+++ b/desktop/electrobun-shell/README.md
@@ -82,3 +82,10 @@ Build + packaged runtime verify:
 bun run build
 bun scripts/verify-packaged-runtime.ts
 ```
+
+Install the root dependencies with `bun install --frozen-lockfile` before
+building the shell. Staging uses the root package's pinned Bun executable,
+and the desktop bundle ships that same version. Electrobun may invoke its
+build hooks with an older embedded Bun; that hook runtime must not install
+the staged dependencies. The packaged-runtime check rejects a bundled Bun
+version that differs from the root pin.

--- a/desktop/electrobun-shell/electrobun.config.ts
+++ b/desktop/electrobun-shell/electrobun.config.ts
@@ -32,6 +32,8 @@ export default {
     gnoControlPort: 3928,
   },
   build: {
+    // The launcher and GNO child must use the same tested runtime as staging.
+    bunVersion: pkg.devDependencies.bun,
     copy: {
       ".generated/gno-runtime": DEFAULT_GNO_RUNTIME_FOLDER,
     },

--- a/desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts
+++ b/desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+// Bun has no temporary-directory, symlink or recursive cleanup API.
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import pkg from "../../../package.json";
+import config from "../electrobun.config";
+import { getStagingBun, stageRuntime } from "./stage-gno-runtime";
+
+test("staging uses the pinned binary and rejects drift before clearing artifacts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "gno-desktop-bun-"));
+  const binary = join(root, "node_modules/bun/bin/bun.exe");
+  const target = join(root, "staged");
+  try {
+    await mkdir(join(root, "node_modules/bun/bin"), { recursive: true });
+    await mkdir(target);
+    await symlink(
+      resolve(import.meta.dir, "../../../node_modules/bun/bin/bun.exe"),
+      binary
+    );
+    await Bun.write(
+      join(root, "package.json"),
+      JSON.stringify({ devDependencies: { bun: pkg.devDependencies.bun } })
+    );
+    expect(await getStagingBun(root)).toBe(binary);
+    expect(config.build.bunVersion).toBe(pkg.devDependencies.bun);
+    await Bun.write(join(target, "sentinel"), "preserve previous staging");
+    await Bun.write(
+      join(root, "package.json"),
+      JSON.stringify({ devDependencies: { bun: "0.0.0" } })
+    );
+    const failure = await stageRuntime(root, target).then(
+      () => null,
+      (error: unknown) => error
+    );
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain(
+      "Desktop staging Bun mismatch"
+    );
+    expect(await Bun.file(join(target, "sentinel")).text()).toBe(
+      "preserve previous staging"
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/desktop/electrobun-shell/scripts/stage-gno-runtime.ts
+++ b/desktop/electrobun-shell/scripts/stage-gno-runtime.ts
@@ -16,12 +16,40 @@ const runtimeFiles = [
   "vendor",
 ] as const;
 
-async function stageRuntime(): Promise<void> {
-  await rm(stagingRoot, { force: true, recursive: true });
-  await mkdir(stagingRoot, { recursive: true });
+/** Electrobun executes hooks with its own Bun, independently of build.bunVersion. */
+export async function getStagingBun(sourceRoot: string): Promise<string> {
+  const pkg = await Bun.file(join(sourceRoot, "package.json")).json();
+  const expected = pkg.devDependencies?.bun;
+  if (typeof expected !== "string" || !/^\d+\.\d+\.\d+$/.test(expected)) {
+    throw new Error(
+      "Desktop staging requires an exact root Bun development pin"
+    );
+  }
+  const binary = join(sourceRoot, "node_modules", "bun", "bin", "bun.exe");
+  const result = Bun.spawnSync([binary, "--version"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const actual = new TextDecoder().decode(result.stdout).trim();
+  if (result.exitCode !== 0 || actual !== expected) {
+    throw new Error(
+      `Desktop staging Bun mismatch: expected ${expected}, got ${actual || result.exitCode}`
+    );
+  }
+  return binary;
+}
+
+export async function stageRuntime(
+  sourceRoot = repoRoot,
+  targetRoot = stagingRoot
+): Promise<void> {
+  const bun = await getStagingBun(sourceRoot);
+
+  await rm(targetRoot, { force: true, recursive: true });
+  await mkdir(targetRoot, { recursive: true });
 
   for (const relPath of runtimeFiles) {
-    await cp(join(repoRoot, relPath), join(stagingRoot, relPath), {
+    await cp(join(sourceRoot, relPath), join(targetRoot, relPath), {
       dereference: true,
       force: true,
       recursive: true,
@@ -29,15 +57,9 @@ async function stageRuntime(): Promise<void> {
   }
 
   const install = Bun.spawnSync(
-    [
-      process.execPath,
-      "install",
-      "--production",
-      "--frozen-lockfile",
-      "--ignore-scripts",
-    ],
+    [bun, "install", "--production", "--frozen-lockfile", "--ignore-scripts"],
     {
-      cwd: stagingRoot,
+      cwd: targetRoot,
       stderr: "inherit",
       stdout: "inherit",
     }
@@ -50,9 +72,11 @@ async function stageRuntime(): Promise<void> {
   }
 
   await Bun.write(
-    join(stagingRoot, "desktop-runtime-manifest.json"),
+    join(targetRoot, "desktop-runtime-manifest.json"),
     JSON.stringify(
       {
+        bunVersion: (await Bun.file(join(sourceRoot, "package.json")).json())
+          .devDependencies.bun,
         generatedAt: new Date().toISOString(),
         platform: process.platform,
         arch: process.arch,
@@ -63,7 +87,7 @@ async function stageRuntime(): Promise<void> {
     )
   );
 
-  console.log(`[gno-electrobun] staged runtime at ${stagingRoot}`);
+  console.log(`[gno-electrobun] staged runtime at ${targetRoot}`);
 }
 
-await stageRuntime();
+if (import.meta.main) await stageRuntime();

--- a/desktop/electrobun-shell/scripts/verify-packaged-runtime.ts
+++ b/desktop/electrobun-shell/scripts/verify-packaged-runtime.ts
@@ -111,6 +111,20 @@ async function verify(): Promise<void> {
     ),
     "bundled bun binary"
   );
+  const runtimePackage = await Bun.file(
+    join(runtimeDir, "package.json")
+  ).json();
+  const expectedBun = runtimePackage.devDependencies.bun;
+  const actualBun = runCommand(
+    [bunPath, "--version"],
+    runtimeDir,
+    {}
+  ).stdout.trim();
+  if (actualBun !== expectedBun) {
+    throw new Error(
+      `Packaged Bun mismatch: expected ${expectedBun}, got ${actualBun}`
+    );
+  }
   const launcherPath = expectTruthy(
     await findFirst(buildDir, (path) =>
       path.endsWith(


### PR DESCRIPTION
# Repair GNO 2.0 desktop release packaging

Electrobun invokes its pre-build hook through bundled Bun 1.3.9, which cannot read the root Bun 1.4 lockfile. Setting the app's bundled Bun version alone does not change that hook runtime. Staging now locates and verifies the root-pinned Bun before replacing its output, and the desktop bundle and packaged-runtime checks use the same pin.

> [Spec](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.md) · `fix/desktop-bun-2.0-release` → `main` · Draft: platform artifact acceptance in progress

## TL;DR

- Stage production dependencies with the verified root Bun executable, independent of Electrobun's older hook runtime.
- Bundle that same Bun version and reject packaged-runtime mismatches before CLI checks.
- Complete desktop packaging for the existing 2.0.0 release. No version bump, npm republish, or tag movement: the published npm package and v2.0.0 tag remain at `98fd4eb11db9708a51915df7d2cb113515ed482f`; desktop packaging provenance identifies this follow-up commit separately.

## The change, top to bottom

Use and verify the repository-pinned Bun during desktop staging and in the packaged app, even when Electrobun invokes its pre-build hook through an older Bun.

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn158-b3db6ae2808a` | artifact identity |
| Base commit | `402a5b7538d0b183662f36441925b0d47109ffe2` | artifact currentness |
| Head commit | `b3db6ae2808a8aecc766c1e073d0ab0da1372cf6` | artifact identity |
| Human-review lines | 124 | deterministic file stats |
| Canonical files | 5 | deterministic membership |
| Total files | 9 | deterministic membership |
| Task status | 0/1 tasks done; draft opened while platform artifact acceptance remains in progress. | source:task |
| Version scope | The diff leaves the root version and npm release unchanged. | source:diff, source:commit |

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `desktop/electrobun-shell/electrobun.config.ts` | Check the staging executable version before replacing staging output; configure the bundled runtime from the same root pin. | +2/-0 | — | source:diff |
| `MODIFIED` | `CANONICAL` | `desktop/electrobun-shell/scripts/stage-gno-runtime.ts` | Check the staging executable version before replacing staging output; configure the bundled runtime from the same root pin. | +39/-15 | — | source:diff |
| `MODIFIED` | `CANONICAL` | `desktop/electrobun-shell/README.md` | Check packaged Bun before CLI probes; add focused staging regressions and document the hook/runtime distinction. | +7/-0 | — | source:diff |
| `NEW` | `CANONICAL` | `desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts` | Check packaged Bun before CLI probes; add focused staging regressions and document the hook/runtime distinction. | +47/-0 | — | source:diff |
| `MODIFIED` | `CANONICAL` | `desktop/electrobun-shell/scripts/verify-packaged-runtime.ts` | Check packaged Bun before CLI probes; add focused staging regressions and document the hook/runtime distinction. | +14/-0 | — | source:diff |

## Critical changes

- [desktop/electrobun-shell/scripts/stage-gno-runtime.ts](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/scripts/stage-gno-runtime.ts): verify the executable against the exact root pin before deleting/replacing staging output; use that executable for the frozen production install.
- [desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts): focused regressions for staging runtime selection and refusal behavior.
- [.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.md](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/.flow/specs/fn-158-repair-gno-20-desktop-release-packaging.md): scope the desktop release recovery and preserve the immutable npm/tag boundary.
- [.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.md](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.md): work remains in progress; this draft is not a completed artifact-acceptance claim.
- [.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.json](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/.flow/tasks/fn-158-repair-gno-20-desktop-release-packaging.1.json): task tracking for the release recovery.

## How to review

Start with runtime selection before staging mutation, then check `build.bunVersion` and the packaged Bun comparison. The hook runtime and shipped runtime are separate concerns; both now derive from the root pin. Formal reviews were explicitly disabled. The host owns final acceptance and release artifacts.

## Review plan

**Must review:** [desktop/electrobun-shell/scripts/stage-gno-runtime.ts](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/scripts/stage-gno-runtime.ts), particularly version verification before staging replacement. This is approximately 30% of the changed lines.

**Spot-check:** [desktop/electrobun-shell/electrobun.config.ts](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/electrobun.config.ts), [desktop/electrobun-shell/scripts/verify-packaged-runtime.ts](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/scripts/verify-packaged-runtime.ts), [desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/scripts/stage-gno-runtime.test.ts), and [desktop/electrobun-shell/README.md](https://github.com/gmickel/gno/blob/b3db6ae2808a8aecc766c1e073d0ab0da1372cf6/desktop/electrobun-shell/README.md). Confirm the selected, shipped, and verified runtime versions agree.

**Safe to skim:** `.flow/specs/` and `.flow/tasks/` metadata. The export-time task was incomplete, and its requirement coverage was not machine-recorded; the walkthrough's task status is not a release verdict.

## Validation status

The host's retained local recovery evidence reports an integrity-verified Bun 1.3.9 hook invoking the new staging path: Bun 1.4.2 completed the frozen production install, and the isolated staged runtime passed version/init/update/search with an actual fixture result. Focused desktop tests passed 10 tests/34 assertions; the four implementation/test files passed type-aware lint and formatting. This evidence establishes staging/runtime loading, not a signed macOS application. Core-wide tests were not repeated for this packaging-only repair.

The [targeted Windows packaging run](https://github.com/gmickel/gno/actions/runs/33972434075) completed successfully. macOS build/signing/notarization and final release attachment remain under host validation; no macOS artifact pass is claimed here. Local raw evidence is retained under `desktop-bun-recovery` and will be committed by the host with its final acceptance.

## Open items

- Complete actual platform artifact verification and release attachment, recording desktop packaging commit provenance separately from the existing npm/tag commit.
- Finish fn158 task evidence and requirement coverage after platform acceptance. No task completion is inferred from this draft PR.

Generated by /flow-next:make-pr from fn-158-repair-gno-20-desktop-release-packaging against main on 2026-09-05
<!-- flow-next:make-pr spec=fn-158-repair-gno-20-desktop-release-packaging base=main -->



### Release acceptance update

- Local pinned Bun 1.4.2 full gate: 5,223 tests passed, two existing skips, zero failures; lint/typecheck and docs checks passed.
- Windows build and packaged-runtime verification passed in [targeted run33972434075](https://github.com/gmickel/gno/actions/runs/33972434075), from this exact head. The duplicate PR Windows run was cancelled after that success.
- Heimdall built and verified the packaged app with Bun1.4.2; strict signature, hardened-runtime and required entitlement checks passed. Apple notarization is pending and gates artifact publication.
- Gordon authorized local CI/CD validation and bypassing redundant hosted waits. This packaging-only PR uses that authorization; core npm2.0.0 and its tag remain unchanged.
