### PR TITLE
chore(flow): reconcile and close remote PDF spec

### DIFF
--- a/.flow/specs/fn-136-pdf-viewing-over-a-remote-link.json
+++ b/.flow/specs/fn-136-pdf-viewing-over-a-remote-link.json
@@ -490,7 +490,7 @@
     "plan": 0
   },
   "spec_path": ".flow/specs/fn-136-pdf-viewing-over-a-remote-link.md",
-  "status": "open",
+  "status": "done",
   "title": "PDF viewing over a remote link",
   "tracker": {
     "baseHashFlow": null,
@@ -503,5 +503,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-02T18:08:43.340528Z"
+  "updated_at": "2026-09-06T14:30:20.510519Z"
 }

--- a/.flow/specs/fn-136-pdf-viewing-over-a-remote-link.md
+++ b/.flow/specs/fn-136-pdf-viewing-over-a-remote-link.md
@@ -1,5 +1,7 @@
 # PDF viewing over a remote link
 
+> Closed on 2026-09-06 at Gordon's request. PR #206 was merged on 2026-09-02; Gordon confirmed the remaining remote verification and hosted documentation work was completed. Historical blocked observations below describe the original implementation session, not the final acceptance state. No new remote measurements were performed during this reconciliation.
+
 ## Overview
 
 A PDF opened in the `gno serve` web UI from another machine over a mesh VPN loads slowly, renders blurry, and offers actions that only work on the server host. The measured link to the remote host is a relayed VPN path at about 200 ms per round trip, and the viewer pays one round trip per 64 KB chunk plus one full geometry pass before it draws page 1. This plan fixes the transport, the first paint, the HTTP cache and compression posture of the server, and the locality of the document actions, then measures the result over the real link.
