### PR TITLE
chore: release v2.2.0

### DIFF
--- a/.flow/specs/fn-155-public-share-abuse-reporting-and.json
+++ b/.flow/specs/fn-155-public-share-abuse-reporting-and.json
@@ -18,7 +18,7 @@
   "plan_reviewed_at": null,
   "ready": true,
   "spec_path": ".flow/specs/fn-155-public-share-abuse-reporting-and.md",
-  "status": "open",
+  "status": "done",
   "title": "Public-share abuse reporting and administrator takedown",
   "tracker": {
     "baseHashFlow": null,
@@ -31,5 +31,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-06T09:30:41.076222Z"
+  "updated_at": "2026-09-06T16:43:48.187286Z"
 }

--- a/.flow/specs/fn-156-reader-reading-time-total-views-and.json
+++ b/.flow/specs/fn-156-reader-reading-time-total-views-and.json
@@ -18,7 +18,7 @@
   "plan_reviewed_at": null,
   "ready": true,
   "spec_path": ".flow/specs/fn-156-reader-reading-time-total-views-and.md",
-  "status": "open",
+  "status": "done",
   "title": "Reader reading time, total views, and Markdown copy",
   "tracker": {
     "baseHashFlow": null,
@@ -31,5 +31,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-06T16:28:48.574753Z"
+  "updated_at": "2026-09-06T16:43:48.522727Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-06
+
 ### Added
 
 - The gno.sh reader shows reading-time estimates and approximate page-open
@@ -2712,7 +2714,8 @@ Re-release of 1.0.2 with a CHANGELOG formatting fix so the Publish workflow's
 | 0.4.0   | 2026-01-01 | Web UI and REST API                        |
 | 0.1.0   | 2025-12-30 | Initial release with full search pipeline  |
 
-[Unreleased]: https://github.com/gmickel/gno/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/gmickel/gno/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/gmickel/gno/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/gmickel/gno/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/gmickel/gno/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/gmickel/gno/compare/v2.0.0...v2.0.1

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gno daemon --detach  # headless indexing + resident MCP gateway
 
 <!-- public-truth:current-version -->
 
-> Current source version: **v2.1.1**. See [CHANGELOG.md](./CHANGELOG.md).
+> Current source version: **v2.2.0**. See [CHANGELOG.md](./CHANGELOG.md).
 
 <!-- /public-truth -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmickel/gno",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Local semantic search for your documents. Index Markdown, PDF, and Office files with hybrid BM25 + vector search.",
   "keywords": [
     "embeddings",


### PR DESCRIPTION
I bumped GNO to 2.2.0 after #226, moved the release notes out of Unreleased, and closed the completed fn-155 and fn-156 records. The hosted companion merged in gmickel/gno.sh#59.

The feature passed its implementation reviews, live QA and platform CI before merge. Gordon accepted the small HTTP timing-limit exceedance; the original results and browser limitations remain in the [QA receipt](https://github.com/gmickel/gno/blob/ac46ffbaf6c806ebe9140a42197be901a632e1f1/.flow/review-receipts/qa-fn-156-reader-reading-time-total-views-and.json).

Frozen dependency installation, lint, documentation verification, clipper verification and the v2.2.0 installed-package smoke passed. The local full suite found one stale README version among 5,263 tests; I corrected it and all 17 documentation regression tests passed. Platform CI runs on the corrected head before tagging. The v2.2.0 tag then triggers the coordinated tested-package and desktop publication workflow.
