### PR TITLE
chore: release GNO v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-09-06
+
+### Added
+
+- Choose public, secret-link, invite-only, or encrypted access explicitly when
+  exporting a document or collection from the Web UI, with plan guidance and
+  passphrase confirmation for encrypted exports.
+- Document the coordinated gno.sh Studio publication workflow: review access,
+  update existing publications, withdraw public access, and delete publications
+  or source content with clear confirmation and cleanup status.
+
+### Fixed
+
+- Keep encrypted collection export help accurate and make export dialog controls
+  usable in the packaged Web UI.
+
 ## [2.0.1] - 2026-09-05
 
 ### Changed
@@ -2676,7 +2692,8 @@ Re-release of 1.0.2 with a CHANGELOG formatting fix so the Publish workflow's
 | 0.4.0   | 2026-01-01 | Web UI and REST API                        |
 | 0.1.0   | 2025-12-30 | Initial release with full search pipeline  |
 
-[Unreleased]: https://github.com/gmickel/gno/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/gmickel/gno/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/gmickel/gno/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/gmickel/gno/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/gmickel/gno/compare/v1.46.0...v2.0.0
 [1.46.0]: https://github.com/gmickel/gno/compare/v1.45.1...v1.46.0

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gno daemon --detach  # headless indexing + resident MCP gateway
 
 <!-- public-truth:current-version -->
 
-> Current source version: **v2.0.1**. See [CHANGELOG.md](./CHANGELOG.md).
+> Current source version: **v2.1.0**. See [CHANGELOG.md](./CHANGELOG.md).
 
 <!-- /public-truth -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmickel/gno",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Local semantic search for your documents. Index Markdown, PDF, and Office files with hybrid BM25 + vector search.",
   "keywords": [
     "embeddings",


### PR DESCRIPTION
Prepare GNO 2.1.0 after #220. This updates the package version, release notes, and README version claim for explicit publishing permissions and the coordinated Studio lifecycle release.

I ran the full prerelease checks before the version bump and verified the 2.1.0 packed installation afterward. The package retry passed its real-user-state isolation guard; the first attempt detected changing GNO state on the active workstation. The documentation version guard caught a stale README value, which is fixed and passes the focused tests. gno.sh is deployed and its production fixture and browser checks pass.

The coordinated release workflow will test all platforms and require Windows and signed macOS desktop artifacts before npm publication.
