### PR TITLE
chore: release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-09-06
+
+### Changed
+
+- Record completion and production verification of the hosted reader mobile
+  visibility-badge spacing fix. This release contains tracking and documentation
+  updates; the npm runtime is unchanged from v2.2.0.
+
 ## [2.2.0] - 2026-09-06
 
 ### Added
@@ -2714,7 +2722,8 @@ Re-release of 1.0.2 with a CHANGELOG formatting fix so the Publish workflow's
 | 0.4.0   | 2026-01-01 | Web UI and REST API                        |
 | 0.1.0   | 2025-12-30 | Initial release with full search pipeline  |
 
-[Unreleased]: https://github.com/gmickel/gno/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/gmickel/gno/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/gmickel/gno/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/gmickel/gno/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/gmickel/gno/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/gmickel/gno/compare/v2.0.1...v2.1.0

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ gno daemon --detach  # headless indexing + resident MCP gateway
 
 <!-- public-truth:current-version -->
 
-> Current source version: **v2.2.0**. See [CHANGELOG.md](./CHANGELOG.md).
+> Current source version: **v2.2.1**. See [CHANGELOG.md](./CHANGELOG.md).
 
 <!-- /public-truth -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmickel/gno",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Local semantic search for your documents. Index Markdown, PDF, and Office files with hybrid BM25 + vector search.",
   "keywords": [
     "embeddings",


### PR DESCRIPTION
I bumped GNO to v2.2.1 after merging the verified fn-162 closure, following the repository release policy. The changelog and README now match the source version.

This is a tracking and documentation release; the npm runtime is unchanged from v2.2.0. Frozen-lockfile installation and the full prerelease command passed with Bun 1.4.2, including lint, tests, documentation verification, clipper packaging, and the packed-package smoke test. Publication follows successful hosted checks.
