### PR TITLE
chore(flow): close fn-161 after embedding status fix

### DIFF
--- a/.flow/specs/fn-161-align-embedding-status-with-active.json
+++ b/.flow/specs/fn-161-align-embedding-status-with-active.json
@@ -7,7 +7,7 @@
   "plan_review_status": "unknown",
   "plan_reviewed_at": null,
   "spec_path": ".flow/specs/fn-161-align-embedding-status-with-active.md",
-  "status": "open",
+  "status": "done",
   "title": "Align embedding status with active vector storage",
   "tracker": {
     "baseHashFlow": null,
@@ -20,5 +20,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-06T04:11:58.843198Z"
+  "updated_at": "2026-09-06T05:17:45.975134Z"
 }


### PR DESCRIPTION
Record completion of the merged embedding-status fix.

## The change, top to bottom

Record completion of the merged embedding-status fix.

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn161-close-d9287bde802e` | artifact identity |
| Base commit | `e7f2ae7e779fed73b3801cabf531b2b5a6a5a84a` | artifact currentness |
| Head commit | `d9287bde802ec531b80e4f5c11b3ba601fd63828` | artifact identity |
| Human-review lines | 0 | deterministic file stats |
| Canonical files | 0 | deterministic membership |
| Total files | 1 | deterministic membership |
| Implementation task | 1/1 complete | source:task |

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|

## Review plan

Check the Flow spec status change against the merged implementation PR. The required PR check will validate this commit before it reaches main.

Generated by /flow-next:make-pr from fn-161-align-embedding-status-with-active against origin/main.
<!-- flow-next:make-pr spec=fn-161-align-embedding-status-with-active base=origin/main -->
