### PR TITLE
test: stabilize watcher and memory fixtures

### DIFF
--- a/.flow/specs/fn-157-pin-memory-candidate-match-fixture-clock.json
+++ b/.flow/specs/fn-157-pin-memory-candidate-match-fixture-clock.json
@@ -7,7 +7,7 @@
   "plan_review_status": "unknown",
   "plan_reviewed_at": null,
   "spec_path": ".flow/specs/fn-157-pin-memory-candidate-match-fixture-clock.md",
-  "status": "open",
+  "status": "done",
   "title": "Pin memory candidate-match fixture clock",
   "tracker": {
     "baseHashFlow": null,
@@ -20,5 +20,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-05T12:42:03.298120Z"
+  "updated_at": "2026-09-08T06:52:21.701697Z"
 }

--- a/.flow/specs/fn-164-make-watcher-lifecycle-test-phase.json
+++ b/.flow/specs/fn-164-make-watcher-lifecycle-test-phase.json
@@ -7,7 +7,7 @@
   "plan_review_status": "unknown",
   "plan_reviewed_at": null,
   "spec_path": ".flow/specs/fn-164-make-watcher-lifecycle-test-phase.md",
-  "status": "open",
+  "status": "done",
   "title": "Make watcher lifecycle test phase coordination deterministic",
   "tracker": {
     "baseHashFlow": null,
@@ -20,5 +20,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-06T22:02:21.144062Z"
+  "updated_at": "2026-09-08T06:52:21.983486Z"
 }

--- a/.flow/specs/fn-164-make-watcher-lifecycle-test-phase.json
+++ b/.flow/specs/fn-164-make-watcher-lifecycle-test-phase.json
@@ -1,0 +1,24 @@
+{
+  "branch_name": "fn-164-make-watcher-lifecycle-test-phase",
+  "created_at": "2026-09-06T22:02:21.141147Z",
+  "depends_on_epics": [],
+  "id": "fn-164-make-watcher-lifecycle-test-phase",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-164-make-watcher-lifecycle-test-phase.md",
+  "status": "open",
+  "title": "Make watcher lifecycle test phase coordination deterministic",
+  "tracker": {
+    "baseHashFlow": null,
+    "baseHashTracker": null,
+    "depRelations": [],
+    "id": null,
+    "identifier": null,
+    "lastSyncedAt": null,
+    "mergeBaseFlow": null,
+    "mergeBaseTracker": null,
+    "url": null
+  },
+  "updated_at": "2026-09-06T22:02:21.144062Z"
+}

--- a/.flow/specs/fn-164-make-watcher-lifecycle-test-phase.md
+++ b/.flow/specs/fn-164-make-watcher-lifecycle-test-phase.md
@@ -1,0 +1,18 @@
+# Make watcher lifecycle tests wait for observable completion
+
+## Problem and evidence
+
+Release v2.2.1 run 34062247816 attempt 1 failed two macOS tests in test/serve/watch-service-lifecycle.test.ts. At line 319, the remove/re-add case saw only old.md after a 20ms sleep, before the expected new.md sync. At line 405, the reconciliation case saw new.md first instead of old.md. Both tests coordinate asynchronous work with fixed sleeps. Timing sensitivity is a hypothesis to reproduce, not proof that watcher behavior is correct.
+
+The full suite passed locally and in PR #230 CI on the release source. The focused lifecycle suite then passed locally: 10 tests, zero failures. Release attempt 2 is an unchanged retry. Evidence: https://github.com/gmickel/gno/actions/runs/34062247816 and local /home/gordon/.cache/agent-tmp/v2.2.1-publish-failure.log, /home/gordon/.cache/agent-tmp/v2.2.1-watcher-focused.log.
+
+## Acceptance criteria
+
+- Reproduce or explain each observed ordering failure under delayed scheduling; distinguish a fixture race from a watcher bug.
+- Replace timing-only phase coordination with existing observable completion signals or bounded waits for the actual conditions. Preserve path ordering, invocation counts, and event assertions.
+- Prove teardown drains in-flight work and restores shared mocks before the next test.
+- Run the focused lifecycle file repeatedly and the required full suite, including macOS CI. Retain failing evidence and report the number of repeated runs.
+
+## Boundaries
+
+Keep the work focused on these lifecycle tests and any production defect actually demonstrated by the reproduction. Do not weaken assertions, raise sleeps as the sole fix, move the v2.2.1 tag, or alter release checks. This is follow-up work, not an implementation claim.

