### PR TITLE
chore(flow): close fn-162 after production verification

### DIFF
--- a/.flow/specs/fn-162-prevent-mobile-reader-home-control-from.json
+++ b/.flow/specs/fn-162-prevent-mobile-reader-home-control-from.json
@@ -7,7 +7,7 @@
   "plan_review_status": "unknown",
   "plan_reviewed_at": null,
   "spec_path": ".flow/specs/fn-162-prevent-mobile-reader-home-control-from.md",
-  "status": "open",
+  "status": "done",
   "title": "Prevent mobile reader home control from obscuring visibility badge",
   "tracker": {
     "baseHashFlow": null,
@@ -20,5 +20,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-06T04:30:24.108776Z"
+  "updated_at": "2026-09-06T20:31:19.216008Z"
 }

--- a/.flow/specs/fn-162-prevent-mobile-reader-home-control-from.md
+++ b/.flow/specs/fn-162-prevent-mobile-reader-home-control-from.md
@@ -19,3 +19,12 @@ Adjust the mobile reader header spacing in ~/work/gno.sh so the home control and
 - URL: https://gno.sh/share/gno/atlas
 - Screenshot: /home/gordon/.cache/agent-tmp/fn153/prod-reader-mobile-fresh.png
 - Reader navigation and the publishing lifecycle production smoke passed separately.
+
+## Completion — 6 September 2026
+
+- Fixed in gmickel/gno.sh PR #63; deployed commit 565f692d62b3963f8fe454a62fb7d657cf910125. Mobile reader top padding is 80px; desktop remains 64px.
+- Fresh production reader loads at 375 x 812 and 390 x 844: Home bottom 52.390625px, visibility badge top 80px. Desktop checked at 1380 x 880.
+- Local synthetic label layout checks covered Public URL, Secret link, Invite-only, and Encrypted share in the shared header; all cleared Home at 375px. These were label substitutions, not authentication-flow tests.
+- Browser screenshots: /home/gordon/.cache/agent-tmp/reader-home-before.png, reader-home-after-375.png, reader-home-after-390.png, reader-home-prod-375.png, reader-home-prod-390.png, reader-home-prod-desktop.png (same directory).
+- Site CI run 34057938566 passed formatting, types, tests, database integration, deployment checks, and build. Production HTTP 200; gno-sh active; remote HEAD, origin/main, and .output/REVISION match the deployed commit.
+- Applied the requested lightweight local-view-and-release workflow; no additional formal Flow QA gate.


### PR DESCRIPTION
I closed fn-162 after deploying the mobile reader spacing fix in gmickel/gno.sh#63. This tracking-only change records the production commit, browser measurements and screenshots, and passing site CI.

Verified fresh production loads at 375 × 812 and 390 × 844, plus desktop at 1380 × 880. The visibility badge clears Home on mobile; desktop spacing remains unchanged.