@@ -152,8 +154,8 @@ Task fn-136-pdf-viewing-over-a-remote-link.3 validates the core approach (fewer,
 | R3  | ETag/304 on doc-asset, gzip + immutable SPA chunks; warm reload under 100 KB | fn-136-pdf-viewing-over-a-remote-link.1 (headers, tests), fn-136-pdf-viewing-over-a-remote-link.5 (warm-reload measurement) | — |
 | R4  | `localClient` capability, reveal 403, action gating | fn-136-pdf-viewing-over-a-remote-link.2 | — |
 | R5  | Remote "Open original" inline link | fn-136-pdf-viewing-over-a-remote-link.2 | — |
-| R6  | Measured first paint and request count over the relay | fn-136-pdf-viewing-over-a-remote-link.3 (proof measurement), fn-136-pdf-viewing-over-a-remote-link.5 (final measurement) | BLOCKED: before-numbers captured (37.2 s first paint, 79 requests, 25 x 64 KB Range); after-measurement needs the remote install updated to this build, which this machine cannot do |
-| R7  | Sharp render over the remote link, with capture | fn-136-pdf-viewing-over-a-remote-link.5 | UNMET, capture BLOCKED: the remote screenshot needs the updated build on the remote host; a local DPR 2 check shows a crisp 2.0x canvas, ruling out the render math; the spec stays open until the remote capture lands |
+| R6  | Measured first paint and request count over the relay | fn-136-pdf-viewing-over-a-remote-link.3 (proof measurement), fn-136-pdf-viewing-over-a-remote-link.5 (final measurement) | Completed; owner confirmed on 2026-09-06 (task .6). |
+| R7  | Sharp render over the remote link, with capture | fn-136-pdf-viewing-over-a-remote-link.5 | Completed; owner confirmed on 2026-09-06 (task .6). |
 
 ## References
 

--- a/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.1.md
+++ b/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.1.md
@@ -45,7 +45,9 @@ Review round 1 (NEEDS_WORK) found the identity HEAD Content-Length regression, t
 stage: wave-join - ran (cherry-pick of the worker commit onto the target; no collision)
 stage: impl-review - ran [round 1 NEEDS_WORK -> fixes -> round 2 SHIP] (model: claude-opus-5 via harness subagent, host backend)
 stage: plan-sync - skipped(config: planSync.enabled != true)
+
+2026-09-06 reconciliation: restored completion state from this existing summary and merged PR #206. Gordon confirmed all remaining work was completed and requested spec closure. Earlier BLOCKED/UNMET observations above are historical and superseded by that confirmation.
 ## Evidence
-- Commits: 104311362a53d057803e6805f805bf16d7c1e40c, c37bc1389d79b93f67b1a183ac504f765d356cc4
+- Commits: 104311362a53d057803e6805f805bf16d7c1e40c, c37bc1389d79b93f67b1a183ac504f765d356cc4, d17ac7d8577c87fbd14a072deef3f39db121edae
 - Tests: bun test test/serve/api-doc-assets.test.ts test/serve/fn112-doc-asset-bytes.test.ts test/serve/spa-bundle-source.test.ts test/serve/spa-first-chunk.test.ts test/serve/fn112-production-routes.test.ts test/serve/security.test.ts -> 56 pass, 0 fail (integrated target), bun run lint:check -> clean, worker: bun test test/serve -> 832 pass, 0 fail (workspace)
-- PRs:
+- PRs: https://github.com/gmickel/gno/pull/206

--- a/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.2.md
+++ b/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.2.md
@@ -51,7 +51,9 @@ Review: SHIP on round 1 (Opus, host backend). Its P2 (the reveal gate was `req &
 stage: wave-join - ran (cherry-pick of the worker commit onto the target; snapshot refreshed by the conductor; no collision)
 stage: impl-review - ran [round 1 SHIP] (model: claude-opus-5 via harness subagent, host backend)
 stage: plan-sync - skipped(config: planSync.enabled != true)
+
+2026-09-06 reconciliation: restored completion state from this existing summary and merged PR #206. Gordon confirmed all remaining work was completed and requested spec closure. Earlier BLOCKED/UNMET observations above are historical and superseded by that confirmation.
 ## Evidence
-- Commits: 050dafc0, 8a07db8b, 40750a755cc0a5e6c8d6896319153529a9288a8d
+- Commits: 050dafc0, 8a07db8b, 40750a755cc0a5e6c8d6896319153529a9288a8d, d17ac7d8577c87fbd14a072deef3f39db121edae
 - Tests: bun test test/serve/api-capabilities.test.ts test/serve/api-docs-lifecycle.test.ts test/serve/request-locality.test.ts test/serve/public/pages/DocView-actions.dom.test.tsx test/clipper test/serve/security.test.ts -> green (integrated target), bun run lint:check -> clean, bun test test/serve/spa-snapshot-freshness.test.ts -> 2 pass, worker: bun test (full) -> 4479 pass, 1 fail (snapshot freshness, fixed by the conductor rebuild)
-- PRs:
+- PRs: https://github.com/gmickel/gno/pull/206

--- a/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.3.md
+++ b/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.3.md
@@ -53,7 +53,9 @@ Review: round 1 NEEDS_WORK (smoke gate invalidated, no explicit fetch double in 
 stage: wave-join - ran (cherry-pick of the worker commit and the review-fix commit onto the target; the generated SPA snapshot conflicted with task .2's refresh and was regenerated, not merged)
 stage: impl-review - ran [round 1 NEEDS_WORK -> fixes -> round 2 SHIP] (model: claude-opus-5 via harness subagent, host backend; fixes: cursor-grok-4.6-high via cursor-agent bridge)
 stage: plan-sync - skipped(config: planSync.enabled != true)
+
+2026-09-06 reconciliation: restored completion state from this existing summary and merged PR #206. Gordon confirmed all remaining work was completed and requested spec closure. Earlier BLOCKED/UNMET observations above are historical and superseded by that confirmation.
 ## Evidence
-- Commits: 98c5b6e4, 094de121, 91a69d47, 6271946dd799045e30e6e96cf0e74e8746fac4af
+- Commits: 98c5b6e4, 094de121, 91a69d47, 6271946dd799045e30e6e96cf0e74e8746fac4af, d17ac7d8577c87fbd14a072deef3f39db121edae
 - Tests: bun test test/serve/public/hooks test/serve/public/lib test/serve/public/components/pdf/PdfViewer.dom.test.tsx test/egress/enforcement.test.ts test/serve/spa-snapshot-freshness.test.ts -> 123 pass, 0 fail (integrated target), bun run lint:check -> clean, bun run test:e2e:pdf -> PASSED (large 11,384,001 B / 200 pages ranged tier; medium 4,238,157 B / 60 pages whole-file tier: one HEAD + one Range-less GET), worker: bun test (full) -> 4436 pass, 3 fail outside Touches, all fixed by the conductor (inventory entry, PdfViewer await, snapshot rebuild)
-- PRs:
+- PRs: https://github.com/gmickel/gno/pull/206

--- a/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.4.md
+++ b/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.4.md
@@ -46,7 +46,9 @@ Follow-up not built (out of R2's wording): a render-path `getPage` failure after
 stage: wave-join - ran (cherry-pick of the worker commit and the review-fix commit onto the target; SPA snapshot refreshed by the conductor)
 stage: impl-review - ran [round 1 NEEDS_WORK -> fixes -> round 2 SHIP] (model: claude-opus-5 via harness subagent, host backend; fixes: cursor-grok-4.6-high via cursor-agent bridge, verification and commit by the conductor after the bridge agent hit a session limit)
 stage: plan-sync - skipped(config: planSync.enabled != true)
+
+2026-09-06 reconciliation: restored completion state from this existing summary and merged PR #206. Gordon confirmed all remaining work was completed and requested spec closure. Earlier BLOCKED/UNMET observations above are historical and superseded by that confirmation.
 ## Evidence
-- Commits: 23ebb1f2, 5e69f66f, 3eb34c89, 40d2c96400f5e6846666e19dcfdfb6b7d5699547
+- Commits: 23ebb1f2, 5e69f66f, 3eb34c89, 40d2c96400f5e6846666e19dcfdfb6b7d5699547, d17ac7d8577c87fbd14a072deef3f39db121edae
 - Tests: bun test test/serve/public/hooks test/serve/public/lib test/serve/public/components/pdf -> 135 pass, 0 fail (integrated target), bun run lint:check -> clean, bun test test/serve/spa-snapshot-freshness.test.ts -> 2 pass, bun run test:e2e:pdf -> PASSED on the review-fix tree (incl. CLEAN: anchored-correction CSS contract), worker: bun test (full) -> 4486 pass, 1 fail (snapshot freshness, fixed by the conductor rebuild); e2e PASSED twice
-- PRs:
+- PRs: https://github.com/gmickel/gno/pull/206

--- a/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.5.md
+++ b/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.5.md
@@ -61,7 +61,9 @@ Review: SHIP on round 1 (Opus, host backend); its two P3 doc wording notes (PDF-
 stage: wave-join - ran (cherry-pick of the worker commit onto the target; no collision)
 stage: impl-review - ran [round 1 SHIP] (model: claude-opus-5 via harness subagent, host backend)
 stage: plan-sync - skipped(config: planSync.enabled != true)
+
+2026-09-06 reconciliation: restored completion state from this existing summary and merged PR #206. Gordon confirmed all remaining work was completed and requested spec closure. Earlier BLOCKED/UNMET observations above are historical and superseded by that confirmation.
 ## Evidence
-- Commits: a0195eb5, 1121d06898bdbcdf42563428aade2b2fa35ead89
+- Commits: a0195eb5, 1121d06898bdbcdf42563428aade2b2fa35ead89, d17ac7d8577c87fbd14a072deef3f39db121edae
 - Tests: bun run lint:check -> clean, bun test test/serve/spa-snapshot-freshness.test.ts -> 2 pass, worker: focused Quick suites 16/16, 7/7, 85/85 pass; local R3 warm-reload measurement 0 B JavaScript, 42/42 chunks from cache (evidence in the run notes), R6 after-measurement and R7 remote capture: BLOCKED (remote host not updatable from this machine); hosted site mirror: BLOCKED (repository inaccessible)
-- PRs:
+- PRs: https://github.com/gmickel/gno/pull/206

--- a/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.6.md
+++ b/.flow/tasks/fn-136-pdf-viewing-over-a-remote-link.6.md
@@ -28,9 +28,8 @@ Close the remote-link half of R6 and R7 and mirror the docs to the hosted site. 
 
 
 ## Done summary
-TBD
-
+Completed remote-link verification (R6 and R7) and the hosted documentation mirror, as confirmed by Gordon on 2026-09-06. This reconciliation records owner-confirmed completion; it does not invent measurements or claim a new remote QA run.
 ## Evidence
-- Commits:
+- Commits: d17ac7d8577c87fbd14a072deef3f39db121edae
 - Tests:
-- PRs:
+- PRs: https://github.com/gmickel/gno/pull/206


### PR DESCRIPTION
I reconciled the six task completions and closed `fn-136-pdf-viewing-over-a-remote-link` after Gordon confirmed the remaining remote verification and hosted documentation work was completed.

The implementation merged in #206. This change preserves the original completion summaries and commit evidence, adds the merge commit, and records Gordon's confirmation separately from the historical blocked measurements. No new remote QA run is claimed.

Validation: `flowctl validate --spec fn-136-pdf-viewing-over-a-remote-link --json` passed; the local state reports done with 6/6 completed tasks. Only this spec and its six task summaries changed.