--- a/.flow/tasks/fn-157-pin-memory-candidate-match-fixture-clock.1.md
+++ b/.flow/tasks/fn-157-pin-memory-candidate-match-fixture-clock.1.md
@@ -32,9 +32,8 @@ Both determinism cases pass repeatedly under fixed fixture time; complete memory
 Pin existing MemoryServiceDeps.now for fixtures; preserve all equality/threshold/candidate assertions; run both determinism cases repeatedly and full test/core/memory.test.ts; retain collision/control reproduction evidence.
 
 ## Done summary
-TBD
-
+Pinned the candidate determinism fixtures through MemoryServiceDeps.now, using the verified control clock 2026-09-05T12:29:45.287Z. Corrected the comment to acknowledge metadata-inclusive FTS. Preserved all equality, matching-mode, threshold, and candidate assertions. Both modes passed 20 repetitions; the full memory file and full local suite passed. Collision/control probes and logs remain in /home/gordon/.cache/agent-tmp/fixture-fixes-probes/. Test-only change; no release requested.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: f5ac56bbfb7d18ccb78cbaacb2c755d85d866327
+- Tests: bun test: 5261 pass, 2 existing opt-in skips, 0 fail, Affected memory and watcher files: 38 pass, 0 fail, Four target tests repeated 20 times: 80 pass, 0 fail, Type-aware oxlint with explicit absolute paths: 2 files, 0 warnings/errors; oxfmt passed, Delayed watcher starts (450ms) and completions (60ms): original fails, fixed passes, Forced assertion failure: dispose drains all queued/in-flight work; next test passes, Memory collision clock .286Z fails; fixed control .287Z passes
 - PRs:

--- a/.flow/tasks/fn-164-make-watcher-lifecycle-test-phase.1.json
+++ b/.flow/tasks/fn-164-make-watcher-lifecycle-test-phase.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-09-08T06:41:17.231466Z",
+  "depends_on": [],
+  "id": "fn-164-make-watcher-lifecycle-test-phase.1",
+  "priority": null,
+  "spec": "fn-164-make-watcher-lifecycle-test-phase",
+  "spec_path": ".flow/tasks/fn-164-make-watcher-lifecycle-test-phase.1.md",
+  "status": "todo",
+  "title": "Wait for watcher phases and drain fixtures on failure",
+  "updated_at": "2026-09-08T06:52:20.844921Z"
+}

--- a/.flow/tasks/fn-164-make-watcher-lifecycle-test-phase.1.md
+++ b/.flow/tasks/fn-164-make-watcher-lifecycle-test-phase.1.md
@@ -1,0 +1,12 @@
+# fn-164-make-watcher-lifecycle-test-phase.1 Wait for watcher phases and drain fixtures on failure
+
+## Description
+Fix the two watcher lifecycle timing failures recorded in fn-164. Wait for actual first-sync and full-reconciliation phases, verify the required path batch has completed, and release/drain all mocked work in finally. Preserve every existing assertion.
+## Acceptance
+Original delayed scheduling probes fail and fixed probes pass. Forced assertion failure still drains queued/in-flight work before the next test. Both cases pass 20 repetitions; full local tests and hosted macOS CI pass before merge. No production change, assertion weakening, or release.
+## Done summary
+Replaced timing-only phase coordination in the two failing watcher lifecycle tests with bounded waits for observed sync phases and completed path batches. Added finally blocks that release all fixture gates and await service.dispose before shared mocks reset. Preserved all existing assertions. Delayed start/finish probes fail before the fix and pass afterward; a forced assertion failure drains the service and allows the next test to pass. Twenty repetitions of both watcher cases passed, as did the full local suite. Hosted macOS checks are a merge prerequisite. Evidence lives in /home/gordon/.cache/agent-tmp/fixture-fixes-probes/. No production code changed.
+## Evidence
+- Commits: f5ac56bbfb7d18ccb78cbaacb2c755d85d866327
+- Tests: bun test: 5261 pass, 2 existing opt-in skips, 0 fail, Affected memory and watcher files: 38 pass, 0 fail, Four target tests repeated 20 times: 80 pass, 0 fail, Type-aware oxlint with explicit absolute paths: 2 files, 0 warnings/errors; oxfmt passed, Delayed watcher starts (450ms) and completions (60ms): original fails, fixed passes, Forced assertion failure: dispose drains all queued/in-flight work; next test passes, Memory collision clock .286Z fails; fixed control .287Z passes
+- PRs:

--- a/test/core/memory.test.ts
+++ b/test/core/memory.test.ts
@@ -73,7 +73,11 @@ function fakeEmbedPort(): EmbeddingPort {
 
 async function createHarness(
   prefix: string,
-  options: { embedPort?: EmbeddingPort | null; dbPath?: string } = {}
+  options: {
+    embedPort?: EmbeddingPort | null;
+    dbPath?: string;
+    now?: () => Date;
+  } = {}
 ): Promise<Harness> {
   const root = await mkdtemp(join(tmpdir(), `gno-${prefix}-`));
   await mkdir(join(root, "memory"), { recursive: true });
@@ -110,6 +114,7 @@ async function createHarness(
     lockPath,
     lockWaitMs: 5_000,
     embedPort: options.embedPort ?? null,
+    now: options.now,
   });
   return { root, store, config, collections, lockPath, service };
 }
@@ -725,7 +730,12 @@ describe("candidate-match determinism contract", () => {
   const incoming = "deploy window tuesday 09:00 utc";
 
   async function seeded(prefix: string, embedPort: EmbeddingPort | null) {
-    const harness = await createHarness(prefix, { embedPort });
+    const harness = await createHarness(prefix, {
+      embedPort,
+      // Record IDs are indexed metadata too: a wall-clock-derived ID can
+      // accidentally match the query's 0900 prefix and change the candidate pool.
+      now: () => new Date("2026-09-05T12:29:45.287Z"),
+    });
     for (const text of corpus) {
       const result = await remember(harness, {
         text,
@@ -763,7 +773,8 @@ describe("candidate-match determinism contract", () => {
         threshold: 0.5,
         semanticUnavailable: "no embedding model available",
       });
-      // Only facts sharing a token enter the BM25 pool; the rest never appear.
+      // BM25 searches fact text and metadata; this fixed fixture has three
+      // matching records, including one below the likely-match threshold.
       expect(parsed.candidates.map((c: { match: string }) => c.match)).toEqual([
         "likely",
         "likely",

--- a/test/serve/watch-service-lifecycle.test.ts
+++ b/test/serve/watch-service-lifecycle.test.ts
@@ -21,6 +21,19 @@ import {
 
 installWatchServiceSyncReset();
 
+async function waitUntil(
+  predicate: () => boolean,
+  phase: string
+): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${phase}`);
+    }
+    await Bun.sleep(10);
+  }
+}
+
 describe("watcherCollectionFingerprint", () => {
   test("tracks the effective collection and run-level source availability", () => {
     const collection = createCollection("notes", "/tmp/notes");
@@ -300,31 +313,41 @@ describe("CollectionWatchService lifecycle", () => {
       }) as never,
     });
 
-    service.start();
-    callbacks.get("/tmp/old-notes")?.("change", "old.md");
-    await Bun.sleep(350);
-    expect(seenPaths).toEqual([["old.md"]]);
+    try {
+      service.start();
+      callbacks.get("/tmp/old-notes")?.("change", "old.md");
+      await waitUntil(() => seenPaths.length > 0, "first path sync to start");
+      expect(seenPaths).toEqual([["old.md"]]);
 
-    service.updateCollections([]);
-    service.updateCollections([
-      createCollection("notes", "/tmp/replacement-notes"),
-    ]);
-    callbacks.get("/tmp/replacement-notes")?.("change", "new.md");
-    await Bun.sleep(350);
-    expect(seenPaths).toEqual([["old.md"]]);
+      service.updateCollections([]);
+      service.updateCollections([
+        createCollection("notes", "/tmp/replacement-notes"),
+      ]);
+      callbacks.get("/tmp/replacement-notes")?.("change", "new.md");
+      expect(service.getState().queuedCollections).toEqual(["notes"]);
+      expect(seenPaths).toEqual([["old.md"]]);
 
-    finishFirstSync?.();
-    await Bun.sleep(20);
-    expect(syncCollection).toHaveBeenCalledTimes(1);
-    expect(seenPaths).toEqual([["old.md"], ["new.md"]]);
-    expect(notifySyncComplete).toHaveBeenCalledTimes(1);
-    expect(emit).toHaveBeenCalledTimes(1);
-    expect(emit.mock.calls[0]?.[0]).toMatchObject({
-      collection: "notes",
-      relPath: "new.md",
-      uri: "gno://notes/new.md",
-    });
-    await service.dispose();
+      finishFirstSync?.();
+      await waitUntil(
+        () =>
+          seenPaths.some((batch) => batch.includes("new.md")) &&
+          service.getState().syncingCollections.length === 0,
+        "replacement path sync to complete"
+      );
+      expect(syncCollection).toHaveBeenCalledTimes(1);
+      expect(seenPaths).toEqual([["old.md"], ["new.md"]]);
+      expect(notifySyncComplete).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit.mock.calls[0]?.[0]).toMatchObject({
+        collection: "notes",
+        relPath: "new.md",
+        uri: "gno://notes/new.md",
+      });
+    } finally {
+      // Release blocked work before draining it, even when an assertion fails.
+      finishFirstSync?.();
+      await service.dispose();
+    }
   });
 
   test("reprocesses an edit queued after full reconciliation scanned its path", async () => {
@@ -335,15 +358,12 @@ describe("CollectionWatchService lifecycle", () => {
     const seenPaths: string[][] = [];
     let finishFirstSync: (() => void) | undefined;
     let finishFullSync: (() => void) | undefined;
-    let markFullSyncStarted: (() => void) | undefined;
+    let fullSyncStarted = false;
     const firstSync = new Promise<void>((resolve) => {
       finishFirstSync = resolve;
     });
     const fullSyncGate = new Promise<void>((resolve) => {
       finishFullSync = resolve;
-    });
-    const fullSyncStarted = new Promise<void>((resolve) => {
-      markFullSyncStarted = resolve;
     });
 
     defaultSyncService.syncPaths = (async (_collection, _store, relPaths) => {
@@ -361,7 +381,7 @@ describe("CollectionWatchService lifecycle", () => {
       });
     }) as typeof defaultSyncService.syncPaths;
     defaultSyncService.syncCollection = (async () => {
-      markFullSyncStarted?.();
+      fullSyncStarted = true;
       await fullSyncGate;
       return createSyncResult({
         filesProcessed: 1,
@@ -388,23 +408,33 @@ describe("CollectionWatchService lifecycle", () => {
       }) as never,
     });
 
-    service.start();
-    callbacks.get("/tmp/old-notes")?.("change", "old.md");
-    await Bun.sleep(350);
-    service.updateCollections([
-      createCollection("notes", "/tmp/replacement-notes"),
-    ]);
+    try {
+      service.start();
+      callbacks.get("/tmp/old-notes")?.("change", "old.md");
+      await waitUntil(() => seenPaths.length > 0, "first path sync to start");
+      service.updateCollections([
+        createCollection("notes", "/tmp/replacement-notes"),
+      ]);
 
-    finishFirstSync?.();
-    await fullSyncStarted;
-    callbacks.get("/tmp/replacement-notes")?.("change", "new.md");
-    await Bun.sleep(350);
-    finishFullSync?.();
-    await Bun.sleep(800);
+      finishFirstSync?.();
+      await waitUntil(() => fullSyncStarted, "full reconciliation to start");
+      callbacks.get("/tmp/replacement-notes")?.("change", "new.md");
+      expect(service.getState().queuedCollections).toEqual(["notes"]);
+      finishFullSync?.();
+      await waitUntil(
+        () =>
+          seenPaths.some((batch) => batch.includes("new.md")) &&
+          service.getState().syncingCollections.length === 0,
+        "post-reconciliation path sync to complete"
+      );
 
-    expect(seenPaths[0]).toEqual(["old.md"]);
-    expect(seenPaths.some((batch) => batch.includes("new.md"))).toBe(true);
-    await service.dispose();
+      expect(seenPaths[0]).toEqual(["old.md"]);
+      expect(seenPaths.some((batch) => batch.includes("new.md"))).toBe(true);
+    } finally {
+      finishFirstSync?.();
+      finishFullSync?.();
+      await service.dispose();
+    }
   });
 
   test("updateCollections refreshes sync options for later watcher syncs", async () => {


### PR DESCRIPTION
I fixed two sources of flaky test results: timestamp-derived memory IDs could accidentally match the query, and watcher lifecycle tests assumed asynchronous work would finish within fixed sleeps.

The memory fixtures now use the existing clock injection. The watcher fixtures wait for observed sync phases and always release gates and drain the service in `finally`. All original matching, ordering, count, and event assertions remain. This PR closes fn-157 and fn-164; it changes tests and Flow records only. No version bump or release, as requested.

Validation:
- Full local suite: 5,261 passed, 2 existing opt-in skips, zero failures.
- Affected files: 38 passed. Four target tests repeated 20 times: 80 passed.
- Type-aware lint on both changed files and formatting passed. The local worktree ignore rule causes the broad lint command to select no files, so I explicitly linted the changed absolute paths; CI runs the full lint check.
- Delayed watcher start (450ms) and completion (60ms) probes fail with the original fixtures and pass with these fixes.
- A forced assertion failure still drains the watcher; the following test passes.
- The known memory collision timestamp fails, and the pinned control timestamp passes, with unchanged candidate assertions.

The probe sources and logs are retained locally under `/home/gordon/.cache/agent-tmp/fixture-fixes-probes/`. Hosted checks, including macOS, must pass before merge.
